### PR TITLE
fix failing build/publish job

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,4 +6,4 @@ steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954
     entrypoint: ./scripts/build-and-publish-image.sh
     env:
-    - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller
+    - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller/node-readiness-controller

--- a/scripts/build-and-publish-image.sh
+++ b/scripts/build-and-publish-image.sh
@@ -20,6 +20,6 @@ if [[ -z ${IMG_TAG:-} ]]; then
 fi
 echo "Using IMG_TAG=${IMG_TAG}"
 
-IMG_TAG=${IMG_TAG} IMG_PREFIX=${IMG_PREFIX%/} make docker-build
+IMG_TAG=${IMG_TAG} IMG_PREFIX=${IMG_PREFIX} make docker-build
 
-IMG_TAG=${IMG_TAG} IMG_PREFIX=${IMG_PREFIX%/} make docker-push
+IMG_TAG=${IMG_TAG} IMG_PREFIX=${IMG_PREFIX} make docker-push


### PR DESCRIPTION
Trying to fix failing `post-node-readiness-controller-push-images` job - 

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-node-readiness-controller-push-images/2001302429571747840

```
name invalid: Missing image name. Pushes should be of the form docker push HOST-NAME/PROJECT-ID/REPOSITORY/IMAGE
make: *** [Makefile:179: docker-push] Error 1
ERROR
ERROR: build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954" failed: step exited with non-zero status: 2
--------------------------------------------------------------------------------
2025/12/17 14:50:42 Failed to run some build jobs: [error running [gcloud builds submit --verbosity info --config /home/prow/go/src/github.com/kubernetes-sigs/node-readiness-controller/cloudbuild.yaml --substitutions _PULL_BASE_REF=main,_PULL_BASE_SHA=3157db14d467e178a2268c81ae360f3ebd6d7fcc,_GIT_TAG=v20251217-3157db1 --project k8s-staging-images --gcs-log-dir gs://k8s-staging-images-gcb/logs --gcs-source-staging-dir gs://k8s-staging-images-gcb/source gs://k8s-staging-images-gcb/source/b796772f-0b13-45fd-a82d-ee3d0ea87aa5.tgz --polling-interval 10]: exit status 1] 
```

cc: @ajaysundark 