### PR TITLE
v0.1.1: add release notes

### DIFF
--- a/docs/book/src/releases.md
+++ b/docs/book/src/releases.md
@@ -2,6 +2,55 @@
 
 This page details the official releases of the Node Readiness Controller.
 
+## v0.1.1
+
+**Date:** 2026-01-19
+
+This patch release includes important regression bug fixes and documentation updates made since v0.1.0.
+
+### Release Notes
+
+#### Bug or Regression
+- Fix race condition where deleting a rule could leave taints stuck on nodes ([#84](https://github.com/kubernetes-sigs/node-readiness-controller/pull/84))
+- Ensure new node evaluation results are persisted to rule status ([#87](https://github.com/kubernetes-sigs/node-readiness-controller/pull/87)]
+
+#### Documentation
+- Add/update Concepts documentation (enforcement modes, dry-run, condition reporting) ([#74](https://github.com/kubernetes-sigs/node-readiness-controller/pull/74))
+- Add v0.1.0 release notes to docs ([#76](https://github.com/kubernetes-sigs/node-readiness-controller/pull/76))
+
+### Images
+
+The following container images are published as part of this release.
+
+```
+// Node readiness controller
+registry.k8s.io/node-readiness-controller/node-readiness-controller:v0.1.1
+
+// Report component readiness condition from the node
+registry.k8s.io/node-readiness-controller/node-readiness-reporter:v0.1.1
+
+```
+
+### Installation
+
+To install the CRDs, apply the `crds.yaml` manifest for this version:
+
+```sh
+kubectl apply -f https://github.com/kubernetes-sigs/node-readiness-controller/releases/download/v0.1.1/crds.yaml
+```
+
+To install the controller, apply the `install.yaml` manifest for this version:
+
+```sh
+kubectl apply -f https://github.com/kubernetes-sigs/node-readiness-controller/releases/download/v0.1.1/install.yaml
+```
+
+This will deploy the controller into any available node in the `nrr-system` namespace in your cluster. Check [here](https://node-readiness-controller.sigs.k8s.io/user-guide/installation.html) for more installation instructions.
+
+### Contributors
+
+- ajaysundark
+
 ## v0.1.0
 
 **Date:** 2026-01-14


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/node-readiness-controller/issues/85

Draft release notes for v0.1.1

---

Note: I still kept the release notes as previous release's https://github.com/kubernetes-sigs/node-readiness-controller/issues/82#issuecomment-3741034492 (since we are yet to make the public announcements on mailing list)


/assign @ajaysundark 