### PR TITLE
setup auto-build/publish setup with cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,9 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954
+    entrypoint: ./scripts/build-and-publish-image.sh
+    env:
+    - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller

--- a/docs/TEST_README.md
+++ b/docs/TEST_README.md
@@ -40,7 +40,7 @@ Build the controller image and load it into the Kind cluster nodes.
 
 ```bash
 # Build the image
-make docker-build IMG=controller:latest
+make docker-build IMG_PREFIX=controller IMG_TAG=latest
 
 # Load the image into the kind cluster
 kind load docker-image controller:latest --name nrr-test
@@ -50,7 +50,7 @@ kind load docker-image controller:latest --name nrr-test
 
 Deploy the controller image to nrr-test-worker
 ```bash
-make deploy IMG=controller:latest
+make deploy IMG_PREFIX=controller IMG_TAG=latest
 ```
 
 Verify the controller is running on the platform node (`nrr-test-worker`):

--- a/docs/getting-started.draft.md
+++ b/docs/getting-started.draft.md
@@ -47,10 +47,10 @@ spec:
 
 ### Deployment
 
-**Build and push your image to the location specified by `IMG`:**
+**Build and push your image to the location specified by `IMG_PREFIX`:`IMG_TAG` :**
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/nrr-controller:tag
+make docker-build docker-push IMG_PREFIX=<some-registry>/nrr-controller IMG_TAG=tag
 ```
 
 #### Option 1: Deploy Using Make Commands
@@ -60,7 +60,7 @@ make docker-build docker-push IMG=<some-registry>/nrr-controller:tag
 make install
 
 # Deploy the controller
-make deploy IMG=<some-registry>/nrr-controller:tag
+make deploy IMG_PREFIX=<some-registry>/nrr-controller IMG_TAG=tag
 
 # Create sample rules
 kubectl apply -k examples/network-readiness-rule.yaml

--- a/scripts/build-and-publish-image.sh
+++ b/scripts/build-and-publish-image.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+if [[ -z ${IMG_PREFIX:-} ]]; then
+  echo "IMG_PREFIX is not set"
+  exit 1
+fi
+
+if [[ -z ${IMG_TAG:-} ]]; then
+  # Use a tag if the current commit is a tag, otherwise use a date+git-hash tag
+  if git describe --exact-match --tags HEAD >/dev/null 2>&1; then
+    IMG_TAG=$(git describe --exact-match --tags HEAD)
+  else
+    IMG_TAG="$(date +v%Y%m%d)-$(git rev-parse --short HEAD)"
+  fi
+fi
+echo "Using IMG_TAG=${IMG_TAG}"
+
+IMG_TAG=${IMG_TAG} IMG_PREFIX=${IMG_PREFIX%/} make docker-build
+
+IMG_TAG=${IMG_TAG} IMG_PREFIX=${IMG_PREFIX%/} make docker-push

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -40,9 +40,12 @@ var (
 	// isCertManagerAlreadyInstalled will be set true when CertManager CRDs be found on the cluster
 	isCertManagerAlreadyInstalled = false
 
-	// projectImage is the name of the image which will be build and loaded
+	// imagePrefix is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
-	projectImage = "controller:latest"
+	imagePrefix = "controller"
+	// imageTag is the tag of the image which will be build and loaded
+	// with the code source changes to be tested.
+	imageTag = "latest"
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
@@ -57,14 +60,15 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	By("building the manager(Operator) image")
-	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG_PREFIX=%s", imagePrefix), fmt.Sprintf("IMG_TAG=%s", imageTag))
 	_, err := utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
 
 	// TODO(user): If you want to change the e2e test vendor from Kind, ensure the image is
 	// built and available before running the tests. Also, remove the following block.
 	By("loading the manager(Operator) image on Kind")
-	err = utils.LoadImageToKindClusterWithName(projectImage)
+	//err = utils.LoadImageToKindClusterWithName(projectImage)
+	err = utils.LoadImageToKindClusterWithName(fmt.Sprintf("%s:%s", imagePrefix, imageTag))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Manager", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
 		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
+		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG_PREFIX=%s", imagePrefix), fmt.Sprintf("IMG_TAG=%s", imageTag))
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/node-readiness-controller/issues/20

We now have a staging repository for publishing artifacts - [us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller](http://us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller)

Major changes in the PR are the following 2 files:
- cloudbuild.yaml
- scripts/build-and-publish-image.sh


Rest of the chages:
- I've split the `IMG` env to two parts - `IMG_PREFIX` and `IMG_TAG`,  
  so the auto build/publish setup can tag our images with either a git Tag or use `date+git-hash`
- all files using `IMG` env are adjusted for the same.

---

This PR need to be merged before: https://github.com/kubernetes/test-infra/pull/36097

cc: @ajaysundark 



