### PR TITLE
Fix failing image build: remove variants.yaml

### DIFF
--- a/variants.yaml
+++ b/variants.yaml
@@ -1,5 +1,0 @@
-variants:
-  default:
-    gcp:
-      envs:
-        - "PLATFORMS=linux/amd64,linux/arm64"


### PR DESCRIPTION
The Makefile is already patched default to linux/amd64,linux/arm64, so the gcb env overrides (variants.yaml) are not required.