### PR TITLE
update sed instruction to fix failing build on alpine (auto-build/publish pipeline)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	sed 's|^FROM|FROM --platform=${BUILDPLATFORM}|' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name nrrcontroller-builder
 	$(CONTAINER_TOOL) buildx use nrrcontroller-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG_PREFIX}:${IMG_TAG} -f Dockerfile.cross .


### PR DESCRIPTION
failing job - https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-node-readiness-controller-push-images/2001734052419211264

The image used in cloudbuild pipeline is gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954 (alpine based) and in there, the sed statement fails with the following error:

```
gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954
Using IMG_TAG=v20251218-c5c51a3
# copy existing Dockerfile and insert --platform= into Dockerfile.cross, and preserve the original Dockerfile
sed -e '1 s/\(^FROM\)/FROM --platform=\$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
sed: no previous regexp
make: *** [Makefile:191: docker-buildx] Error 1
ERROR
ERROR: build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954" failed: step exited with non-zero status: 2
-------------------------------------------------------------------------------- 
```

Tested the new sed statement in a local container with the image gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954


cc: @ajaysundark 