### PR TITLE
fix: replace hardcoded arch with env detection in scripts

### DIFF
--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -15,16 +15,16 @@
 #!/bin/bash
 set -x
 
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)
 chmod +x ./kind
 mv ./kind /usr/local/bin/kind
 
-curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
+curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/$(go env GOARCH)
 chmod +x kubebuilder
 mv kubebuilder /usr/local/bin/
 
 KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/$(go env GOARCH)/kubectl"
 chmod +x kubectl
 mv kubectl /usr/local/bin/kubectl
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install the latest version of kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 


### PR DESCRIPTION
This PR adds a small fix to make install scripts a bit more environment-agnostic. 

The default is a hardcoded amd64, but that can be problematic on runners with different architecture (e.g. arm). 

/kind cleanup