### PR TITLE
fix: correct typo in nodeSelectorsOverlap method

### DIFF
--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -97,7 +97,7 @@ func (w *NodeReadinessRuleWebhook) validateTaintConflicts(ctx context.Context, r
 		if existingRule.Spec.Taint.Key == rule.Spec.Taint.Key &&
 			existingRule.Spec.Taint.Effect == rule.Spec.Taint.Effect {
 			// Check if node selectors overlap
-			if w.nodSelectorsOverlap(rule.Spec.NodeSelector, existingRule.Spec.NodeSelector) {
+			if w.nodeSelectorsOverlap(rule.Spec.NodeSelector, existingRule.Spec.NodeSelector) {
 				allErrs = append(allErrs, field.Invalid(
 					taintField,
 					rule.Spec.Taint.Key,
@@ -112,7 +112,7 @@ func (w *NodeReadinessRuleWebhook) validateTaintConflicts(ctx context.Context, r
 }
 
 // nodeSelectorsOverlap checks if two node selectors overlap.
-func (w *NodeReadinessRuleWebhook) nodSelectorsOverlap(selector1, selector2 metav1.LabelSelector) bool {
+func (w *NodeReadinessRuleWebhook) nodeSelectorsOverlap(selector1, selector2 metav1.LabelSelector) bool {
 	// Convert to selectors
 	sel1, err1 := metav1.LabelSelectorAsSelector(&selector1)
 	sel2, err2 := metav1.LabelSelectorAsSelector(&selector2)

--- a/internal/webhook/nodereadinessgaterule_webhook_test.go
+++ b/internal/webhook/nodereadinessgaterule_webhook_test.go
@@ -279,7 +279,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 
 	Context("Node Selector Overlap Detection", func() {
 		It("should detect overlapping nil selectors", func() {
-			overlaps := webhook.nodSelectorsOverlap(metav1.LabelSelector{}, metav1.LabelSelector{})
+			overlaps := webhook.nodeSelectorsOverlap(metav1.LabelSelector{}, metav1.LabelSelector{})
 			Expect(overlaps).To(BeTrue()) // Both nil = both match all nodes
 		})
 
@@ -290,10 +290,10 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 				},
 			}
 
-			overlaps := webhook.nodSelectorsOverlap(metav1.LabelSelector{}, selector)
+			overlaps := webhook.nodeSelectorsOverlap(metav1.LabelSelector{}, selector)
 			Expect(overlaps).To(BeFalse())
 
-			overlaps = webhook.nodSelectorsOverlap(selector, metav1.LabelSelector{})
+			overlaps = webhook.nodeSelectorsOverlap(selector, metav1.LabelSelector{})
 			Expect(overlaps).To(BeFalse())
 		})
 
@@ -310,7 +310,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 				},
 			}
 
-			overlaps := webhook.nodSelectorsOverlap(selector1, selector2)
+			overlaps := webhook.nodeSelectorsOverlap(selector1, selector2)
 			Expect(overlaps).To(BeTrue()) // Identical selectors overlap
 		})
 
@@ -327,7 +327,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 				},
 			}
 
-			overlaps := webhook.nodSelectorsOverlap(selector1, selector2)
+			overlaps := webhook.nodeSelectorsOverlap(selector1, selector2)
 			Expect(overlaps).To(BeFalse()) // Different selectors don't overlap (simple heuristic)
 		})
 	})


### PR DESCRIPTION
This PR fixes a small typo in the nodeSelectorsOverlap method and its usage in tests.

`nodSelectorsOverlap` --> `nodeSelectorsOverlap` 

/kind cleanup
