### PR TITLE
Enable KAL linter

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -1,0 +1,32 @@
+version: "2"
+run:
+  go: "1.24"
+  allow-parallel-runners: true
+linters:
+  default: none
+  enable:
+    - kubeapilinter # linter for Kube API conventions
+  settings:
+    custom:
+      kubeapilinter:
+        type: module
+        description: KAL is the Kube-API-Linter and lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters:
+            enable:
+              - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
+            disable:
+            - "*" # We will manually enable new linters after understanding the impact. Disable all by default.
+  exclusions:
+    generated: strict
+    paths:
+      - ".*_test.go"  # Exclude test files.
+    rules:
+    ## KAL should only run on API folders.
+    - path-except: "api//*"
+      linters:
+        - kubeapilinter
+
+issues:
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/hack/tools/.custom-gcl.yaml
+++ b/hack/tools/.custom-gcl.yaml
@@ -1,0 +1,6 @@
+version: v2.5.0
+name: golangci-lint-kube-api-linter
+destination: ./bin
+plugins:
+- module: 'sigs.k8s.io/kube-api-linter'
+  version: v0.0.0-20251107220451-f87b38edda8c


### PR DESCRIPTION
This PR enables KAL linter, More about it can be read here https://github.com/kubernetes-sigs/kube-api-linter

Only one linter is enabled, Follow up task is to explore and add other KAL linters https://github.com/kubernetes-sigs/kube-api-linter/blob/main/docs/linters.md and also enable it in github action / CI jobs