### PR TITLE
Rename api group version to readiness.node.x-k8s.io

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,7 +39,7 @@ This project implements a Kubernetes controller that manages node taints based o
 │   └── main.go                         # Controller entrypoint
 ├── config/
 │   ├── crd/bases/
-│   │   └── nodereadiness.io_nodereadinessgaterules.yaml  # Generated CRD
+│   │   └── readiness.node.x-k8s.io_nodereadinessgaterules.yaml  # Generated CRD
 │   ├── rbac/
 │   │   ├── role.yaml                   # Controller RBAC
 │   │   ├── role_binding.yaml           # RBAC binding
@@ -73,7 +73,7 @@ Controller logic start here: cmd/main.go
 
 ### Generated CRD
 
-Kubebuilder generated schema: config/crd/bases/nodereadiness.io_nodereadinessgaterules.yaml
+Kubebuilder generated schema: config/crd/bases/readiness.node.x-k8s.io_nodereadinessgaterules.yaml
 
 ### RBAC
 
@@ -246,7 +246,7 @@ if shouldRemoveTaint && currentlyHasTaint {
 
 ### CNI Readiness Rule
 ```yaml
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   name: cni-readiness-rule
@@ -268,7 +268,7 @@ spec:
 
 ### Storage Readiness Rule
 ```yaml
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   name: storage-readiness-rule

--- a/PROJECT
+++ b/PROJECT
@@ -3,7 +3,7 @@
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
 cliVersion: 4.9.0
-domain: nodereadiness.io
+domain: readiness.node.x-k8s.io
 layout:
 - go.kubebuilder.io/v4
 projectName: nrgcontroller
@@ -12,7 +12,7 @@ resources:
 - api:
     crdVersion: v1
   controller: true
-  domain: nodereadiness.io
+  domain: readiness.node.x-k8s.io
   kind: NodeReadinessGateRule
   path: sigs.k8s.io/node-readiness-controller/api/v1alpha1
   version: v1alpha1

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With this controller you can:
 **Example Rule**
 
 ```yaml
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   name: network-readiness-rule

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the  v1alpha1 API group.
 // +kubebuilder:object:generate=true
-// +groupName=nodereadiness.io
+// +groupName=readiness.node.x-k8s.io
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "nodereadiness.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "readiness.node.x-k8s.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,7 +88,7 @@ func main() {
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "ba65f13e.nodereadiness.io",
+		LeaderElectionID:       "ba65f13e.readiness.node.x-k8s.io",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessgaterules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessgaterules.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
-  name: nodereadinessgaterules.nodereadiness.io
+  name: nodereadinessgaterules.readiness.node.x-k8s.io
 spec:
-  group: nodereadiness.io
+  group: readiness.node.x-k8s.io
   names:
     kind: NodeReadinessGateRule
     listKind: NodeReadinessGateRuleList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,5 +2,5 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/nodereadiness.io_nodereadinessgaterules.yaml
+- bases/readiness.node.x-k8s.io_nodereadinessgaterules.yaml
 # +kubebuilder:scaffold:crdkustomizeresource

--- a/config/rbac/nodereadinessgaterule_admin_role.yaml
+++ b/config/rbac/nodereadinessgaterule_admin_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project nrgcontroller itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants full permissions ('*') over nodereadiness.io.
+# Grants full permissions ('*') over readiness.node.x-k8s.io.
 # This role is intended for users authorized to modify roles and bindings within the cluster,
 # enabling them to delegate specific permissions to other users or groups as needed.
 
@@ -14,13 +14,13 @@ metadata:
   name: nodereadinessgaterule-admin-role
 rules:
 - apiGroups:
-  - nodereadiness.io
+  - readiness.node.x-k8s.io
   resources:
   - nodereadinessgaterules
   verbs:
   - '*'
 - apiGroups:
-  - nodereadiness.io
+  - readiness.node.x-k8s.io
   resources:
   - nodereadinessgaterules/status
   verbs:

--- a/config/rbac/nodereadinessgaterule_editor_role.yaml
+++ b/config/rbac/nodereadinessgaterule_editor_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project nrgcontroller itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants permissions to create, update, and delete resources within the nodereadiness.io.
+# Grants permissions to create, update, and delete resources within the readiness.node.x-k8s.io.
 # This role is intended for users who need to manage these resources
 # but should not control RBAC or manage permissions for others.
 
@@ -14,7 +14,7 @@ metadata:
   name: nodereadinessgaterule-editor-role
 rules:
 - apiGroups:
-  - nodereadiness.io
+  - readiness.node.x-k8s.io
   resources:
   - nodereadinessgaterules
   verbs:
@@ -26,7 +26,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - nodereadiness.io
+  - readiness.node.x-k8s.io
   resources:
   - nodereadinessgaterules/status
   verbs:

--- a/config/rbac/nodereadinessgaterule_viewer_role.yaml
+++ b/config/rbac/nodereadinessgaterule_viewer_role.yaml
@@ -1,7 +1,7 @@
 # This rule is not used by the project nrgcontroller itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants read-only access to nodereadiness.io resources.
+# Grants read-only access to readiness.node.x-k8s.io resources.
 # This role is intended for users who need visibility into these resources
 # without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
 
@@ -14,7 +14,7 @@ metadata:
   name: nodereadinessgaterule-viewer-role
 rules:
 - apiGroups:
-  - nodereadiness.io
+  - readiness.node.x-k8s.io
   resources:
   - nodereadinessgaterules
   verbs:
@@ -22,7 +22,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - nodereadiness.io
+  - readiness.node.x-k8s.io
   resources:
   - nodereadinessgaterules/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -31,7 +31,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - nodereadiness.io
+  - readiness.node.x-k8s.io
   resources:
   - nodereadinessgaterules
   verbs:
@@ -43,13 +43,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - nodereadiness.io
+  - readiness.node.x-k8s.io
   resources:
   - nodereadinessgaterules/finalizers
   verbs:
   - update
 - apiGroups:
-  - nodereadiness.io
+  - readiness.node.x-k8s.io
   resources:
   - nodereadinessgaterules/status
   verbs:

--- a/config/samples/v1alpha1_nodereadinessgaterule.yaml
+++ b/config/samples/v1alpha1_nodereadinessgaterule.yaml
@@ -1,4 +1,4 @@
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   labels:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -15,7 +15,7 @@ webhooks:
   name: vnodereadinessgaterule.kb.io
   rules:
   - apiGroups:
-    - nodereadiness.io
+    - readiness.node.x-k8s.io
     apiVersions:
     - v1alpha1
     operations:

--- a/docs/getting-started.draft.md
+++ b/docs/getting-started.draft.md
@@ -8,7 +8,7 @@
 This rule ensures nodes have working storage before removing the storage readiness taint:
 
 ```yaml
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   name: storage-readiness-rule

--- a/docs/troubleshooting.draft.md
+++ b/docs/troubleshooting.draft.md
@@ -49,7 +49,7 @@ kubectl logs -n nrgcontroller-system deployment/nrgcontroller-controller-manager
 Verify CRDs are installed:
 
 ```sh
-kubectl get crd nodereadinessgaterules.nodereadiness.io
+kubectl get crd nodereadinessgaterules.readiness.node.x-k8s.io
 ```
 
 

--- a/examples/network-readiness-rule.yaml
+++ b/examples/network-readiness-rule.yaml
@@ -1,4 +1,4 @@
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   name: network-readiness-rule

--- a/internal/controller/nodereadinessgaterule_controller.go
+++ b/internal/controller/nodereadinessgaterule_controller.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	// finalizerName is the finalizer added to NodeReadinessGateRule to ensure cleanup
-	finalizerName = "nodereadiness.io/cleanup-taints"
+	finalizerName = "readiness.node.x-k8s.io/cleanup-taints"
 )
 
 // ReadinessGateController manages node taints based on readiness gate rules
@@ -76,9 +76,9 @@ type RuleReconciler struct {
 	Controller *ReadinessGateController
 }
 
-// +kubebuilder:rbac:groups=nodereadiness.io,resources=nodereadinessgaterules,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=nodereadiness.io,resources=nodereadinessgaterules/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=nodereadiness.io,resources=nodereadinessgaterules/finalizers,verbs=update
+// +kubebuilder:rbac:groups=readiness.node.x-k8s.io,resources=nodereadinessgaterules,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=readiness.node.x-k8s.io,resources=nodereadinessgaterules/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=readiness.node.x-k8s.io,resources=nodereadinessgaterules/finalizers,verbs=update
 
 func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)

--- a/internal/controller/nodereadinessgaterule_controller_test.go
+++ b/internal/controller/nodereadinessgaterule_controller_test.go
@@ -626,7 +626,7 @@ var _ = Describe("NodeReadinessGateRule Controller", func() {
 				updatedRule := &nodereadinessiov1alpha1.NodeReadinessGateRule{}
 				_ = k8sClient.Get(ctx, types.NamespacedName{Name: "cleanup-rule"}, updatedRule)
 				return updatedRule.Finalizers
-			}, time.Second*5).Should(ContainElement("nodereadiness.io/cleanup-taints"))
+			}, time.Second*5).Should(ContainElement("readiness.node.x-k8s.io/cleanup-taints"))
 
 			// Verify node still has taint
 			updatedNode := &corev1.Node{}

--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -43,7 +43,7 @@ func NewNodeReadinessGateRuleWebhook(c client.Client) *NodeReadinessGateRuleWebh
 	}
 }
 
-// +kubebuilder:webhook:path=/validate-nodereadiness-io-v1alpha1-nodereadinessgaterule,mutating=false,failurePolicy=fail,sideEffects=None,groups=nodereadiness.io,resources=nodereadinessgaterules,verbs=create;update,versions=v1alpha1,name=vnodereadinessgaterule.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-nodereadiness-io-v1alpha1-nodereadinessgaterule,mutating=false,failurePolicy=fail,sideEffects=None,groups=readiness.node.x-k8s.io,resources=nodereadinessgaterules,verbs=create;update,versions=v1alpha1,name=vnodereadinessgaterule.kb.io,admissionReviewVersions=v1
 
 // validateNodeReadinessGateRule performs validation logic
 func (w *NodeReadinessGateRuleWebhook) validateNodeReadinessGateRule(ctx context.Context, rule *readinessv1alpha1.NodeReadinessGateRule, isUpdate bool) field.ErrorList {

--- a/test/e2e/testdata/bootstrap-only-rule.yaml
+++ b/test/e2e/testdata/bootstrap-only-rule.yaml
@@ -1,4 +1,4 @@
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   name: bootstrap-test-rule

--- a/test/e2e/testdata/continuous-rule.yaml
+++ b/test/e2e/testdata/continuous-rule.yaml
@@ -1,4 +1,4 @@
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   name: continuous-test-rule

--- a/test/e2e/testdata/dryrun-rule.yaml
+++ b/test/e2e/testdata/dryrun-rule.yaml
@@ -1,4 +1,4 @@
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   name: dryrun-test-rule

--- a/test/e2e/testdata/multi-condition-rule.yaml
+++ b/test/e2e/testdata/multi-condition-rule.yaml
@@ -1,4 +1,4 @@
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   name: multi-condition-rule

--- a/test/e2e/testdata/node-selector-rule.yaml
+++ b/test/e2e/testdata/node-selector-rule.yaml
@@ -1,4 +1,4 @@
-apiVersion: nodereadiness.io/v1alpha1
+apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessGateRule
 metadata:
   name: node-selector-rule


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/node-readiness-controller/issues/2