### PR TITLE
update go header file path in makefile generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ manifests: $(CONTROLLER_GEN) ## Generate WebhookConfiguration, ClusterRole and C
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate/boilerplate.go.txt" paths="./..."
 
 ## --------------------------------------
 ## Lint / Verify


### PR DESCRIPTION
minor update in the go header file path for controller-gen `generate` makefile target

fix for failing CI test - https://github.com/kubernetes-sigs/node-readiness-controller/actions/runs/20160881255/job/57872797333?pr=34

```
/home/runner/work/node-readiness-controller/node-readiness-controller/hack/tools/bin/controller-gen-v0.19.0 rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/home/runner/work/node-readiness-controller/node-readiness-controller/hack/tools/bin/controller-gen-v0.19.0 object:headerFile="hack/boilerplate.go.txt" paths="./..."
open hack/boilerplate.go.txt: no such file or directory
Error: not all generators ran successfully
run `controller-gen object:headerFile=hack/boilerplate.go.txt paths=./... -w` to see all available markers, or `controller-gen object:headerFile=hack/boilerplate.go.txt paths=./... -h` for usage
make: *** [Makefile:121: generate] Error 1
Error: Process completed with exit code 2.
```

/assign @ajaysundark 