### PR TITLE
Rename from nrg(node readiness gate) to nrr (node readiness rule)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -382,7 +382,7 @@ rules:
 
 ## Future Extensions
 
-### Planned Features (via nrgctl)
+### Planned Features (via nrrctl)
 - Interactive rule management
 - Hard rollback capabilities
 - Rule version control and history

--- a/Makefile
+++ b/Makefile
@@ -187,10 +187,10 @@ PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- $(CONTAINER_TOOL) buildx create --name nrgcontroller-builder
-	$(CONTAINER_TOOL) buildx use nrgcontroller-builder
+	- $(CONTAINER_TOOL) buildx create --name nrrcontroller-builder
+	$(CONTAINER_TOOL) buildx use nrrcontroller-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- $(CONTAINER_TOOL) buildx rm nrgcontroller-builder
+	- $(CONTAINER_TOOL) buildx rm nrrcontroller-builder
 	rm Dockerfile.cross
 
 .PHONY: build-installer
@@ -242,7 +242,7 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
-KIND_CLUSTER ?= nrg-test-e2e
+KIND_CLUSTER ?= nrr-test-e2e
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist

--- a/PROJECT
+++ b/PROJECT
@@ -6,7 +6,7 @@ cliVersion: 4.9.0
 domain: readiness.node.x-k8s.io
 layout:
 - go.kubebuilder.io/v4
-projectName: nrgcontroller
+projectName: nrrcontroller
 repo: sigs.k8s.io/node-readiness-controller
 resources:
 - api:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: nrg-system
+namespace: nrr-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: nrg-
+namePrefix: nrr-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system
@@ -15,4 +15,4 @@ spec:
     targetPort: 8443
   selector:
     control-plane: controller-manager
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -14,13 +14,13 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-      app.kubernetes.io/name: nrgcontroller
+      app.kubernetes.io/name: nrrcontroller
   replicas: 1
   template:
     metadata:
@@ -28,7 +28,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
-        app.kubernetes.io/name: nrgcontroller
+        app.kubernetes.io/name: nrrcontroller
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # The manager is deployed on control-plane nodes by default. Modify the nodeAffinity rules

--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: allow-metrics-traffic
   namespace: system
@@ -13,7 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
-      app.kubernetes.io/name: nrgcontroller
+      app.kubernetes.io/name: nrrcontroller
   policyTypes:
     - Ingress
   ingress:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system
@@ -24,4 +24,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-      app.kubernetes.io/name: nrgcontroller
+      app.kubernetes.io/name: nrrcontroller

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 - metrics_reader_role.yaml
 # For each CRD, "Admin", "Editor" and "Viewer" roles are scaffolded by
 # default, aiding admins in cluster management. Those roles are
-# not used by the nrgcontroller itself. You can comment the following lines
+# not used by the nrrcontroller itself. You can comment the following lines
 # if you do not want those helpers be installed with your Project.
 - nodereadinessrule_admin_role.yaml
 - nodereadinessrule_editor_role.yaml

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
 roleRef:

--- a/config/rbac/nodereadinessrule_admin_role.yaml
+++ b/config/rbac/nodereadinessrule_admin_role.yaml
@@ -1,4 +1,4 @@
-# This rule is not used by the project nrgcontroller itself.
+# This rule is not used by the project nrrcontroller itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
 # Grants full permissions ('*') over readiness.node.x-k8s.io.
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: nodereadinessrule-admin-role
 rules:

--- a/config/rbac/nodereadinessrule_editor_role.yaml
+++ b/config/rbac/nodereadinessrule_editor_role.yaml
@@ -1,4 +1,4 @@
-# This rule is not used by the project nrgcontroller itself.
+# This rule is not used by the project nrrcontroller itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
 # Grants permissions to create, update, and delete resources within the readiness.node.x-k8s.io.
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: nodereadinessrule-editor-role
 rules:

--- a/config/rbac/nodereadinessrule_viewer_role.yaml
+++ b/config/rbac/nodereadinessrule_viewer_role.yaml
@@ -1,4 +1,4 @@
-# This rule is not used by the project nrgcontroller itself.
+# This rule is not used by the project nrrcontroller itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
 # Grants read-only access to readiness.node.x-k8s.io resources.
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: nodereadinessrule-viewer-role
 rules:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/config/samples/v1alpha1_nodereadinessrule.yaml
+++ b/config/samples/v1alpha1_nodereadinessrule.yaml
@@ -2,7 +2,7 @@ apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessRule
 metadata:
   labels:
-    app.kubernetes.io/name: nrgcontroller
+    app.kubernetes.io/name: nrrcontroller
     app.kubernetes.io/managed-by: kustomize
   name: nodereadinessrule-sample
 spec:

--- a/config/testing/kind/kind-3node-config.yaml
+++ b/config/testing/kind/kind-3node-config.yaml
@@ -1,6 +1,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-name: nrg-test
+name: nrr-test
 nodes:
 - role: control-plane
 - role: worker # platform

--- a/config/testing/kind/test-config.yaml
+++ b/config/testing/kind/test-config.yaml
@@ -1,6 +1,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-name: nrg-test
+name: nrr-test
 nodes:
 - role: control-plane
 - role: worker

--- a/demo.tape
+++ b/demo.tape
@@ -14,10 +14,10 @@ Set TypingSpeed 35ms
 # --- SETUP ---
 Hide
 # Expect the kind cluster is already created following docs/TEST_README.md
-Type "kubectl config use-context kind-nrg-test"
+Type "kubectl config use-context kind-nrr-test"
 Enter
 # Ensure the node starts in a "Tainted" state (Condition False -> Taint Present)
-Type "./hack/test-workloads/flip-node-condition.sh nrg-test-worker network.k8s.io/CalicoReady false"
+Type "./hack/test-workloads/flip-node-condition.sh nrr-test-worker network.k8s.io/CalicoReady false"
 Enter
 Type "clear"
 Enter
@@ -40,7 +40,7 @@ Type "# NodeReadiness controller installed on control-plane node"
 Show
 Sleep 2s
 Enter
-Type "kubectl get deploy -n nrg-system"
+Type "kubectl get deploy -n nrr-system"
 Enter
 Sleep 2s
 
@@ -51,7 +51,7 @@ Type "# 2. Worker node has a Taint 'readiness.k8s.io/NetworkReady' because Calic
 Show
 Sleep 2s
 Enter
-Type@15ms `kubectl get node nrg-test-worker -o custom-columns="NAME:.metadata.name,STATUS:.status.conditions[?(@.type=='network.k8s.io/CalicoReady')].status,TAINTS:.spec.taints[*].key"`
+Type@15ms `kubectl get node nrr-test-worker -o custom-columns="NAME:.metadata.name,STATUS:.status.conditions[?(@.type=='network.k8s.io/CalicoReady')].status,TAINTS:.spec.taints[*].key"`
 Enter 1
 Sleep 3s
 
@@ -73,7 +73,7 @@ Type "# 4. Simulate the CNI plugin reporting 'Ready' status"
 Show
 Sleep 2s
 Enter
-Type@15ms "./hack/test-workloads/flip-node-condition.sh nrg-test-worker network.k8s.io/CalicoReady true"
+Type@15ms "./hack/test-workloads/flip-node-condition.sh nrr-test-worker network.k8s.io/CalicoReady true"
 Enter 1
 Sleep 4s
 
@@ -84,7 +84,7 @@ Type "# 5. NodeReadiness controller on observing the expected status change will
 Show
 Sleep 2s
 Enter
-Type@15ms `kubectl get node nrg-test-worker -o custom-columns="NAME:.metadata.name,STATUS:.status.conditions[?(@.type=='network.k8s.io/CalicoReady')].status,TAINTS:.spec.taints[*].key"`
+Type@15ms `kubectl get node nrr-test-worker -o custom-columns="NAME:.metadata.name,STATUS:.status.conditions[?(@.type=='network.k8s.io/CalicoReady')].status,TAINTS:.spec.taints[*].key"`
 Enter 2
 Sleep 2s
 Type "# Success! The Controller automatically removed the managed taint and node is ready for workloads"

--- a/docs/TEST_README.md
+++ b/docs/TEST_README.md
@@ -1,15 +1,15 @@
 # Node Readiness Gates E2E Test Guide (Kind)
 
-This guide details how to run an end-to-end test for the Node Readiness Gates (NRG) controller using a local Kind cluster.
+This guide details how to run an end-to-end test for the Node Readiness Rules (NRR) controller using a local Kind cluster.
 
-The test demonstrates a realistic, production-aligned scenario where critical addons run on a dedicated platform node pool, and the NRG controller manages a network readiness taint on a separate application worker node.
+The test demonstrates a realistic, production-aligned scenario where critical addons run on a dedicated platform node pool, and the NRR controller manages a network readiness taint on a separate application worker node.
 
 ### Test Topology
 
 The test uses a 3-node Kind cluster:
-1.  **`nrg-test-control-plane`**: The Kubernetes control plane.
-2.  **`nrg-test-worker` (Platform Node)**: A dedicated node for running cluster-critical addons. It is labeled `reserved-for=platform` and has a corresponding taint to repel normal application workloads. Cert-manager and the NRG controller will run here.
-3.  **`nrg-test-worker2` (Application Node)**: A standard worker node that starts with a `readiness.k8s.io/NetworkReady=pending:NoSchedule` taint, simulating a node that is not yet ready for application traffic.
+1.  **`nrr-test-control-plane`**: The Kubernetes control plane.
+2.  **`nrr-test-worker` (Platform Node)**: A dedicated node for running cluster-critical addons. It is labeled `reserved-for=platform` and has a corresponding taint to repel normal application workloads. Cert-manager and the NRR controller will run here.
+3.  **`nrr-test-worker2` (Application Node)**: A standard worker node that starts with a `readiness.k8s.io/NetworkReady=pending:NoSchedule` taint, simulating a node that is not yet ready for application traffic.
 
 ## Running the Test
 
@@ -25,7 +25,7 @@ The test uses a 3-node Kind cluster:
 The provided Kind configuration creates the 3-node topology with the necessary labels and taints.
 
 ```bash
-kind create cluster --config config/testing/kind/kind-config.yaml
+kind create cluster --config config/testing/kind/kind-3node-config.yaml
 ```
 
 Install CRDs
@@ -43,19 +43,19 @@ Build the controller image and load it into the Kind cluster nodes.
 make docker-build IMG=controller:latest
 
 # Load the image into the kind cluster
-kind load docker-image controller:latest --name nrg-test
+kind load docker-image controller:latest --name nrr-test
 ```
 
 ### Step 3: Controller Deployment
 
-Deploy the controller image to nrg-test-worker
+Deploy the controller image to nrr-test-worker
 ```bash
 make deploy IMG=controller:latest
 ```
 
-Verify the controller is running on the platform node (`nrg-test-worker`):
+Verify the controller is running on the platform node (`nrr-test-worker`):
 ```bash
-kubectl get pods -n nrg-system -o wide
+kubectl get pods -n nrr-system -o wide
 ```
 
 ### Step 4: Deploy the Readiness Rule
@@ -68,11 +68,11 @@ kubectl apply -f examples/network-readiness-rule.yaml
 
 ### Step 6: Verify Initial State
 
-Check that the application worker node (`nrg-test-worker2`) has the `NetworkReady` taint.
+Check that the application worker node (`nrr-test-worker2`) has the `NetworkReady` taint.
 
 ```bash
 # The output should include 'readiness.k8s.io/NetworkReady'
-kubectl get node nrg-test-worker2 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
+kubectl get node nrr-test-worker2 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
 ```
 
 ### Step 7: Deploy Calico CNI with Readiness Reporter
@@ -89,13 +89,13 @@ hack/test-workloads/apply-calico.sh
 1.  **Check for the new node condition on the application node:**
     ```bash
     # Look for 'network.k8s.io/CalicoReady   True'
-    kubectl get node nrg-test-worker2 -o jsonpath='Conditions:{"\n"}{range .status.conditions[*]}{.type}{"\t"}{.status}{"\n"}{end}'
+    kubectl get node nrr-test-worker2 -o jsonpath='Conditions:{"\n"}{range .status.conditions[*]}{.type}{"\t"}{.status}{"\n"}{end}'
     ```
 
 2.  **Verify the taint has been removed from the application node:**
     ```bash
     # The output should NO LONGER include 'readiness.k8s.io/NetworkReady'
-    kubectl get node nrg-test-worker2 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
+    kubectl get node nrr-test-worker2 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
     ```
 
 ### Step 9: Autoscaling Simulation Test
@@ -105,14 +105,14 @@ This section tests how the controller handles new nodes being added to the clust
 1.  **Scale up the worker nodes:**
     ```bash
     # Add 2 new worker nodes (for a total of 4 workers)
-    hack/test-workloads/kindscaler.sh nrg-test 2
+    hack/test-workloads/kindscaler.sh nrr-test 2
     ```
 
 2.  **Verify new nodes are tainted:**
     ```bash
     # Check the taints on the new nodes
-    kubectl get node nrg-test-worker3 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
-    kubectl get node nrg-test-worker4 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
+    kubectl get node nrr-test-worker3 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
+    kubectl get node nrr-test-worker4 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
     ```
 
 3.  **Verify taints are removed after Calico is ready:**
@@ -120,12 +120,12 @@ This section tests how the controller handles new nodes being added to the clust
     ```bash
     # Wait and verify the taints are removed from the new nodes
     sleep 60
-    kubectl get node nrg-test-worker3 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
-    kubectl get node nrg-test-worker4 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
+    kubectl get node nrr-test-worker3 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
+    kubectl get node nrr-test-worker4 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
     ```
 
 ### Step 10: Cleanup
 
 ```bash
-kind delete cluster --name nrg-test
+kind delete cluster --name nrr-test
 ```

--- a/docs/getting-started.draft.md
+++ b/docs/getting-started.draft.md
@@ -50,7 +50,7 @@ spec:
 **Build and push your image to the location specified by `IMG`:**
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/nrg-controller:tag
+make docker-build docker-push IMG=<some-registry>/nrr-controller:tag
 ```
 
 #### Option 1: Deploy Using Make Commands
@@ -60,7 +60,7 @@ make docker-build docker-push IMG=<some-registry>/nrg-controller:tag
 make install
 
 # Deploy the controller
-make deploy IMG=<some-registry>/nrg-controller:tag
+make deploy IMG=<some-registry>/nrr-controller:tag
 
 # Create sample rules
 kubectl apply -k examples/network-readiness-rule.yaml

--- a/docs/troubleshooting.draft.md
+++ b/docs/troubleshooting.draft.md
@@ -5,7 +5,7 @@
 1. **Rule conflicts**: Multiple rules targeting the same taint key
    ```sh
    # Check validation webhook logs
-   kubectl logs -n nrgcontroller-system deployment/nrgcontroller-controller-manager | grep webhook
+   kubectl logs -n nrrcontroller-system deployment/nrrcontroller-controller-manager | grep webhook
    ```
 
 2. **Missing node conditions**: Rules waiting for conditions that don't exist
@@ -20,10 +20,10 @@
 3. **RBAC issues**: Controller can't update nodes or rules
    ```sh
    # Check controller logs for permission errors
-   kubectl logs -n nrgcontroller-system deployment/nrgcontroller-controller-manager
+   kubectl logs -n nrrcontroller-system deployment/nrrcontroller-controller-manager
 
    # Verify RBAC
-   kubectl describe clusterrole nrgcontroller-manager-role
+   kubectl describe clusterrole nrrcontroller-manager-role
    ```
 
 ### Bootstrap Completion Tracking
@@ -42,8 +42,8 @@ kubectl get node <node-name> -o jsonpath='{.metadata.annotations}'
 Check that the controller is running:
 
 ```sh
-kubectl get pods -n nrgcontroller-system
-kubectl logs -n nrgcontroller-system deployment/nrgcontroller-controller-manager
+kubectl get pods -n nrrcontroller-system
+kubectl logs -n nrrcontroller-system deployment/nrrcontroller-controller-manager
 ```
 
 Verify CRDs are installed:
@@ -59,6 +59,6 @@ Enable verbose logging:
 
 ```sh
 # Edit controller deployment to add debug flags
-kubectl patch deployment -n nrgcontroller-system nrgcontroller-controller-manager \
+kubectl patch deployment -n nrrcontroller-system nrrcontroller-controller-manager \
   -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","args":["--zap-log-level=debug"]}]}}}}'
 ```

--- a/hack/test-workloads/condition-calico-not-ready.yaml
+++ b/hack/test-workloads/condition-calico-not-ready.yaml
@@ -1,7 +1,7 @@
 # Sample condition file to set a condition to a failed state.
 #
 # This can be used with the update-node-conditions.sh script
-# to test if the nrg-controller correctly re-applies taints.
+# to test if the nrr-controller correctly re-applies taints.
 #
 type: "network.k8s.io/CalicoReady"
 status: "False"

--- a/hack/test-workloads/condition-calico-ready.yaml
+++ b/hack/test-workloads/condition-calico-ready.yaml
@@ -1,7 +1,7 @@
 # Sample condition file for the update-node-conditions.sh script.
 #
 # This condition simulates the Calico CNI becoming ready on a node.
-# The nrg-controller should watch for this condition and remove the
+# The nrr-controller should watch for this condition and remove the
 # corresponding taint when the status becomes "True".
 #
 type: "network.k8s.io/CalicoReady"

--- a/hack/test-workloads/kindscaler.sh
+++ b/hack/test-workloads/kindscaler.sh
@@ -62,7 +62,7 @@ done
 start_index=$(($highest_index + 1))
 end_index=$(($highest_index + $COUNT))
 for i in $(seq $start_index $end_index); do
-    # Use nrg-test-worker2 as the template for all new worker nodes.
+    # Use nrr-test-worker2 as the template for all new worker nodes.
     # This ensures they get the correct labels and taints.
     TEMPLATE_NODE_NAME="$CLUSTER_NAME-worker2"
     NEW_NODE_NAME="$CLUSTER_NAME-worker$i"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -51,7 +51,7 @@ var (
 // CertManager.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	_, _ = fmt.Fprintf(GinkgoWriter, "Starting nrgcontroller integration test suite\n")
+	_, _ = fmt.Fprintf(GinkgoWriter, "Starting nrrcontroller integration test suite\n")
 	RunSpecs(t, "e2e suite")
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -35,16 +35,16 @@ import (
 )
 
 // namespace where the project is deployed in
-const namespace = "nrg-system"
+const namespace = "nrr-system"
 
 // serviceAccountName created for the project
-const serviceAccountName = "nrg-controller-manager"
+const serviceAccountName = "nrr-controller-manager"
 
 // metricsServiceName is the name of the metrics service of the project
-const metricsServiceName = "nrg-controller-manager-metrics-service"
+const metricsServiceName = "nrr-controller-manager-metrics-service"
 
 // metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
-const metricsRoleBindingName = "nrg-metrics-binding"
+const metricsRoleBindingName = "nrr-metrics-binding"
 
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string


### PR DESCRIPTION
Recently we renamed the KIND from NodeReadinessGate to NodeReadinessRule via PR https://github.com/kubernetes-sigs/node-readiness-controller/pull/27

As a follow up we need to change from nrg to nrr to be consistent.