### PR TITLE
chore: add kubeconfig to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ bin/*
 hack/tools/bin
 Dockerfile.cross
 
+# Kubeconfig might contain secrets
+*.kubeconfig
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
Kubeconfig might contain secrets, and should usually not be tracked in git.

Just some housekeeping.

/kind cleanup