### PR TITLE
Update kindscaler to wait for cgroupv2 init

### DIFF
--- a/hack/test-workloads/kindscaler.sh
+++ b/hack/test-workloads/kindscaler.sh
@@ -71,7 +71,8 @@ for i in $(seq $start_index $end_index); do
     docker cp $TEMPLATE_NODE_NAME:/kind/kubeadm.conf kubeadm-$i.conf > /dev/null 2>&1
 
     # Replace the container role name with specific node name in the kubeadm file
-    sed -i "s/$TEMPLATE_NODE_NAME$/$NEW_NODE_NAME/g" "./kubeadm-$i.conf"
+    sed -i.bak "s/$TEMPLATE_NODE_NAME$/$NEW_NODE_NAME/g" "./kubeadm-$i.conf"
+    rm -f "./kubeadm-$i.conf.bak"
 
     IMAGE=$(docker ps | grep $CLUSTER_NAME | awk '{print $2}' | head -1)
 	
@@ -84,6 +85,22 @@ for i in $(seq $start_index $end_index); do
     --detach --tty --label io.x-k8s.kind.cluster=$CLUSTER_NAME --net kind \
     --restart=on-failure:1 --init=false $IMAGE > /dev/null 2>&1
 
+    # wait for cgroupv2 initialization before docker exec
+    wait_count=0
+    while [ $wait_count -lt 30 ]; do
+        status=$(docker exec $NEW_NODE_NAME systemctl is-system-running 2>/dev/null || true)
+        if [[ "$status" == "running" ]]; then
+            break
+        fi
+        sleep 2
+        wait_count=$((wait_count + 1))
+    done
+    status=$(docker exec $NEW_NODE_NAME systemctl is-system-running 2>/dev/null || true)
+    if [[ $wait_count -ge 30 ]] && [ "$status" != "running" ]; then
+        echo "Container $NEW_NODE_NAME failed to initialize systemd"
+        echo "Review $NEW_NODE_NAME logs and remove container"
+        exit 1
+    fi
     docker cp kubeadm-$i.conf $NEW_NODE_NAME:/kind/kubeadm.conf > /dev/null 2>&1
     docker exec --privileged $NEW_NODE_NAME kubeadm join --config /kind/kubeadm.conf --skip-phases=preflight --v=6 > /dev/null 2>&1
     rm -f kubeadm-*.conf


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


## Description
Updated kindscaler to handle cgroupv2 initialization before running kubeadm join. Also updated `sed` command to handle macOS BSD syntax.

## Related Issue
Fixes #160 

## Type of Change
/kind bug

## Testing
Setup kind cluster using the config provided under `config/testing/kind` and follow instructions for autoscaling simulation tests under `docs/TEST_README.md`.
The command `hack/test-workloads/kindscaler.sh nrr-test 2` will wait for container to initialize cgroupv2 before running kubeadm join to join the cluster. 

## Checklist
- [ x ] `make test` passes
- [ x ] `make lint` passes

## Does this PR introduce a user-facing change?
No. dev/testing utility change.

```release-note
NONE
```