### PR TITLE
feat: constrained impersonation for secure node status updates

### DIFF
--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -37,6 +37,7 @@ const (
 	envConditionType     = "CONDITION_TYPE"
 	envCheckEndpoint     = "CHECK_ENDPOINT"
 	envCheckInterval     = "CHECK_INTERVAL"
+	envImpersonateNode   = "IMPERSONATE_NODE"
 	defaultCheckInterval = 30 * time.Second
 	defaultHTTPTimeout   = 10 * time.Second
 )
@@ -88,6 +89,14 @@ func main() {
 	if err != nil {
 		klog.ErrorS(err, "Failed to create in-cluster config")
 		os.Exit(1)
+	}
+
+	// Set the constrained impersonation config
+	if os.Getenv(envImpersonateNode) == "true" {
+		config.Impersonate = rest.ImpersonationConfig{
+			UserName: "system:node:" + nodeName,
+		}
+		klog.InfoS("Node impersonation enabled", "impersonating", config.Impersonate.UserName)
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)

--- a/config/testing/kind/kind-constrained-impersonation-config.yaml
+++ b/config/testing/kind/kind-constrained-impersonation-config.yaml
@@ -1,0 +1,28 @@
+# Kind cluster configuration for testing Constrained Impersonation (KEP-5284).
+# Requires Kubernetes v1.35+ (Alpha) or v1.36+ (Beta).
+# The ConstrainedImpersonation feature gate must be enabled on the API server.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: nrr-constrained-impersonation
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  apiServer:
+    extraArgs:
+      feature-gates: "ConstrainedImpersonation=true"
+nodes:
+- role: control-plane
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        register-with-taints: "readiness.k8s.io/NetworkReady=pending:NoSchedule"
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        register-with-taints: "readiness.k8s.io/NetworkReady=pending:NoSchedule"

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -15,16 +15,17 @@
 <!-- - [Storage Drivers](./examples/storage-readiness.md) -->
 - [Security Agent](./examples/security-agent-readiness.md)
 <!-- - [Device Drivers](./examples/dra-readiness.md) -->
+- [Constrained Impersonation](./examples/constrained-impersonation.md)
 
 # Releases
 
 - [Release Notes](./releases.md)
 
-<!-- # Operations -->
+# Operations
 
 <!-- - [Monitoring](./operations/monitoring.md) -->
 <!-- - [Troubleshooting](./operations/troubleshooting.md) -->
-<!-- - [Security](./operations/security.md) -->
+- [Security](./operations/security.md)
 
 <!-- # Development -->
 

--- a/docs/book/src/examples/constrained-impersonation.md
+++ b/docs/book/src/examples/constrained-impersonation.md
@@ -1,0 +1,110 @@
+# Secure Status Reporting
+
+By default, a readiness reporter's ServiceAccount is granted broad permissions to update the status of **any** Node in the cluster. If a node is compromised, an attacker can manipulate the readiness status of every other node.
+
+[Constrained Impersonation (KEP-5284)](https://github.com/kubernetes/enhancements/issues/5284) solves this by allowing the reporter to impersonate only the Node it runs on. The API server enforces this at the authorization layer, so that no other node's status can be touched.
+
+This guide walks through a CNI readiness example that uses constrained impersonation instead of broad RBAC. It is a hardened variant of the [CNI Readiness](./cni-readiness.md) example.
+
+> **Prerequisites**: Kubernetes v1.35+ with the `ConstrainedImpersonation` feature gate enabled, or v1.36+ where it is Beta and enabled by default.
+
+> **Note**: You can find all the manifests used in this guide in the [`examples/constrained-impersonation`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/constrained-impersonation) directory.
+
+## Step-by-Step Guide
+
+### 1. Create a Kind Cluster
+
+Create a cluster with the `ConstrainedImpersonation` feature gate enabled and worker nodes that join with a startup taint:
+
+```sh
+kind create cluster \
+  --config config/testing/kind/kind-constrained-impersonation-config.yaml \
+  --image kindest/node:v1.35.0
+```
+
+### 2. Install the CRDs and Controller
+
+```sh
+make install
+make deploy
+```
+
+### 3. Deploy the Example
+
+```sh
+cd examples/constrained-impersonation
+kubectl apply -f .
+```
+
+### 4. RBAC Explained
+
+The RBAC consists of two ClusterRoles:
+
+**Impersonation role** — allows the reporter to impersonate its own Node:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-readiness-impersonator
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["nodes"]
+  verbs: ["impersonate:associated-node"]
+```
+
+**Constrained action role** — restricts what the impersonated identity can do:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-status-patcher-constrained
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["impersonate-on:associated-node:get"]
+- apiGroups: [""]
+  resources: ["nodes/status"]
+  verbs: ["impersonate-on:associated-node:update"]
+```
+
+### 5. Verification
+
+**Check that the reporter is running:**
+
+```sh
+kubectl -n kube-system get pods -l app=cni-reporter
+```
+
+**Check node conditions:**
+
+```sh
+kubectl get nodes -o custom-columns='NAME:.metadata.name,CALICO_READY:.status.conditions[?(@.type=="projectcalico.org/CalicoReady")].status'
+```
+
+### 6. Security Verification
+
+**Verify the ServiceAccount has no direct permissions:**
+
+```sh
+kubectl auth can-i get nodes --as=system:serviceaccount:kube-system:cni-reporter
+# no
+kubectl auth can-i update nodes/status --as=system:serviceaccount:kube-system:cni-reporter
+# no
+```
+
+The SA cannot read or update any node directly; all access goes through constrained impersonation.
+
+**Verify the reporter can still update its own node (via impersonation):**
+
+```sh
+kubectl get nodes -o custom-columns='NAME:.metadata.name,CALICO_READY:.status.conditions[?(@.type=="projectcalico.org/CalicoReady")].status'
+```
+
+The `CalicoReady` condition should appear on every node.
+This proves the reporter is successfully impersonating its local node identity and writing status.
+
+## Comparison with Broad RBAC
+
+For a deeper discussion, see [Security](../operations/security.md).

--- a/docs/book/src/operations/security.md
+++ b/docs/book/src/operations/security.md
@@ -1,0 +1,72 @@
+# Security
+
+The Node Readiness Controller relies on external **reporters**, lightweight components running on each node, to publish readiness information as Node conditions. Because these reporters must patch Node status objects, the RBAC they require needs careful attention.
+
+## The Threat Model
+
+Reporters typically run as DaemonSet pods or sidecars on the nodes they monitor.
+They use the Kubernetes API to update `nodes/status` with condition data that the controller consumes.
+
+With **broad RBAC** (the default in Kubernetes < v1.35), a reporter's ServiceAccount is granted `patch` and `update` on all `nodes/status` resources cluster-wide. This means that if a single node is compromised, an attacker can:
+
+- Mark **other** nodes as ready or not-ready, influencing scheduling decisions across the cluster.
+- Inject false conditions to bypass readiness gates on nodes they do not control.
+
+This violates the principle of least privilege: a reporter should only be able to modify the status of the node it runs on.
+
+## Constrained Impersonation (KEP-5284)
+
+[Constrained Impersonation](https://github.com/kubernetes/enhancements/issues/5284) (KEP-5284) introduces authorization rules that restrict a ServiceAccount to impersonating only the Node identity associated with the pod's bound service account token, and to performing only specific actions during that impersonation.
+
+### How It Works
+
+Two ClusterRoles are used together:
+
+1. **Impersonation role** — grants the reporter the ability to impersonate the identity of its own Node and nothing else.
+
+   ```yaml
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: node-readiness-impersonator
+   rules:
+   - apiGroups: ["authentication.k8s.io"]
+     resources: ["nodes"]
+     verbs: ["impersonate:associated-node"]
+   ```
+
+   The `impersonate:associated-node` verb tells the API server to validate that the pod's bound service account token references the same node (via the `authentication.kubernetes.io/node-name` extra key).
+   A reporter on `node-A` cannot impersonate `node-B`.
+
+2. **Constrained action role** — restricts what the impersonated identity is allowed to do.
+
+   ```yaml
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: node-status-patcher-constrained
+   rules:
+   - apiGroups: [""]
+     resources: ["nodes"]
+     verbs: ["impersonate-on:associated-node:get"]
+   - apiGroups: [""]
+     resources: ["nodes/status"]
+     verbs: ["impersonate-on:associated-node:update"]
+   ```
+
+   The `impersonate-on:associated-node:<verb>` verbs permit only specific operations during the impersonated session.
+   The reporter can get its own Node and update its status, but cannot modify labels, taints, the spec, or any resource other than `nodes/status`.
+
+Both roles are bound to the reporter's ServiceAccount via ClusterRoleBindings.
+
+### Reporter Configuration
+
+The reporter must be configured to use impersonation by setting the `IMPERSONATE_NODE` environment variable to `"true"`. When enabled, the reporter sends `Impersonate-User: system:node:<nodeName>` headers on every API request, which triggers the constrained impersonation authorization flow in the API server.
+
+```yaml
+env:
+  - name: IMPERSONATE_NODE
+    value: "true"
+```
+
+When `IMPERSONATE_NODE` is not set, the reporter uses its ServiceAccount identity directly (the pre-v1.35 behavior).

--- a/examples/constrained-impersonation/rbac.yaml
+++ b/examples/constrained-impersonation/rbac.yaml
@@ -1,0 +1,47 @@
+# Constrained Impersonation RBAC (KEP-5284)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-readiness-impersonator
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["nodes"]
+  verbs: ["impersonate:associated-node"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-status-patcher-constrained
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["impersonate-on:associated-node:get"]
+- apiGroups: [""]
+  resources: ["nodes/status"]
+  verbs: ["impersonate-on:associated-node:update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cni-reporter-impersonator-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-readiness-impersonator
+subjects:
+- kind: ServiceAccount
+  name: cni-reporter
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cni-reporter-constrained-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-status-patcher-constrained
+subjects:
+- kind: ServiceAccount
+  name: cni-reporter
+  namespace: kube-system

--- a/examples/constrained-impersonation/readiness-rule.yaml
+++ b/examples/constrained-impersonation/readiness-rule.yaml
@@ -1,0 +1,17 @@
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: network-readiness-rule
+spec:
+  conditions:
+    - type: "projectcalico.org/CalicoReady"
+      requiredStatus: "True"
+  taint:
+    key: "readiness.k8s.io/NetworkReady"
+    effect: "NoSchedule"
+    value: "pending"
+  enforcementMode: "continuous"
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist

--- a/examples/constrained-impersonation/reporter-ds.yaml
+++ b/examples/constrained-impersonation/reporter-ds.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cni-reporter
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cni-reporter
+  namespace: kube-system
+  labels:
+    app: cni-reporter
+spec:
+  selector:
+    matchLabels:
+      app: cni-reporter
+  template:
+    metadata:
+      labels:
+        app: cni-reporter
+    spec:
+      hostNetwork: true
+      serviceAccountName: cni-reporter
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: cni-status-patcher
+        image: registry.k8s.io/node-readiness-controller/node-readiness-reporter:v0.1.1
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: CHECK_ENDPOINT
+            value: "http://localhost:9099/readiness"
+          - name: CONDITION_TYPE
+            value: "projectcalico.org/CalicoReady"
+          - name: CHECK_INTERVAL
+            value: "5s"
+          - name: IMPERSONATE_NODE
+            value: "true"
+        resources:
+          limits:
+            cpu: "10m"
+            memory: "32Mi"
+          requests:
+            cpu: "10m"
+            memory: "32Mi"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


## Description
<!-- Brief description of changes -->

This PR adds support for Constrained Impersonation so reporters can only update the status of the node they run on, instead of any node in the cluster.

### Changes

- Reporter reads `IMPERSONATE_NODE` env var to send `Impersonate-User: system:node:<nodeName>` headers when enabled. It is an opt-in feature as older Kubernetes versions don't support it.
- A new example (`examples/constrained-impersonation/`) with RBAC, DaemonSet, and readiness rule is added.
- New docs (`operations/security.md` and `examples/constrained-impersonation.md`) are added.

### Notes

- This feature requires Kubernetes v1.35+ (Alpha) or v1.36+ (Beta, enabled by default).
- Existing examples are unchanged, and impersonation is opt-in via a new example.

## Related Issue

Fixes https://github.com/kubernetes-sigs/node-readiness-controller/issues/139

## Type of Change

/kind feature

## Testing
<!-- How was this tested? -->

You can follow along this [document](https://github.com/ali-a-a/node-readiness-controller/blob/f437da759e782b584f0073d0c6c4878ed5588365/docs/book/src/examples/constrained-impersonation.md) to test it locally.

## Checklist
- [X] `make test` passes
- [X] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Add support for Constrained Impersonation (KEP-5284) in the readiness condition reporter. Requires Kubernetes v1.35+.
```