### PR TITLE
fix: retry lychee link check on transient upstream errors

### DIFF
--- a/hack/verify-links.sh
+++ b/hack/verify-links.sh
@@ -70,4 +70,10 @@ fi
 chmod +x ${TEMP_DIR}/${LYCHEE_BINARY}
 
 echo "Checking links in Markdown files..."
-"${TEMP_DIR}/${LYCHEE_BINARY}" --no-progress --timeout 30 --format detailed  '**/*.md'
+"${TEMP_DIR}/${LYCHEE_BINARY}" \
+    --no-progress \
+    --timeout 30 \
+    --max-retries 5 \
+    --retry-wait-time 5 \
+    --format detailed \
+    '**/*.md'

--- a/hack/verify-links.sh
+++ b/hack/verify-links.sh
@@ -73,7 +73,7 @@ echo "Checking links in Markdown files..."
 "${TEMP_DIR}/${LYCHEE_BINARY}" \
     --no-progress \
     --timeout 30 \
-    --max-retries 5 \
-    --retry-wait-time 5 \
+    --max-retries 3 \
+    --retry-wait-time 3 \
     --format detailed \
     '**/*.md'


### PR DESCRIPTION
## Description

The `verify-links` step (lychee Markdown link checker, run by `hack/verify-links.sh` via `make verify`) has been flaking on transient GitHub `502 Bad Gateway` responses. lychee defaults to `--max-retries 3 --retry-wait-time 1`, which is often not enough to ride out brief GitHub edge hiccups, so a single 5xx fails the whole job.

This PR bumps the retry budget so transient 5xx / rate-limit responses recover within the same job:

- `--max-retries 5`
- `--retry-wait-time 5`

Observed flake on PR #193 (same commit, same job, only the upstream response differed):

- failed: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_node-readiness-controller/193/pull-node-readiness-controller-verify-all/2050597698947518464
  ```
  Errors in docs/book/src/releases.md
  [502] https://github.com/kubernetes-sigs/node-readiness-controller/pull/101 | Rejected status code: 502 Bad Gateway
  [502] https://github.com/kubernetes-sigs/node-readiness-controller/pull/123 | Rejected status code: 502 Bad Gateway
  ```
- passed (retrigger, no code changes): https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_node-readiness-controller/193/pull-node-readiness-controller-verify-all/2050598858269921280

## Related Issue

None

## Type of Change

/kind flake

## Testing

Ran `./hack/verify-links.sh` locally:

```
Checking links in Markdown files...
🔍 Total..........153
✅ Successful.....131
🚫 Errors...........0
```

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```