### PR TITLE
docs: add controller metrics reference

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -20,9 +20,9 @@
 
 - [Release Notes](./releases.md)
 
-<!-- # Operations -->
+# Operations
 
-<!-- - [Monitoring](./operations/monitoring.md) -->
+- [Monitoring](./operations/monitoring.md)
 <!-- - [Troubleshooting](./operations/troubleshooting.md) -->
 <!-- - [Security](./operations/security.md) -->
 

--- a/docs/book/src/operations/monitoring.md
+++ b/docs/book/src/operations/monitoring.md
@@ -1,0 +1,80 @@
+# Monitoring
+
+Node Readiness Controller exposes Prometheus-compatible metrics. This page describes the Prometheus metrics exposed by Node Readiness Controller for monitoring rule evaluation, taint operations, failures, and bootstrap progress.
+
+## Metrics Endpoint
+
+The controller serves metrics on `/metrics` only when metrics are explicitly enabled. Depending on the installation, the endpoint is served either over HTTP or over HTTPS. See [Installation](../user-guide/installation.md) for deployment details.
+
+## Supported Metrics
+
+### `node_readiness_rules_total`
+
+Number of `NodeReadinessRule` objects tracked by the controller.
+
+| Property | Value |
+| --- | --- |
+| Type | `gauge` |
+| Labels | none |
+| Recorded when | The controller refreshes or removes a tracked rule |
+
+### `node_readiness_taint_operations_total`
+
+Total number of taint operations performed by the controller.
+
+| Property | Value |
+| --- | --- |
+| Type | `counter` |
+| Labels | `rule`, `operation` |
+| Recorded when | The controller successfully adds or removes a taint |
+
+#### Labels
+
+| Label | Description | Values |
+| --- | --- | --- |
+| `rule` | `NodeReadinessRule` name | Any rule name |
+| `operation` | Taint operation performed by the controller | `add`, `remove` |
+
+### `node_readiness_evaluation_duration_seconds`
+
+Duration of rule evaluations.
+
+| Property | Value |
+| --- | --- |
+| Type | `histogram` |
+| Labels | none |
+| Buckets | Prometheus default histogram buckets |
+| Recorded when | The controller evaluates a rule against a node |
+
+### `node_readiness_failures_total`
+
+Total number of failure events recorded by the controller.
+
+| Property | Value |
+| --- | --- |
+| Type | `counter` |
+| Labels | `rule`, `reason` |
+| Recorded when | The controller records an evaluation failure or taint add/remove failure |
+
+#### Labels
+
+| Label | Description | Values |
+| --- | --- | --- |
+| `rule` | `NodeReadinessRule` name | Any rule name |
+| `reason` | Failure label recorded by the controller | `EvaluationError`, `AddTaintError`, `RemoveTaintError` |
+
+### `node_readiness_bootstrap_completed_total`
+
+Total number of nodes that have completed bootstrap.
+
+| Property | Value |
+| --- | --- |
+| Type | `counter` |
+| Labels | `rule` |
+| Recorded when | The controller marks bootstrap as completed for a node under a bootstrap-only rule |
+
+#### Labels
+
+| Label | Description | Values |
+| --- | --- | --- |
+| `rule` | `NodeReadinessRule` name | Any rule name |


### PR DESCRIPTION
## Description
Added user-facing docs covering all the metrics defined in [internal/metrics/metrics.go](https://github.com/kubernetes-sigs/node-readiness-controller/blob/main/internal/metrics/metrics.go). I tried to keep the structure simple and extensible so we can build on it as we add more metrics, while still keeping it consistent with the rest of the docs. 

I also kept the per-metric detail fairly lightweight for now, so lmk if you want more detail for each metric or if the current level is okay.

## Related Issue
Fixes #94


## Type of Change
/kind documentation


## Testing
N/A

## Checklist
- [X] `make test` passes
- [X] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```
