### PR TITLE
API changes to make enforcement mode required and remove few status fields

### DIFF
--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -63,7 +63,7 @@ type NodeReadinessRuleSpec struct {
 	// "bootstrap-only" applies the configuration once during initial setup.
 	// "continuous" ensures the state is monitored and corrected throughout the resource lifecycle.
 	//
-	// +optional
+	// +required
 	EnforcementMode EnforcementMode `json:"enforcementMode,omitempty"`
 
 	// taint defines the specific Taint (Key, Value, and Effect) to be managed
@@ -233,16 +233,6 @@ type ConditionEvaluationResult struct {
 	// +required
 	// +kubebuilder:validation:Enum=True;False;Unknown
 	RequiredStatus corev1.ConditionStatus `json:"requiredStatus,omitempty"`
-
-	// satisfied indicates whether the CurrentStatus matches the RequiredStatus.
-	//
-	// +required
-	Satisfied bool `json:"satisfied"` //nolint:kubeapilinter
-
-	// missing indicates that the specified condition was not found on the Node.
-	//
-	// +required
-	Missing bool `json:"missing"` //nolint:kubeapilinter
 }
 
 // DryRunResults provides a summary of the actions the controller would perform if DryRun mode is enabled.

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -181,6 +181,7 @@ spec:
                 type: object
             required:
             - conditions
+            - enforcementMode
             - nodeSelector
             - taint
             type: object
@@ -312,10 +313,6 @@ spec:
                             - "False"
                             - Unknown
                             type: string
-                          missing:
-                            description: missing indicates that the specified condition
-                              was not found on the Node.
-                            type: boolean
                           requiredStatus:
                             description: requiredStatus is the status value defined
                               in the rule that must be matched, one of True, False,
@@ -325,10 +322,6 @@ spec:
                             - "False"
                             - Unknown
                             type: string
-                          satisfied:
-                            description: satisfied indicates whether the CurrentStatus
-                              matches the RequiredStatus.
-                            type: boolean
                           type:
                             description: type corresponds to the Node condition type
                               being evaluated.
@@ -337,9 +330,7 @@ spec:
                             type: string
                         required:
                         - currentStatus
-                        - missing
                         - requiredStatus
-                        - satisfied
                         - type
                         type: object
                       maxItems: 5000

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -159,6 +159,7 @@ var _ = Describe("Node Controller", func() {
 					NodeSelector: metav1.LabelSelector{
 						MatchLabels: map[string]string{"env": "test"},
 					},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
 				},
 			}
 		})

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -283,7 +283,6 @@ func (r *ReadinessGateController) evaluateRuleForNode(ctx context.Context, rule 
 	for _, condReq := range rule.Spec.Conditions {
 		currentStatus := r.getConditionStatus(node, condReq.Type)
 		satisfied := currentStatus == condReq.RequiredStatus
-		missing := currentStatus == corev1.ConditionUnknown
 
 		if !satisfied {
 			allConditionsSatisfied = false
@@ -293,13 +292,11 @@ func (r *ReadinessGateController) evaluateRuleForNode(ctx context.Context, rule 
 			Type:           condReq.Type,
 			CurrentStatus:  currentStatus,
 			RequiredStatus: condReq.RequiredStatus,
-			Satisfied:      satisfied,
-			Missing:        missing,
 		})
 
 		log.V(1).Info("Condition evaluation", "node", node.Name, "rule", rule.Name,
 			"conditionType", condReq.Type, "current", currentStatus, "required", condReq.RequiredStatus,
-			"satisfied", satisfied, "missing", missing)
+			"satisfied", satisfied)
 	}
 
 	// Determine taint action


### PR DESCRIPTION
1. Make EnforcementMode as required.

EnforcementMode is one of the key fields in spec which dictates the lifecycle of rule, It would be better if user is aware of this field  and its impact before applying the rule.
If required in future we can add a Default webhook and handle this.

2. Removed `Satisfied` and `Missing` fields from ConditionEvaluationResult from status

As of now these fields just checks and updates if the current status equal to required status, In ConditionEvaluationResult we already of CurrentStatus and RequiredStatus stored, so thinking this no more required.
We can add later if required.