### PR TITLE
fix(dev-container): disable moby in newer version of debian

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
   "name": "Kubebuilder DevContainer",
   "image": "golang:1.24",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": false
+    },
     "ghcr.io/devcontainers/features/git:1": {}
   },
 
@@ -22,4 +24,3 @@
 
   "onCreateCommand": "bash .devcontainer/post-install.sh"
 }
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

## Description
<!-- Brief description of changes -->

Newer debian installs (including go 1.24) don't ship with the moby cli option available for docker in docker.

Disable the moby option in the devcontainer.

Without it if a devcontainer is launched you get:

```
#13 [dev_containers_target_stage 5/6] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=docker-in-docker_0,target=/tmp/build-features-src/docker-in-docker_0     cp -ar /tmp/build-features-src/docker-in-docker_0 /tmp/dev-container-features  && chmod -R 0755 /tmp/dev-container-features/docker-in-docker_0  && cd /tmp/dev-container-features/docker-in-docker_0  && chmod +x ./devcontainer-features-install.sh  && ./devcontainer-features-install.sh  && rm -rf /tmp/dev-container-features/docker-in-docker_0
2026-02-11 13:54:47.041Z: #13 0.341 ===========================================================================
#13 0.341 Feature       : Docker (Docker-in-Docker)
#13 0.341 Description   : Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.
#13 0.341 Id            : ghcr.io/devcontainers/features/docker-in-docker
#13 0.341 Version       : 2.14.0
#13 0.341 Documentation : ********/devcontainers/features/tree/main/src/docker-in-docker
#13 0.341 Options       :
#13 0.341     VERSION="latest"
#13 0.341     MOBY="********"
#13 0.341     MOBYBUILDXVERSION="latest"
#13 0.341     DOCKERDASHCOMPOSEVERSION="v2"
#13 0.341     AZUREDNSAUTODETECTION="********"
#13 0.341     DOCKERDEFAULTADDRESSPOOL=""
#13 0.341     INSTALLDOCKERBUILDX="********"
2026-02-11 13:54:47.042Z: #13 0.341     INSTALLDOCKERCOMPOSESWITCH="false"
#13 0.341     DISABLEIP6TABLES="false"
#13 0.341 ===========================================================================
2026-02-11 13:54:47.122Z: #13 0.377 (!) The 'moby' option is not supported on Debian 'trixie' because 'moby-cli' and related system packages have been removed from that distribution.
#13 0.377 (!) To continue, either set the feature option '"moby": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04').
#13 0.378 ERROR: Feature "Docker (Docker-in-Docker)" (ghcr.io/devcontainers/features/docker-in-docker) failed to install! Look at the documentation at ********/devcontainers/features/tree/main/src/docker-in-docker for help troubleshooting this error.
#13 ERROR: process "/bin/sh -c cp -ar /tmp/build-features-src/docker-in-docker_0 /tmp/dev-container-features  && chmod -R 0755 /tmp/dev-container-features/docker-in-docker_0  && cd /tmp/dev-container-features/docker-in-docker_0  && chmod +x ./devcontainer-features-install.sh  && ./devcontainer-features-install.sh  && rm -rf /tmp/dev-container-features/docker-in-docker_0" did not complete successfully: exit code: 1
------
 > [dev_containers_target_stage 5/6] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=docker-in-docker_0,target=/tmp/build-features-src/docker-in-docker_0     cp -ar /tmp/build-features-src/docker-in-docker_0 /tmp/dev-container-features  && chmod -R 0755 /tmp/dev-container-features/docker-in-docker_0  && cd /tmp/dev-container-features/docker-in-docker_0  && chmod +x ./devcontainer-features-install.sh  && ./devcontainer-features-install.sh  && rm -rf /tmp/dev-container-features/docker-in-docker_0:
0.341     DOCKERDASHCOMPOSEVERSION="v2"
0.341     AZUREDNSAUTODETECTION="********"
0.341     DOCKERDEFAULTADDRESSPOOL=""
0.341     INSTALLDOCKERBUILDX="********"
0.341     INSTALLDOCKERCOMPOSESWITCH="false"
0.341     DISABLEIP6TABLES="false"
0.341 ===========================================================================
0.377 (!) The 'moby' option is not supported on Debian 'trixie' because 'moby-cli' and related system packages have been removed from that distribution.
0.377 (!) To continue, either set the feature option '"moby": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04').
0.378 ERROR: Feature "Docker (Docker-in-Docker)" (ghcr.io/devcontainers/features/docker-in-docker) failed to install! Look at the documentation at ********/devcontainers/features/tree/main/src/docker-in-docker for help troubleshooting this error.
------
```

## Related Issue
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

## Type of Change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

## Testing
<!-- How was this tested? -->

## Checklist
- [ ] `make test` passes
- [ ] `make lint` passes

Devcontainer was launched from this branch

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
  1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
  2. Add 'Doc #(issue)' after the block if there is a follow up
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
Doc #(issue)