### PR TITLE
docs: add uninstallation best practices and separate CRD from deploy

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,7 +15,6 @@ namePrefix: nrr-
 #    someName: someValue
 
 resources:
-- ../crd
 - ../rbac
 - ../manager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,15 +97,27 @@ kubectl apply -f examples/network-readiness-rule.yaml
 
 ### Uninstallation
 
+> **Important**: Follow this order to avoid stuck resources due to finalizers.
+
+The controller adds a finalizer (`readiness.node.x-k8s.io/cleanup-taints`) to each `NodeReadinessRule` to ensure node taints are cleaned up before the rule is deleted. This means you must delete CRs **while the controller is still running**.
+
 ```sh
-# Delete all rule instances
+# 1. Delete all rule instances first (while controller is running)
 kubectl delete nodereadinessrules --all
 
-# Delete the controller
+# 2. Delete the controller
 make undeploy
 
-# Delete the CRDs
+# 3. Delete the CRDs
 make uninstall
+```
+
+#### Recovering from Stuck Resources
+
+If you deleted the controller before removing the CRs, the finalizer will block CR deletion. To recover, manually remove the finalizer:
+
+```sh
+kubectl patch nodereadinessrule <rule-name> -p '{"metadata":{"finalizers":[]}}' --type=merge
 ```
 
 ## Operations


### PR DESCRIPTION
- Add documentation about proper uninstall order to avoid finalizer deadlocks
- Add recovery steps for stuck resources with manual finalizer removal
- Remove CRDs from config/default since `undeploy` and `uninstall` earlier used to do the same thing.
- CRDs are now managed separately via `make install`/`make uninstall`

Fixes: #48 