### PR TITLE
cleanup: Remove unused globalDryRun feature (#123)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -312,7 +312,6 @@ spec:
 ### Error Recovery
 - Failed node evaluations recorded in rule status
 - Controller continues processing other nodes on individual failures
-- Global dry-run mode as emergency off-switch
 - Conservative approach: missing conditions = unsatisfied (keep restrictive taints)
 
 ### Observability

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -132,8 +132,8 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 			continue
 		}
 
-		// Skip if dry run or global dry run
-		if rule.Spec.DryRun || r.globalDryRun {
+		// Skip if dry run
+		if rule.Spec.DryRun {
 			log.Info("Skipping rule - dry run mode",
 				"node", node.Name, "rule", rule.Name)
 			continue

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -56,9 +56,6 @@ type RuleReadinessController struct {
 	// Cache for efficient rule lookup
 	ruleCacheMutex sync.RWMutex
 	ruleCache      map[string]*readinessv1alpha1.NodeReadinessRule // ruleName -> rule
-
-	// Global dry run mode (emergency off-switch)
-	globalDryRun bool
 }
 
 // RuleReconciler handles NodeReadinessRule reconciliation.
@@ -575,11 +572,6 @@ func (r *RuleReadinessController) processDryRun(ctx context.Context, rule *readi
 	}
 
 	return nil
-}
-
-// SetGlobalDryRun sets the global dry run mode (emergency off-switch).
-func (r *RuleReadinessController) SetGlobalDryRun(dryRun bool) {
-	r.globalDryRun = dryRun
 }
 
 // cleanupTaintsForRule removes taints managed by this rule from all applicable nodes.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


## Description
Removing dead code for the GlobalDryRun feature , since it was never used.
## Related Issue
Fixes #123 


## Type of Change
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Testing
<!-- How was this tested? -->

## Checklist
- [ ✓ ] `make test` passes
- [ ✓ ] `make lint` passes

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
  1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
  2. Add 'Doc #(issue)' after the block if there is a follow up
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
Doc #(issue)