### PR TITLE
Build: Fix native cross-compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -184,16 +184,13 @@ docker-push: ## Push docker image with the manager.
 # - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 # - be able to push the image to your registry (i.e. if you do not set a valid value via ${IMG_PREFIX}:${IMG_TAG} then the export will fail)
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+PLATFORMS ?= linux/arm64,linux/amd64
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed 's|^FROM|FROM --platform=${BUILDPLATFORM}|' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name nrrcontroller-builder
 	$(CONTAINER_TOOL) buildx use nrrcontroller-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG_PREFIX}:${IMG_TAG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG_PREFIX}:${IMG_TAG} .
 	- $(CONTAINER_TOOL) buildx rm nrrcontroller-builder
-	rm Dockerfile.cross
 
 .PHONY: build-installer
 build-installer: manifests generate $(KUSTOMIZE) ## Generate a consolidated YAML with CRDs and deployment.

--- a/variants.yaml
+++ b/variants.yaml
@@ -1,0 +1,5 @@
+variants:
+  default:
+    gcp:
+      envs:
+        - "PLATFORMS=linux/amd64,linux/arm64"


### PR DESCRIPTION
- Restrict GCB architectures to amd64 and arm64 via variants.yaml
- Remove broken 'sed' hack in Makefile fix empty platform string
- Update Makefile PLATFORMS default to supported architectures.