### PR TITLE
configure cloudbuild to run on machineType: E2_HIGHCPU_32

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,7 @@
 
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: E2_HIGHCPU_32
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954
     entrypoint: ./scripts/build-and-publish-image.sh


### PR DESCRIPTION
Some progress, but more errors.

Now the build is timing out. Trying with a better machinetype -

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-node-readiness-controller-push-images/2002243698796007424

```

#40 [linux/ppc64le builder 7/7] RUN CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -o manager cmd/main.go
Your build timed out. Use the [--timeout=DURATION] flag to change the timeout threshold.
BUILD FAILURE: Build step failure: build exceed the duration(seconds:3600)
ERROR: (gcloud.builds.submit) build 5aa719f9-979e-4ce2-83dd-d6864f6b7583 completed with status "TIMEOUT"
TIMEOUT
ERROR: context deadline exceeded
--------------------------------------------------------------------------------
2025/12/20 06:05:16 Failed to run some build jobs: [error running [gcloud builds submit --verbosity info --config /home/prow/go/src/github.com/kubernetes-sigs/node-readiness-controller/cloudbuild.yaml --substitutions _PULL_BASE_REF=main,_PULL_BASE_SHA=60a525782802ec89b3cd07f8473136e25649a480,_GIT_TAG=v20251220-60a5257 --project k8s-staging-images --gcs-log-dir gs://k8s-staging-images-gcb/logs --gcs-source-staging-dir gs://k8s-staging-images-gcb/source gs://k8s-staging-images-gcb/source/cba5854f-e808-4cb3-9b90-cdd0a3df2df4.tgz --polling-interval 10]: exit status 1] 
```

cc: @ajaysundark 