### PR TITLE
feat: add Effect and DryRun printcolumns to NodeReadinessRule

### DIFF
--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -298,8 +298,10 @@ type DryRunResults struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=nrr
-// +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.enforcementMode`,description="Continuous, Bootstrap or Dryrun - shows if the rule is in enforcement or dryrun mode."
+// +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.enforcementMode`,description="The enforcement mode of the rule: bootstrap-only or continuous."
 // +kubebuilder:printcolumn:name="Taint",type=string,JSONPath=`.spec.taint.key`,description="The readiness taint applied by this rule."
+// +kubebuilder:printcolumn:name="Effect",type=string,JSONPath=`.spec.taint.effect`,description="The taint effect: NoSchedule, PreferNoSchedule or NoExecute."
+// +kubebuilder:printcolumn:name="DryRun",type=boolean,JSONPath=`.spec.dryRun`,description="Whether the rule is in dry-run mode and only previews taint changes."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of this resource"
 
 // NodeReadinessRule is the Schema for the NodeReadinessRules API.

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -17,8 +17,7 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - description: Continuous, Bootstrap or Dryrun - shows if the rule is in enforcement
-        or dryrun mode.
+    - description: 'The enforcement mode of the rule: bootstrap-only or continuous.'
       jsonPath: .spec.enforcementMode
       name: Mode
       type: string
@@ -26,6 +25,14 @@ spec:
       jsonPath: .spec.taint.key
       name: Taint
       type: string
+    - description: 'The taint effect: NoSchedule, PreferNoSchedule or NoExecute.'
+      jsonPath: .spec.taint.effect
+      name: Effect
+      type: string
+    - description: Whether the rule is in dry-run mode and only previews taint changes.
+      jsonPath: .spec.dryRun
+      name: DryRun
+      type: boolean
     - description: The age of this resource
       jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
## Description

Adds two `additionalPrinterColumns` to the `NodeReadinessRule` CRD so operators can see relevant rule details directly from `kubectl get nrr`:

- **Effect** (`.spec.taint.effect`) — surfaces `NoSchedule` / `PreferNoSchedule` / `NoExecute`. The README explicitly warns that `NoExecute` evicts existing pods and can cause significant disruption, so making the effect visible at a glance is operationally useful.
- **DryRun** (`.spec.dryRun`) — surfaces whether a rule is in dry-run mode (previewing changes only) versus actively managing taints.

Also trims the existing `Mode` column description from *"Continuous, Bootstrap or Dryrun..."* to *"The enforcement mode of the rule: bootstrap-only or continuous."* — the original text was inaccurate because `EnforcementMode` only enums to `bootstrap-only` or `continuous`; dry-run is a separate boolean field on the spec (now exposed by the new `DryRun` column).

Before:
```
NAME                     MODE         TAINT                           AGE
network-readiness-rule   continuous   readiness.k8s.io/NetworkReady   5m
```

After:
```
NAME                     MODE             TAINT                           EFFECT       DRYRUN   AGE
network-readiness-rule   bootstrap-only   readiness.k8s.io/NetworkReady   NoSchedule   true     5m
```

## Related Issue

None

## Type of Change

/kind feature

## Testing

- `make manifests` regenerates the CRD YAML cleanly
- `make build` and `make test` pass
- Verified end-to-end in a 3-node kind cluster: applied the updated CRD, then both `examples/cni-readiness/network-readiness-rule.yaml` (continuous) and `examples/cni-readiness/network-readiness-dryrun-rule.yaml` (dry-run). `kubectl get nrr` shows the new columns with the expected values; non-dry-run rules render a blank `DRYRUN` cell (standard k8s printcolumn behavior for `omitempty` booleans).

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Added `Effect` and `DryRun` columns to `kubectl get nodereadinessrules` (`kubectl get nrr`) output, surfacing the taint effect and dry-run mode of each rule.
```