### PR TITLE
persist node evaluation results for newly added nodes

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -184,7 +184,6 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 					latestRule.Status.NodeEvaluations,
 					currEval,
 				)
-				return nil
 			}
 
 			// handle status.FailedNodes for this node


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/node-readiness-controller/issues/86