### PR TITLE
refactor: modernize range over loop

### DIFF
--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -153,8 +153,8 @@ func LoadImageToKindClusterWithName(name string) error {
 // according to line breakers, and ignores the empty elements in it.
 func GetNonEmptyLines(output string) []string {
 	var res []string
-	elements := strings.Split(output, "\n")
-	for _, element := range elements {
+	elements := strings.SplitSeq(output, "\n")
+	for element := range elements {
 		if element != "" {
 			res = append(res, element)
 		}


### PR DESCRIPTION
Just a small refactor to modernize a for range loop.

This was auto-applied via `go fix`.

As a follow-up, we could add the [modernize linter](https://golangci-lint.run/docs/linters/configuration/#modernize) to `golangci-lint` config.

See:
https://go.dev/blog/gofix
https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_stringsseq

/kind cleanup