### PR TITLE
fix rule deletion race condition with node-reconciliation

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -174,6 +174,10 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 func (r *RuleReconciler) reconcileDelete(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
+	// Update cache with deletion-marked rule before cleanup.
+	log.V(3).Info("Updating cache with deletion-marked rule before cleanup")
+	r.Controller.updateRuleCache(ctx, rule)
+
 	log.Info("Cleaning up taints for deleted rule", "rule", rule.Name)
 	if err := r.Controller.cleanupTaintsForRule(ctx, rule); err != nil {
 		log.Error(err, "Failed to cleanup taints for rule", "rule", rule.Name)


### PR DESCRIPTION
If there's a delete rule reconciliation, the finalizer triggers taint removal. This node update triggered node-reconciliation, which sometimes tried to re-add the taint when working with stale cache.

The patch here is that rule cache update should happen as the first step in `reconcileDelete` before `cleanupTaintsForRule`, so any further node reconciliation works with the latest update. 

Fixes https://github.com/kubernetes-sigs/node-readiness-controller/issues/83