### PR TITLE
Check rule generation before updating the staus

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -457,6 +457,11 @@ func (r *ReadinessGateController) updateRuleStatus(ctx context.Context, rule *re
 			return err
 		}
 
+		if latestRule.GetGeneration() != rule.GetGeneration() {
+			log.V(4).Info("Rule generation mismatch during status update, avoiding retry to let new reconciliation handle it")
+			return nil
+		}
+
 		// Merge our status updates into fresh version
 		// This ensures we're updating based on the latest resourceVersion
 		latestRule.Status.NodeEvaluations = rule.Status.NodeEvaluations


### PR DESCRIPTION
Since both node controller and node readiness controller trying to update the status of rule, There may be  conflict where the status updated by the NRR controller overriden by node controller, this tries to match the rule generation and make sure both are at the same level before updating the status,

From Error logs

```
2025-12-17T20:09:42+05:30	DEBUG	Updating rule status	{"controller": "nodereadiness-controller", "object": {"name":"network-readiness-rule"}, "namespace": "", "name": "network-readiness-rule", "reconcileID": "46cd3c25-2e2a-4e51-a39a-5852d051e052", "rule": "network-readiness-rule", "nodeEvaluations": 2, "appliedNodes": 2}
.
.
.
2025-12-17T20:09:53+05:30	DEBUG	Updating rule status	{"controller": "node", "controllerGroup": "", "controllerKind": "Node", "Node": {"name":"nrg-test-worker2"}, "namespace": "", "name": "nrg-test-worker2", "reconcileID": "49acd35b-8ad5-4da8-902f-102b25da14a1", "rule": "network-readiness-rule", "nodeEvaluations": 1, "appliedNodes": 0}
```

Fixes: https://github.com/kubernetes-sigs/node-readiness-controller/issues/43