### PR TITLE
CI: harden GitHub Actions workflows security

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -6,16 +6,21 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   govulncheck:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Clone the code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # Fetch full history so git worktree can check out the base branch.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -23,7 +28,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+        run: go install golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 # v1.1.4
 
       - name: Run govulncheck
         # NRC_VERIFY_GIT_BRANCH tells the script which branch to use as the

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,13 +4,19 @@ on:
   push:
   pull_request:
 
+permissions: {}
+
 jobs:
   lint:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Clone the code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -8,18 +8,20 @@ on:
     paths:
       - 'VERSION'
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   cut-release:
     name: Cut Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Read Version
         id: version

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,13 +4,19 @@ on:
   push:
   pull_request:
 
+permissions: {}
+
 jobs:
   test-e2e:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Clone the code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,19 @@ on:
   push:
   pull_request:
 
+permissions: {}
+
 jobs:
   test:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Clone the code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0


### PR DESCRIPTION
This PR hardens the security on GitHub Actions workflows.

Summary of changes:

- Add `persist-credentials: false` to checkout action to remediate [artipacked](https://docs.zizmor.sh/audits/#artipacked).
- Change top-level permissions to `{}` (none) and grant necessary permissions in job-level, as needed, to remediate [excessive permissions](https://docs.zizmor.sh/audits/#excessive-permissions).
- Pin `govulncheck` install to commit hash.