### PR TITLE
doc: Replace vendor-specific examples with generic ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ metadata:
   name: network-readiness-rule
 spec:
   conditions:
-    - type: "tigera.io/CalicoReady"
+    - type: "example.com/CNIReady"
       requiredStatus: "True"
   taint:
     key: "readiness.k8s.io/NetworkReady"

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -46,7 +46,7 @@ metadata:
   name: network-readiness-rule
 spec:
   conditions:
-    - type: "tigera.io/CalicoReady"
+    - type: "example.com/CNIReady"
       requiredStatus: "True"
   taint:
     key: "readiness.k8s.io/NetworkReady"


### PR DESCRIPTION
This PR aims to replace vendor-specific references with generic examples (e.g., example.com/CNIReady).

Changes included:
- Updated README.md
- Updated docs/book/src/introduction.md

Fixes #60 