### PR TITLE
Update manager.yaml to modify nodeSelector and tolerations

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,6 +56,8 @@ spec:
       #             values:
       #               - platform    # Modify this value based on your platform node labels.
       priorityClassName: system-cluster-critical
+      # TODO: In the future, this could be replaced with tolerate only readiness.k8s.io/* taints specifically, when wildcard support is available in K8s.
+      # (ref: https://github.com/kubernetes/enhancements/issues/5500)
       tolerations:
       - operator: Exists
         effect: NoSchedule


### PR DESCRIPTION
## Description
Removed nodeSelector for control-plane and updated to use default tolerations.

## Related Issue

Fixes #98 

## Type of Change

/kind feature

## Testing
<!-- How was this tested? -->

## Checklist
- [ ] `make test` passes
- [ ] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
allow placement of controller on any node with broad tolerations.
```
