### PR TITLE
feat: add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,62 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
+- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+-->
+
+
+## Description
+<!-- Brief description of changes -->
+
+## Related Issue
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+
+Fixes #
+
+or
+
+None
+-->
+
+## Type of Change
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
+
+## Testing
+<!-- How was this tested? -->
+
+## Checklist
+- [ ] `make test` passes
+- [ ] `make lint` passes
+
+## Does this PR introduce a user-facing change?
+
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+  1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+  2. Add 'Doc #(issue)' after the block if there is a follow up
+For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
+-->
+
+```release-note
+
+```
+Doc #(issue)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


## Description
<!-- Brief description of changes -->
This PR adds a PR template to the repository. Following the release note discussion in https://github.com/kubernetes-sigs/node-readiness-controller/issues/105#issuecomment-3787418946, I adopted the structure used by the [kubernetes/release](https://github.com/kubernetes/release/blob/master/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L45) repository for generating auto release notes.

## Related Issue
Fixes #105 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
No test needed.
<!-- How was this tested? -->

## Documentation update needed
-
<-- release-note or N/A and capture doc #(issue) --> 

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```