### PR TITLE
feat: Add kubectl shorthand for NodeReadinessGateRule

### DIFF
--- a/api/v1alpha1/nodereadinessgaterule_types.go
+++ b/api/v1alpha1/nodereadinessgaterule_types.go
@@ -106,7 +106,7 @@ type DryRunResults struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=nrgr
 
 // NodeReadinessGateRule is the Schema for the nodereadinessgaterules API
 type NodeReadinessGateRule struct {

--- a/config/crd/bases/nodereadiness.io_nodereadinessgaterules.yaml
+++ b/config/crd/bases/nodereadiness.io_nodereadinessgaterules.yaml
@@ -11,6 +11,8 @@ spec:
     kind: NodeReadinessGateRule
     listKind: NodeReadinessGateRuleList
     plural: nodereadinessgaterules
+    shortNames:
+    - nrgr
     singular: nodereadinessgaterule
   scope: Cluster
   versions:


### PR DESCRIPTION
1. Modify nodereadinessgaterule_types.go file
// +kubebuilder:resource:scope=Cluster
Change to
// +kubebuilder:resource:scope=Cluster,shortName=nrgr

2. Generate the compiled yaml file using the make file
nodereadiness.io_nodereadinessgaterules.yaml