### PR TITLE
Reserve specific taint key prefixes 

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -258,7 +258,7 @@ spec:
     - type: "network.kubernetes.io/NetworkProxyReady"
       requiredStatus: "True"
   taint:
-    key: "readiness.k8s.io/NetworkReady"
+    key: "readiness.k8s.io/network/not-ready"
     effect: "NoSchedule"
     value: "pending"
   enforcementMode: "bootstrap-only"
@@ -278,7 +278,7 @@ spec:
     - type: "storage.kubernetes.io/CSIReady"
       requiredStatus: "True"
   taint:
-    key: "readiness.k8s.io/StorageReady"
+    key: "readiness.k8s.io/storage/not-ready"
     effect: "NoSchedule"
   enforcementMode: "continuous"
   gracePeriod: "60s"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ spec:
     - type: "example.com/CNIReady"
       requiredStatus: "True"
   taint:
-    key: "readiness.k8s.io/NetworkReady"
+    key: "readiness.k8s.io/example.com/network-not-ready"
     effect: "NoSchedule"
     value: "pending"
   enforcementMode: "bootstrap-only"
@@ -61,6 +61,21 @@ spec:
 ```
 
 Find a more detailed walkthrough of setting up Node Readiness Controller in your Kind cluster [here](https://github.com/kubernetes-sigs/node-readiness-controller/blob/main/docs/TEST_README.md).
+
+### Taint Key Conventions
+
+All taint keys must use the `readiness.k8s.io/` prefix. The following core prefixes are reserved and not allowed for user rules:
+- `readiness.k8s.io/system/*`
+- `readiness.k8s.io/core/*`
+- `readiness.k8s.io/node/*`
+- `readiness.k8s.io/device/*`
+- `readiness.k8s.io/network/*`
+- `readiness.k8s.io/storage/*`
+
+Use user-space keys under `readiness.k8s.io/*` with a DNS-style component to avoid conflicts, for example:
+- `readiness.k8s.io/example.com/network-not-ready`
+- `readiness.k8s.io/projectcalico.org/cni-ready`
+- `readiness.k8s.io/vendor.io/storage-driver-ready`
 
 ## High-level Roadmap
 

--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -82,6 +82,12 @@ type NodeReadinessRuleSpec struct {
 	//
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self.key.startsWith('readiness.k8s.io/')",message="taint key must start with 'readiness.k8s.io/'"
+	// +kubebuilder:validation:XValidation:rule="!self.key.startsWith('readiness.k8s.io/system/')",message="reserved taint prefix 'readiness.k8s.io/system/*' is not allowed"
+	// +kubebuilder:validation:XValidation:rule="!self.key.startsWith('readiness.k8s.io/core/')",message="reserved taint prefix 'readiness.k8s.io/core/*' is not allowed"
+	// +kubebuilder:validation:XValidation:rule="!self.key.startsWith('readiness.k8s.io/node/')",message="reserved taint prefix 'readiness.k8s.io/node/*' is not allowed"
+	// +kubebuilder:validation:XValidation:rule="!self.key.startsWith('readiness.k8s.io/device/')",message="reserved taint prefix 'readiness.k8s.io/device/*' is not allowed"
+	// +kubebuilder:validation:XValidation:rule="!self.key.startsWith('readiness.k8s.io/network/')",message="reserved taint prefix 'readiness.k8s.io/network/*' is not allowed"
+	// +kubebuilder:validation:XValidation:rule="!self.key.startsWith('readiness.k8s.io/storage/')",message="reserved taint prefix 'readiness.k8s.io/storage/*' is not allowed"
 	// +kubebuilder:validation:XValidation:rule="self.key.size() <= 253",message="taint key length must be at most 253 characters"
 	// +kubebuilder:validation:XValidation:rule="size(self.key.split('/')) == 2",message="taint key must have exactly one '/' separator (prefix/name format)"
 	// +kubebuilder:validation:XValidation:rule="size(self.key.split('/')[1]) > 0 && size(self.key.split('/')[1]) <= 63",message="taint key name part must be 1-63 characters"

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -200,6 +200,24 @@ spec:
                 x-kubernetes-validations:
                 - message: taint key must start with 'readiness.k8s.io/'
                   rule: self.key.startsWith('readiness.k8s.io/')
+                - message: reserved taint prefix 'readiness.k8s.io/system/*' is not
+                    allowed
+                  rule: '!self.key.startsWith(''readiness.k8s.io/system/'')'
+                - message: reserved taint prefix 'readiness.k8s.io/core/*' is not
+                    allowed
+                  rule: '!self.key.startsWith(''readiness.k8s.io/core/'')'
+                - message: reserved taint prefix 'readiness.k8s.io/node/*' is not
+                    allowed
+                  rule: '!self.key.startsWith(''readiness.k8s.io/node/'')'
+                - message: reserved taint prefix 'readiness.k8s.io/device/*' is not
+                    allowed
+                  rule: '!self.key.startsWith(''readiness.k8s.io/device/'')'
+                - message: reserved taint prefix 'readiness.k8s.io/network/*' is not
+                    allowed
+                  rule: '!self.key.startsWith(''readiness.k8s.io/network/'')'
+                - message: reserved taint prefix 'readiness.k8s.io/storage/*' is not
+                    allowed
+                  rule: '!self.key.startsWith(''readiness.k8s.io/storage/'')'
                 - message: taint key length must be at most 253 characters
                   rule: self.key.size() <= 253
                 - message: taint key must have exactly one '/' separator (prefix/name

--- a/config/samples/v1alpha1_nodereadinessrule.yaml
+++ b/config/samples/v1alpha1_nodereadinessrule.yaml
@@ -10,7 +10,7 @@ spec:
     - type: "network.kubernetes.io/CNIReady"
       requiredStatus: "True"
   taint:
-    key: "readiness.k8s.io/NetworkReady"
+    key: "readiness.k8s.io/example.com/network-not-ready"
     effect: "NoSchedule"
     value: "pending"
   enforcementMode: "bootstrap-only"

--- a/config/testing/kind/kind-3node-config.yaml
+++ b/config/testing/kind/kind-3node-config.yaml
@@ -11,11 +11,11 @@ nodes:
       kubeletExtraArgs:
         node-labels: "reserved-for=platform"
         register-with-taints: "node-restriction.kubernetes.io/reserved-for=platform:NoExecute"
-- role: worker # workers; reserved labels like node-role.kubernetes.io/worker cannot be used in kind ref: kind/issues/3536 
+- role: worker # workers; reserved labels like node-role.kubernetes.io/worker cannot be used in kind ref: kind/issues/3536
   kubeadmConfigPatches:
   - |
     kind: JoinConfiguration
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "reserved-for=worker"
-        register-with-taints: "readiness.k8s.io/NetworkReady=pending:NoSchedule"
+        register-with-taints: "readiness.k8s.io/projectcalico.org/network-not-ready=pending:NoSchedule"

--- a/config/testing/kind/test-config.yaml
+++ b/config/testing/kind/test-config.yaml
@@ -9,4 +9,4 @@ nodes:
     kind: JoinConfiguration
     nodeRegistration:
       kubeletExtraArgs:
-        register-with-taints: "readiness.k8s.io/NetworkReady=pending:NoSchedule"
+        register-with-taints: "readiness.k8s.io/projectcalico.org/network-not-ready=pending:NoSchedule"

--- a/docs/TEST_README.md
+++ b/docs/TEST_README.md
@@ -9,7 +9,7 @@ The test demonstrates a realistic, production-aligned scenario where critical ad
 The test uses a 3-node Kind cluster:
 1.  **`nrr-test-control-plane`**: The Kubernetes control plane. The NRR controller will run here unless specifically configured.
 2.  **`nrr-test-worker` (Platform Node)**: A dedicated node for running cluster-critical addons. It is labeled `reserved-for=platform` and has a corresponding taint to repel normal application workloads. Cert-manager will run here.
-3.  **`nrr-test-worker2` (Application Node)**: A standard worker node that starts with a `readiness.k8s.io/NetworkReady=pending:NoSchedule` taint, simulating a node that is not yet ready for application traffic.
+3.  **`nrr-test-worker2` (Application Node)**: A standard worker node that starts with a `readiness.k8s.io/projectcalico.org/network-not-ready=pending:NoSchedule` taint, simulating a node that is not yet ready for application traffic.
 
 ## Running the Test
 
@@ -94,7 +94,7 @@ kubectl apply -f examples/cni-readiness/network-readiness-rule.yaml
 Check that the application worker node (`nrr-test-worker2`) has the `NetworkReady` taint.
 
 ```bash
-# The output should include 'readiness.k8s.io/NetworkReady'
+# The output should include 'readiness.k8s.io/projectcalico.org/network-not-ready'
 kubectl get node nrr-test-worker2 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
 ```
 
@@ -120,7 +120,7 @@ examples/cni-readiness/apply-calico.sh
 
 2.  **Verify the taint has been removed from the application node:**
     ```bash
-    # The output should NO LONGER include 'readiness.k8s.io/NetworkReady'
+# The output should NO LONGER include 'readiness.k8s.io/projectcalico.org/network-not-ready'
     kubectl get node nrr-test-worker2 -o jsonpath='Taints:{"\n"}{range .spec.taints[*]}{.key}{"\n"}{end}'
     ```
 

--- a/docs/book/src/examples/cni-readiness.md
+++ b/docs/book/src/examples/cni-readiness.md
@@ -8,8 +8,8 @@ In many Kubernetes clusters, the CNI plugin runs as a DaemonSet. When a new node
 This guide demonstrates how to use the Node Readiness Controller to prevent pods from being scheduled on a node until the Container Network Interface (CNI) plugin (e.g., Calico) is fully initialized and ready.
 
 The high-level steps are:
-1.  Node is bootstrapped with a [startup taint](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) `readiness.k8s.io/NetworkReady=pending:NoSchedule` immediately upon joining.
-2.  A reporter DaemonSet is deployed to monitor the CNI's health and report it to the API server as node-condition (`projectcalico.org/CalicoReady`). 
+1.  Node is bootstrapped with a [startup taint](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) `readiness.k8s.io/projectcalico.org/network-not-ready=pending:NoSchedule` immediately upon joining.
+2.  A reporter DaemonSet is deployed to monitor the CNI's health and report it to the API server as node-condition (`projectcalico.org/CalicoReady`).
 3. Node Readiness Controller will untaint the node only when the CNI reports it is ready.
 
 ## Step-by-Step Guide
@@ -85,7 +85,7 @@ subjects:
 
 ### 3. Create the Node Readiness Rule
 
-Now define the rule that enforces the requirement. This tells the controller: *"Keep the `readiness.k8s.io/NetworkReady` taint on the node until `projectcalico.org/CalicoReady` is True."*
+Now define the rule that enforces the requirement. This tells the controller: *"Keep the `readiness.k8s.io/projectcalico.org/network-not-ready` taint on the node until `projectcalico.org/CalicoReady` is True."*
 
 ```yaml
 # network-readiness-rule.yaml
@@ -101,7 +101,7 @@ spec:
   
   # The taint to manage
   taint:
-    key: "readiness.k8s.io/NetworkReady"
+    key: "readiness.k8s.io/projectcalico.org/network-not-ready"
     effect: "NoSchedule"
     value: "pending"
   
@@ -135,7 +135,7 @@ To test this, add a new node to the cluster.
 
 1.  **Check the Node Taints**:
     Immediately upon joining, the node should have the taint:
-    `readiness.k8s.io/NetworkReady=pending:NoSchedule`.
+    `readiness.k8s.io/projectcalico.org/network-not-ready=pending:NoSchedule`.
 
 2.  **Check Node Conditions**:
     Watch the node conditions. You will initially see `projectcalico.org/CalicoReady` as `False` or missing.

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -49,7 +49,7 @@ spec:
     - type: "example.com/CNIReady"
       requiredStatus: "True"
   taint:
-    key: "readiness.k8s.io/NetworkReady"
+    key: "readiness.k8s.io/example.com/network-not-ready"
     effect: "NoSchedule"
     value: "pending"
   enforcementMode: "bootstrap-only"

--- a/docs/book/src/reference/api-spec.md
+++ b/docs/book/src/reference/api-spec.md
@@ -162,6 +162,7 @@ _Appears in:_
 | `conditions` _[ConditionRequirement](#conditionrequirement) array_ | conditions contains a list of the Node conditions that defines the specific<br />criteria that must be met for taints to be managed on the target Node.<br />The presence or status of these conditions directly triggers the application or removal of Node taints. |  | MaxItems: 32 <br />MinItems: 1 <br /> |
 | `enforcementMode` _[EnforcementMode](#enforcementmode)_ | enforcementMode specifies how the controller maintains the desired state.<br />enforcementMode is one of bootstrap-only, continuous.<br />"bootstrap-only" applies the configuration once during initial setup.<br />"continuous" ensures the state is monitored and corrected throughout the resource lifecycle. |  | Enum: [bootstrap-only continuous] <br /> |
 | `taint` _[Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#taint-v1-core)_ | taint defines the specific Taint (Key, Value, and Effect) to be managed<br />on Nodes that meet the defined condition criteria. |  |  |
+<br />Key must start with `readiness.k8s.io/`. Reserved core prefixes are forbidden: `readiness.k8s.io/{system,core,node,device,network,storage}/*`. Use user-space keys such as `readiness.k8s.io/<dns.subdomain>/<component>`.
 | `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta)_ | nodeSelector limits the scope of this rule to a specific subset of Nodes. |  |  |
 | `dryRun` _boolean_ | dryRun when set to true, The controller will evaluate Node conditions and log intended taint modifications<br />without persisting changes to the cluster. Proposed actions are reflected in the resource status. |  |  |
 
@@ -203,5 +204,4 @@ _Appears in:_
 | --- | --- |
 | `Present` | TaintStatusPresent represent the taint present on the Node.<br /> |
 | `Absent` | TaintStatusAbsent represent the taint absent on the Node.<br /> |
-
 

--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -22,6 +22,19 @@ Typical taint keys look like:
 - `readiness.k8s.io/csi.vendor.com/storage-driver-not-ready`
 - `readiness.k8s.io/<dns.subdomain>/<component-name>`
 
+Reserved core prefixes (not allowed for user rules):
+- `readiness.k8s.io/system/*`
+- `readiness.k8s.io/core/*`
+- `readiness.k8s.io/node/*`
+- `readiness.k8s.io/device/*`
+- `readiness.k8s.io/network/*`
+- `readiness.k8s.io/storage/*`
+
+Use vendor/user-space paths under `readiness.k8s.io/*` that include a DNS-style component to avoid conflicts, for example:
+- `readiness.k8s.io/example.com/my-component`
+- `readiness.k8s.io/projectcalico.org/network-not-ready`
+- `readiness.k8s.io/vendor.io/storage-driver-ready`
+
 The segment after `readiness.k8s.io/` should describe the dependency or subsystem whose readiness is being guarded (for example, a CNI plugin, storage backend, or security agent). Treat this domain as reserved for the controller and closely related components, and avoid reusing it for unrelated taints.
 
 ## Enforcement Modes

--- a/docs/book/src/user-guide/getting-started.md
+++ b/docs/book/src/user-guide/getting-started.md
@@ -133,9 +133,25 @@ taint:
 **Invalid:**
 ```yaml
 taint:
-  key: "network-ready"              # Missing prefix
-  key: "node.kubernetes.io/ready"   # Wrong prefix
+  key: "network-ready"                        # Missing prefix
+  key: "node.kubernetes.io/ready"             # Wrong prefix
+  key: "readiness.k8s.io/system/foo"          # Reserved prefix
+  key: "readiness.k8s.io/network/bar"         # Reserved prefix
+  key: "readiness.k8s.io/storage/not-ready"   # Reserved prefix
 ```
+
+Reserved core prefixes under `readiness.k8s.io/*` are forbidden to avoid conflicts with future controller features:
+- `readiness.k8s.io/system/*`
+- `readiness.k8s.io/core/*`
+- `readiness.k8s.io/node/*`
+- `readiness.k8s.io/device/*`
+- `readiness.k8s.io/network/*`
+- `readiness.k8s.io/storage/*`
+
+Use vendor/user-space keys with DNS-style components, for example:
+- `readiness.k8s.io/example.com/network-not-ready`
+- `readiness.k8s.io/projectcalico.org/cni-ready`
+- `readiness.k8s.io/vendor.io/storage-driver-ready`
 
 
 ## Testing with Dry Run

--- a/examples/cni-readiness/README.md
+++ b/examples/cni-readiness/README.md
@@ -3,7 +3,7 @@
 This example demonstrates how to use the Node Readiness Controller to ensure nodes are only marked ready for workloads after the CNI (Calico) has fully initialized.
 
 ### How it works:
-1. Nodes join with a `readiness.k8s.io/NetworkReady=pending:NoSchedule` taint.
+1. Nodes join with a `readiness.k8s.io/network/not-ready=pending:NoSchedule` taint.
 2. A lightweight DaemonSet (`cni-reporter-ds.yaml`)
    monitors Calico's health endpoint (`localhost:9099/readiness`) and updates a
    node condition `projectcalico.org/CalicoReady`.

--- a/examples/cni-readiness/network-readiness-dryrun-rule.yaml
+++ b/examples/cni-readiness/network-readiness-dryrun-rule.yaml
@@ -8,7 +8,7 @@ spec:
     - type: "projectcalico.org/CalicoReady"
       requiredStatus: "True"
   taint:
-    key: "readiness.k8s.io/NetworkReady"
+    key: "readiness.k8s.io/projectcalico.org/network-not-ready"
     effect: "NoSchedule"
     value: "pending"
   enforcementMode: "bootstrap-only"

--- a/examples/cni-readiness/network-readiness-rule.yaml
+++ b/examples/cni-readiness/network-readiness-rule.yaml
@@ -7,7 +7,7 @@ spec:
     - type: "projectcalico.org/CalicoReady"
       requiredStatus: "True"
   taint:
-    key: "readiness.k8s.io/NetworkReady"
+    key: "readiness.k8s.io/projectcalico.org/network-not-ready"
     effect: "NoSchedule"
     value: "pending"
   enforcementMode: "continuous"

--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -19,6 +19,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,6 +69,29 @@ func (w *NodeReadinessRuleWebhook) validateSpec(spec readinessv1alpha1.NodeReadi
 	}
 	if selector != nil && selector.Empty() {
 		allErrs = append(allErrs, field.Required(field.NewPath("spec", "nodeSelector"), "nodeSelector must not be empty"))
+	}
+
+	// Validate taint - reserved prefix validation (defense in depth, also validated by CRD)
+	taintField := field.NewPath("spec", "taint")
+	if spec.Taint.Key != "" {
+		if !strings.HasPrefix(spec.Taint.Key, "readiness.k8s.io/") {
+			allErrs = append(allErrs, field.Invalid(taintField.Child("key"), spec.Taint.Key, "taint key must start with 'readiness.k8s.io/'"))
+		} else {
+			reserved := []string{
+				"readiness.k8s.io/system/",
+				"readiness.k8s.io/core/",
+				"readiness.k8s.io/node/",
+				"readiness.k8s.io/device/",
+				"readiness.k8s.io/network/",
+				"readiness.k8s.io/storage/",
+			}
+			for _, p := range reserved {
+				if strings.HasPrefix(spec.Taint.Key, p) {
+					allErrs = append(allErrs, field.Invalid(taintField.Child("key"), spec.Taint.Key, fmt.Sprintf("reserved taint prefix '%s*' is not allowed", p)))
+					break
+				}
+			}
+		}
 	}
 
 	return allErrs
@@ -197,3 +221,5 @@ func (w *NodeReadinessRuleWebhook) ValidateDelete(ctx context.Context, obj runti
 	// No validation needed for delete operations
 	return nil, nil
 }
+
+// Made with Bob

--- a/internal/webhook/nodereadinessgaterule_webhook_test.go
+++ b/internal/webhook/nodereadinessgaterule_webhook_test.go
@@ -437,7 +437,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 						},
 					},
 					Taint: corev1.Taint{
-						Key:    "test-key",
+						Key:    "readiness.k8s.io/test-key",
 						Effect: corev1.TaintEffectNoExecute, // NoExecute effect
 					},
 					EnforcementMode: readinessv1alpha1.EnforcementModeContinuous, // Continuous mode
@@ -465,7 +465,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 						},
 					},
 					Taint: corev1.Taint{
-						Key:    "test-key",
+						Key:    "readiness.k8s.io/test-key",
 						Effect: corev1.TaintEffectNoExecute, // NoExecute effect
 					},
 					EnforcementMode: readinessv1alpha1.EnforcementModeBootstrapOnly, // Bootstrap mode
@@ -492,7 +492,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 						},
 					},
 					Taint: corev1.Taint{
-						Key:    "test-key",
+						Key:    "readiness.k8s.io/test-key",
 						Effect: corev1.TaintEffectNoSchedule, // NoSchedule effect
 					},
 					EnforcementMode: readinessv1alpha1.EnforcementModeContinuous,
@@ -517,7 +517,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 						},
 					},
 					Taint: corev1.Taint{
-						Key:    "test-key",
+						Key:    "readiness.k8s.io/test-key",
 						Effect: corev1.TaintEffectPreferNoSchedule, // PreferNoSchedule effect
 					},
 					EnforcementMode: readinessv1alpha1.EnforcementModeContinuous,
@@ -559,7 +559,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 			// Test NoExecute + continuous
 			spec := readinessv1alpha1.NodeReadinessRuleSpec{
 				Taint: corev1.Taint{
-					Key:    "test",
+					Key:    "readiness.k8s.io/test",
 					Effect: corev1.TaintEffectNoExecute,
 				},
 				EnforcementMode: readinessv1alpha1.EnforcementModeContinuous,
@@ -578,6 +578,112 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 			spec.Taint.Effect = corev1.TaintEffectNoSchedule
 			warnings = webhook.generateNoExecuteWarnings(spec)
 			Expect(warnings).To(BeEmpty())
+		})
+	})
+
+	Context("Reserved Prefix Validation", func() {
+		It("should reject all reserved readiness.k8s.io core prefixes", func() {
+			reservedKeys := []string{
+				"readiness.k8s.io/system/foo",
+				"readiness.k8s.io/core/bar",
+				"readiness.k8s.io/node/baz",
+				"readiness.k8s.io/device/xyz",
+				"readiness.k8s.io/network/abc",
+				"readiness.k8s.io/storage/def",
+			}
+			for _, k := range reservedKeys {
+				rule := &readinessv1alpha1.NodeReadinessRule{
+					Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+						Conditions: []readinessv1alpha1.ConditionRequirement{
+							{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+						},
+						NodeSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"node-role.kubernetes.io/worker": "",
+							},
+						},
+						Taint: corev1.Taint{
+							Key:    k,
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+						EnforcementMode: readinessv1alpha1.EnforcementModeBootstrapOnly,
+					},
+				}
+				allErrs := webhook.validateSpec(rule.Spec)
+				Expect(allErrs).NotTo(BeEmpty())
+				Expect(allErrs[0].Field).To(Equal("spec.taint.key"))
+			}
+		})
+
+		// Test that commonly used taint keys are properly rejected as they fall under reserved prefixes.
+		It("should reject readiness.k8s.io/network/not-ready (reserved prefix)", func() {
+			rule := &readinessv1alpha1.NodeReadinessRule{
+				Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+					Conditions: []readinessv1alpha1.ConditionRequirement{
+						{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+					},
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+					Taint: corev1.Taint{
+						Key:    "readiness.k8s.io/network/not-ready",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					EnforcementMode: readinessv1alpha1.EnforcementModeBootstrapOnly,
+				},
+			}
+			allErrs := webhook.validateSpec(rule.Spec)
+			Expect(allErrs).NotTo(BeEmpty())
+			Expect(allErrs[0].Field).To(Equal("spec.taint.key"))
+			Expect(allErrs[0].Detail).To(ContainSubstring("reserved taint prefix 'readiness.k8s.io/network/*' is not allowed"))
+		})
+
+		It("should reject readiness.k8s.io/storage/not-ready (reserved prefix)", func() {
+			rule := &readinessv1alpha1.NodeReadinessRule{
+				Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+					Conditions: []readinessv1alpha1.ConditionRequirement{
+						{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+					},
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+					Taint: corev1.Taint{
+						Key:    "readiness.k8s.io/storage/not-ready",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					EnforcementMode: readinessv1alpha1.EnforcementModeBootstrapOnly,
+				},
+			}
+			allErrs := webhook.validateSpec(rule.Spec)
+			Expect(allErrs).NotTo(BeEmpty())
+			Expect(allErrs[0].Field).To(Equal("spec.taint.key"))
+			Expect(allErrs[0].Detail).To(ContainSubstring("reserved taint prefix 'readiness.k8s.io/storage/*' is not allowed"))
+		})
+
+		It("should allow user-space keys under readiness.k8s.io", func() {
+			rule := &readinessv1alpha1.NodeReadinessRule{
+				Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+					Conditions: []readinessv1alpha1.ConditionRequirement{
+						{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+					},
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+					Taint: corev1.Taint{
+						Key:    "readiness.k8s.io/example.com/my-component",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					EnforcementMode: readinessv1alpha1.EnforcementModeBootstrapOnly,
+				},
+			}
+			allErrs := webhook.validateSpec(rule.Spec)
+			Expect(allErrs).To(BeEmpty())
 		})
 	})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -289,7 +289,7 @@ status:
 				if err != nil {
 					return false
 				}
-				return !strings.Contains(output, "readiness.k8s.io/StorageReady")
+				return !strings.Contains(output, "readiness.k8s.io/e2e-test.io/storage-not-ready")
 			}, 10*time.Second, 2*time.Second).Should(BeTrue())
 
 			By("updating node condition to False")
@@ -303,7 +303,7 @@ status:
 				if err != nil {
 					return false
 				}
-				return strings.Contains(output, "readiness.k8s.io/StorageReady")
+				return strings.Contains(output, "readiness.k8s.io/e2e-test.io/storage-not-ready")
 			}, 30*time.Second, 2*time.Second).Should(BeTrue())
 
 			By("updating node condition back to True")
@@ -317,7 +317,7 @@ status:
 				if err != nil {
 					return false
 				}
-				return !strings.Contains(output, "readiness.k8s.io/StorageReady")
+				return !strings.Contains(output, "readiness.k8s.io/e2e-test.io/storage-not-ready")
 			}, 30*time.Second, 2*time.Second).Should(BeTrue())
 
 			By("cleaning up test resources")

--- a/test/e2e/testdata/continuous-rule.yaml
+++ b/test/e2e/testdata/continuous-rule.yaml
@@ -7,7 +7,7 @@ spec:
     - type: "StorageReady"
       requiredStatus: "True"
   taint:
-    key: "readiness.k8s.io/StorageReady"
+    key: "readiness.k8s.io/e2e-test.io/storage-not-ready"
     effect: "NoSchedule"
     value: "pending"
   enforcementMode: "continuous"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


## Description
1. Reserved taint key prefixes for:
- `readiness.k8s.io/system/*`
- `readiness.k8s.io/core/*`
- `readiness.k8s.io/node/*`
- `readiness.k8s.io/device/*`
- `readiness.k8s.io/network/*` 
- `readiness.k8s.io/storage/*`
2. Updated yaml examples and doc to reflect the same

## Related Issue
Fixes #3 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

## Type of Change
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Testing
<!-- How was this tested? -->

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
  1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
  2. Add 'Doc #(issue)' after the block if there is a follow up
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Reserved specific taint key prefixes (readiness.k8s.io/{system,core,node,device,network,storage}/*) for core operations.
```
Doc #(issue)