### PR TITLE
use release artifacts for e2e tests

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -42,10 +42,12 @@ var (
 
 	// imagePrefix is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
-	imagePrefix = "controller"
+	imagePrefix = utils.GetEnvOrDefault("IMG_PREFIX", "controller")
 	// imageTag is the tag of the image which will be build and loaded
 	// with the code source changes to be tested.
-	imageTag = "latest"
+	imageTag = utils.GetEnvOrDefault("IMG_TAG", "latest")
+	// skipBuild will skip the docker-build and kind load steps if set to true.
+	skipBuild = os.Getenv("SKIP_RESOURCE_BUILD") == "true"
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
@@ -59,17 +61,19 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	By("building the manager(Operator) image")
-	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG_PREFIX=%s", imagePrefix), fmt.Sprintf("IMG_TAG=%s", imageTag))
-	_, err := utils.Run(cmd)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
+	if !skipBuild {
+		By("building the manager(Operator) image")
+		cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG_PREFIX=%s", imagePrefix), fmt.Sprintf("IMG_TAG=%s", imageTag))
+		_, err := utils.Run(cmd)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
 
-	// TODO(user): If you want to change the e2e test vendor from Kind, ensure the image is
-	// built and available before running the tests. Also, remove the following block.
-	By("loading the manager(Operator) image on Kind")
-	//err = utils.LoadImageToKindClusterWithName(projectImage)
-	err = utils.LoadImageToKindClusterWithName(fmt.Sprintf("%s:%s", imagePrefix, imageTag))
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
+		// TODO(user): If you want to change the e2e test vendor from Kind, ensure the image is
+		// built and available before running the tests. Also, remove the following block.
+		By("loading the manager(Operator) image on Kind")
+		//err = utils.LoadImageToKindClusterWithName(projectImage)
+		err = utils.LoadImageToKindClusterWithName(fmt.Sprintf("%s:%s", imagePrefix, imageTag))
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
+	}
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with CertManager already installed,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -53,6 +53,8 @@ var _ = Describe("Manager", Ordered, func() {
 	// enforce the restricted security policy to the namespace, installing CRDs,
 	// and deploying the controller.
 	BeforeAll(func() {
+		useReleaseArtifacts := os.Getenv("USE_RELEASE_ARTIFACTS") == "true"
+
 		By("creating manager namespace")
 		cmd := exec.Command("kubectl", "create", "ns", namespace)
 		_, err := utils.Run(cmd)
@@ -64,15 +66,27 @@ var _ = Describe("Manager", Ordered, func() {
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
 
-		By("installing CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+		if useReleaseArtifacts {
+			By("installing CRDs from dist/crds.yaml")
+			cmd = exec.Command("kubectl", "apply", "-f", "dist/crds.yaml")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs from dist/")
 
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG_PREFIX=%s", imagePrefix), fmt.Sprintf("IMG_TAG=%s", imageTag))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+			By("deploying the controller-manager from dist/install.yaml")
+			cmd = exec.Command("kubectl", "apply", "-f", "dist/install.yaml")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to deploy from dist/")
+		} else {
+			By("installing CRDs")
+			cmd = exec.Command("make", "install")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+
+			By("deploying the controller-manager")
+			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG_PREFIX=%s", imagePrefix), fmt.Sprintf("IMG_TAG=%s", imageTag))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+		}
 
 		Expect(err).NotTo(HaveOccurred(), "Failed to patch deployment")
 	})
@@ -80,17 +94,29 @@ var _ = Describe("Manager", Ordered, func() {
 	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
 	// and deleting the namespace.
 	AfterAll(func() {
+		useReleaseArtifacts := os.Getenv("USE_RELEASE_ARTIFACTS") == "true"
+
 		By("cleaning up the curl pod for metrics")
 		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
 		_, _ = utils.Run(cmd)
 
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
+		if useReleaseArtifacts {
+			By("undeploying the controller-manager from dist/install.yaml")
+			cmd = exec.Command("kubectl", "delete", "-f", "dist/install.yaml", "--ignore-not-found")
+			_, _ = utils.Run(cmd)
 
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
+			By("uninstalling CRDs from dist/crds.yaml")
+			cmd = exec.Command("kubectl", "delete", "-f", "dist/crds.yaml", "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		} else {
+			By("undeploying the controller-manager")
+			cmd = exec.Command("make", "undeploy")
+			_, _ = utils.Run(cmd)
+
+			By("uninstalling CRDs")
+			cmd = exec.Command("make", "uninstall")
+			_, _ = utils.Run(cmd)
+		}
 
 		By("removing manager namespace")
 		cmd = exec.Command("kubectl", "delete", "ns", namespace)

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -149,6 +149,15 @@ func LoadImageToKindClusterWithName(name string) error {
 	return err
 }
 
+// GetEnvOrDefault returns the value of the environment variable if it exists,
+// otherwise it returns the provided default value.
+func GetEnvOrDefault(key, defaultValue string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return defaultValue
+}
+
 // GetNonEmptyLines converts given command output string into individual objects
 // according to line breakers, and ignores the empty elements in it.
 func GetNonEmptyLines(output string) []string {


### PR DESCRIPTION
## Description
Enable testing with released manifests directly to help with qualification

## Related Issue

xref: https://github.com/kubernetes-sigs/node-readiness-controller/issues/151

## Type of Change

/kind feature

## Testing
Ran e2e tests with env flags

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
release-automation: run e2e-tests from published artifacts
```
Doc #151 