### PR TITLE
Fix rule status updates

### DIFF
--- a/examples/network-readiness-dryrun-rule.yaml
+++ b/examples/network-readiness-dryrun-rule.yaml
@@ -1,0 +1,18 @@
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: network-readiness-rule
+spec:
+  dryRun: true
+  conditions:
+    - type: "network.k8s.io/CalicoReady"
+      requiredStatus: "True"
+  taint:
+    key: "readiness.k8s.io/NetworkReady"
+    effect: "NoSchedule"
+    value: "pending"
+  enforcementMode: "continuous"
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -264,6 +264,10 @@ func (r *ReadinessGateController) processAllNodesForRule(ctx context.Context, ru
 	rule.Status.ObservedGeneration = rule.Generation
 	rule.Status.AppliedNodes = appliedNodes
 
+	if !rule.Spec.DryRun {
+		rule.Status.DryRunResults = readinessv1alpha1.DryRunResults{}
+	}
+
 	log.Info("Completed processing nodes for rule", "rule", rule.Name, "processedCount", len(appliedNodes))
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/node-readiness-controller/issues/43

```
// Initial:
$ kind create cluster --config config/testing/kind/kind-3node-config.yaml

// build and deploy controller (running in contorl-plane node)

$ kubectl get pods -n nrr-system -o wide
NAME                                      READY   STATUS    RESTARTS   AGE     IP           NODE                     NOMINATED NODE   READINESS GATES
nrr-controller-manager-66f7649cb7-6h896   1/1     Running   0          4m41s   10.244.0.5   nrr-test-control-plane   <none>           <none>

// current state 3 x nodes:
//    - cp has running nrr controller
//    - test-worker2 is intentionally tainted for NetworkReady
//    - test-worker is not tainted (mimicking some node misconfiguration - dryrun should capture this)

$ kubectl get nodes -o custom-columns="NAME:.metadata.name,TAINT:.spec.taints"
NAME                     TAINT
nrr-test-control-plane   [map[effect:NoSchedule key:node-role.kubernetes.io/control-plane]]
nrr-test-worker          [map[effect:NoExecute key:node-restriction.kubernetes.io/reserved-for value:platform]]
nrr-test-worker2         [map[effect:NoSchedule key:readiness.k8s.io/NetworkReady value:pending]]

// rule created in dry-run shows any node which is not control-plane to have either CalicoReady condition or  NetworkReady taint

$ kubectl apply -f ./examples/network-readiness-dryrun-rule.yaml 
nodereadinessrule.readiness.node.x-k8s.io/network-readiness-rule created

$ kubectl get nrr network-readiness-rule -ojson | jq .spec
{
  "conditions": [
    {
      "requiredStatus": "True",
      "type": "network.k8s.io/CalicoReady"
    }
  ],
  "dryRun": true,
  "enforcementMode": "continuous",
  "nodeSelector": {
    "matchExpressions": [
      {
        "key": "node-role.kubernetes.io/control-plane",
        "operator": "DoesNotExist"
      }
    ]
  },
  "taint": {
    "effect": "NoSchedule",
    "key": "readiness.k8s.io/NetworkReady",
    "value": "pending"
  }
}

// dryrun results:
// - affected nodes = 2 (testworker and testworker2)
// - riskyOperations = 2 (testworker and testworker2 do not report any value for this expected condition)
// taintsToAdd = 1 ( testworker didnt carry initial taint; creating this rule will create this taint on this node as controller will enforce this expected state)
// - summary: will taint 1 node, 2 nodes have missing conditions (summarizes the expected result of this rule creation action)

$ kubectl get nrr network-readiness-rule -ojson | jq .status
{
  "dryRunResults": {
    "affectedNodes": 2,
    "riskyOperations": 2,
    "summary": "would add 1 taints, 2 nodes have missing conditions",
    "taintsToAdd": 1,
    "taintsToRemove": 0
  }
}

// install CNI with hack/test-workloads/apply-calico.sh
// wait for installation

 kubectl get nodes -o custom-columns="NAME:.metadata.name, CONDITION:.status.conditions[?(@.type=='network.k8s.io/CalicoReady')].status"
NAME                      CONDITION
nrr-test-control-plane   True
nrr-test-worker          True
nrr-test-worker2         True

$ kubectl apply -f ./examples/network-readiness-rule.yaml
nodereadinessrule.readiness.node.x-k8s.io/network-readiness-rule configured

$ kubectl get nrr network-readiness-rule -ojson | jq .status
{
  "appliedNodes": [
    "nrr-test-worker",
    "nrr-test-worker2"
  ],
  "nodeEvaluations": [
    {
      "conditionResults": [
        {
          "currentStatus": "True",
          "missing": false,
          "requiredStatus": "True",
          "satisfied": true,
          "type": "network.k8s.io/CalicoReady"
        }
      ],
      "lastEvaluationTime": "2025-12-22T09:42:10Z",
      "nodeName": "nrr-test-worker",
      "taintStatus": "Absent"
    },
    {
      "conditionResults": [
        {
          "currentStatus": "True",
          "missing": false,
          "requiredStatus": "True",
          "satisfied": true,
          "type": "network.k8s.io/CalicoReady"
        }
      ],
      "lastEvaluationTime": "2025-12-22T09:42:10Z",
      "nodeName": "nrr-test-worker2",
      "taintStatus": "Absent"
    }
  ],
  "observedGeneration": 2
}

```

1. observedGeneration and appliedNodes are correctly reflected
2. dryrun results are removed