### PR TITLE
Enable more rules for KAL and golang CI

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -14,9 +14,54 @@ linters:
         settings:
           linters:
             enable:
+              - "commentstart" # Ensure comments start with the serialized version of the field name.
+              - "conditions" # Ensure conditions have the correct json tags and markers.
+              - "conflictingmarkers"
+              - "duplicatemarkers" # Ensure there are no exact duplicate markers. for types and fields.
+              - "forbiddenmarkers" # Ensure that types and fields do not contain any markers that are forbidden.
+              - "integers" # Ensure only int32 and int64 are used for integers.
+              - "jsontags" # Ensure every field has a json tag.
+              - "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
+              - "nobools" # Bools do not evolve over time, should use enums instead.
+              - "nodurations" # Prevents usage of `Duration` types.
+              - "nofloats" # Ensure floats are not used.
+              - "nonullable" # Ensure that types and fields do not have the nullable marker.
               - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
+              - "notimestamp" # Prevents usage of 'Timestamp' fields
+              - "optionalfields" # Ensure that all fields marked as optional adhere to being pointers and
+                                 # having the `omitempty` value in their `json` tag where appropriate.
+              - "optionalorrequired" # Every field should be marked as `+optional` or `+required`.
+              - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`
+              - "ssatags" # Ensure array fields have the appropriate listType markers
+              - "statusoptional" # Ensure all first children within status should be optional.
+              - "statussubresource" # All root objects that have a `status` field should have a status subresource.
+              - "uniquemarkers" # Ensure that types and fields do not contain more than a single definition of a marker that should only be present once.
             disable:
             - "*" # We will manually enable new linters after understanding the impact. Disable all by default.
+          lintersConfig:
+            conflictingmarkers:
+              conflicts:
+                - name: "default_vs_required"
+                  sets:
+                    - [ "default", "kubebuilder:default" ]
+                    - [ "required", "kubebuilder:validation:Required", "k8s:required" ]
+                  description: "A field with a default value cannot be required"
+            conditions:
+              isFirstField: Warn # Require conditions to be the first field in the status struct.
+              usePatchStrategy: Forbid # Forbid patchStrategy markers on the Conditions field.
+              useProtobuf: Forbid # We don't use protobuf, so protobuf tags are not required.\
+            forbiddenmarkers:
+              markers:
+                # We don't want to do any defaulting (including OpenAPI) anymore on API fields because we prefer
+                # to have a clear signal on user intent. This also allows us to easily change the default behavior if necessary.
+                - identifier: "kubebuilder:default"
+                - identifier: "default"
+            optionalfields:
+              pointers:
+                preference: WhenRequired # Always | WhenRequired # Whether to always require pointers, or only when required. Defaults to `Always`.
+                policy: SuggestFix # SuggestFix | Warn # The policy for pointers in optional fields. Defaults to `SuggestFix`.
+              omitempty:
+                policy: SuggestFix # SuggestFix | Warn | Ignore # The policy for omitempty in optional fields. Defaults to `SuggestFix`.
   exclusions:
     generated: strict
     paths:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,28 +4,54 @@ run:
 linters:
   default: none
   enable:
-    - copyloopvar
-    - dupl
-    - errcheck
-    - ginkgolinter
-    - goconst
-    - gocyclo
-    - govet
-    - ineffassign
-    - lll
-    - misspell
-    - nakedret
-    - prealloc
-    - revive
-    - staticcheck
-    - unconvert
-    - unparam
-    - unused
+    - asasalint # warns about passing []any to func(...any) without expanding it
+    - asciicheck # non ascii symbols
+    - bidichk # dangerous unicode sequences
+    - bodyclose # unclosed http bodies
+    - containedctx # context.Context nested in a struct
+    - copyloopvar # copying loop variables
+    - dogsled # too many blank identifiers in assignments
+    - dupword # duplicate words
+    - durationcheck # multiplying two durations
+    - errcheck # unchecked errors
+    - errchkjson # invalid types passed to json encoder
+    - forbidigo # allows to block usage of funcs
+    - ginkgolinter # ginkgo and gomega
+    - gocritic # bugs, performance, style (we could add custom ones to this one)
+    - godot # checks that comments end in a period
+    - godox # block FIXMEs
+    - goprintffuncname # printft-like functions should be named with f at the end
+    - gosec # potential security problems
+    - govet # basically 'go vet'
+    - importas # consistent import aliases
+    - ineffassign # ineffectual assignments
+    - intrange # suggest using integer range in for loops
+    - loggercheck # check for even key/value pairs in logger calls
+    - misspell # spelling
+    - nakedret # naked returns (named return parameters and an empty return)
+    - nilerr # returning nil after checking err is not nil
+    - noctx # http requests without context.Context
+    - nolintlint # badly formatted nolint directives
+    - nosprintfhostport # using sprintf to construct host:port in a URL
+    - prealloc # suggest preallocating slices
+    - predeclared # shadowing predeclared identifiers
+    - revive # better version of golint
+    - staticcheck # some of staticcheck's rules
+    - thelper # test helpers not starting with t.Helper()
+    - unconvert # unnecessary type conversions
+    - unparam # unused function parameters
+    - unused # unused constants, variables,functions, types
+    - usestdlibvars # using variables/constants from the standard library
+    - usetesting # report function to be replaced by testing
+    - whitespace # unnecessary newlines
   settings:
     revive:
       rules:
         - name: comment-spacings
         - name: import-shadowing
+    godox:
+      keywords:
+        - FIXME # FIXME's should be removed before merging PRs
   exclusions:
     generated: lax
     rules:
@@ -36,10 +62,18 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - linters:
+          - gosec
+        path: "test/utils/"
+        text: "G204"
+      - linters:
+          - noctx
+        path: "test/utils/"
     paths:
       - third_party$
       - builtin$
       - examples$
+
 formatters:
   enable:
     - gofmt


### PR DESCRIPTION
This PR enables more golanglint and KAL rules.

Follow up on: https://github.com/kubernetes-sigs/node-readiness-controller/pull/41#discussion_r2633638221