### PR TITLE
fix(README): update path to logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node Readiness Controller
 
-<img style="float: right; margin: auto;"  width="180px" src="docs/logo/node-readiness-controller-logo.svg"/>
+<img style="float: right; margin: auto;"  width="180px" src="docs/book/src/logo/node-readiness-controller-logo.svg"/>
 
 A Kubernetes controller that provides fine-grained, declarative readiness for nodes. It ensures nodes only accept workloads when all required components eg: network agents, GPU drivers,
 storage drivers or custom health-checks, are fully ready on the node.


### PR DESCRIPTION
https://github.com/kubernetes-sigs/node-readiness-controller/commit/9dbc9b340398724421d706da0b286b919c52b0b6 commit moved the logo location. 