### PR TITLE
[cloudbuild.yaml] build and publish node-readiness-reporter image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,4 +6,11 @@ steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954
     entrypoint: ./scripts/build-and-publish-image.sh
     env:
-    - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller/node-readiness-controller
+    - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller
+    - COMPONENT=controller
+
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954
+    entrypoint: ./scripts/build-and-publish-image.sh
+    env:
+    - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller
+    - COMPONENT=reporter


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/node-readiness-controller/issues/20

follow up on https://github.com/kubernetes-sigs/node-readiness-controller/pull/57#discussion_r2674027266 and https://github.com/kubernetes-sigs/node-readiness-controller/pull/57#issuecomment-3731988664

Adding cloudbuild.yaml step for building and publishing node-readiness-reporter image (just like the existing node-readiness-controller image) for now. 

We will define the proper cadence (i.e. a conditional rule for when to build the node-readiness-reporter) after a further discussion within the group and update.

cc: @ajaysundark 

