### PR TITLE
Remove stale failedNodes entries for deleted nodes

### DIFF
--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	readinessv1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
 )
 
 // nodeSelectorChanged checks if nodeSelector has changed.
@@ -115,6 +116,29 @@ func taintsEqual(a, b []corev1.Taint) bool {
 	}
 
 	return true
+}
+
+// filters nodeEvaluations and failedNodes to keep only existing nodes.
+func filterStatusForExistingNodes(
+	existingNodes map[string]bool,
+	nodeEvaluations []readinessv1alpha1.NodeEvaluation,
+	failedNodes []readinessv1alpha1.NodeFailure,
+) ([]readinessv1alpha1.NodeEvaluation, []readinessv1alpha1.NodeFailure) {
+	filteredEvaluations := make([]readinessv1alpha1.NodeEvaluation, 0, len(nodeEvaluations))
+	for _, evaluation := range nodeEvaluations {
+		if existingNodes[evaluation.NodeName] {
+			filteredEvaluations = append(filteredEvaluations, evaluation)
+		}
+	}
+
+	filteredFailedNodes := make([]readinessv1alpha1.NodeFailure, 0, len(failedNodes))
+	for _, failure := range failedNodes {
+		if existingNodes[failure.NodeName] {
+			filteredFailedNodes = append(filteredFailedNodes, failure)
+		}
+	}
+
+	return filteredEvaluations, filteredFailedNodes
 }
 
 // labelsEqual checks if two label maps are equal.

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	readinessv1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
 )
 
 //nolint:godot
@@ -105,7 +106,30 @@ func taintsEqual(a, b []corev1.Taint) bool {
 	return true
 }
 
-// labelsEqual checks if two label maps hold the same keys with the same values.
+// filters nodeEvaluations and failedNodes to keep only existing nodes.
+func filterStatusForExistingNodes(
+	existingNodes map[string]bool,
+	nodeEvaluations []readinessv1alpha1.NodeEvaluation,
+	failedNodes []readinessv1alpha1.NodeFailure,
+) ([]readinessv1alpha1.NodeEvaluation, []readinessv1alpha1.NodeFailure) {
+	filteredEvaluations := make([]readinessv1alpha1.NodeEvaluation, 0, len(nodeEvaluations))
+	for _, evaluation := range nodeEvaluations {
+		if existingNodes[evaluation.NodeName] {
+			filteredEvaluations = append(filteredEvaluations, evaluation)
+		}
+	}
+
+	filteredFailedNodes := make([]readinessv1alpha1.NodeFailure, 0, len(failedNodes))
+	for _, failure := range failedNodes {
+		if existingNodes[failure.NodeName] {
+			filteredFailedNodes = append(filteredFailedNodes, failure)
+		}
+	}
+
+	return filteredEvaluations, filteredFailedNodes
+}
+
+// labelsEqual checks if two label maps are equal.
 func labelsEqual(a, b map[string]string) bool {
 	return maps.Equal(a, b)
 }

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -215,19 +215,11 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 	}
 
 	// Filter out deleted nodes
-	var newNodeEvaluations []readinessv1alpha1.NodeEvaluation
-	for _, evaluation := range rule.Status.NodeEvaluations {
-		if existingNodes[evaluation.NodeName] {
-			newNodeEvaluations = append(newNodeEvaluations, evaluation)
-		}
-	}
-
-	var newFailedNodes []readinessv1alpha1.NodeFailure
-	for _, failure := range rule.Status.FailedNodes {
-		if existingNodes[failure.NodeName] {
-			newFailedNodes = append(newFailedNodes, failure)
-		}
-	}
+	newNodeEvaluations, newFailedNodes := filterStatusForExistingNodes(
+		existingNodes,
+		rule.Status.NodeEvaluations,
+		rule.Status.FailedNodes,
+	)
 
 	if len(newNodeEvaluations) == len(rule.Status.NodeEvaluations) &&
 		len(newFailedNodes) == len(rule.Status.FailedNodes) {
@@ -247,19 +239,11 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 			return err
 		}
 
-		var freshNodeEvaluations []readinessv1alpha1.NodeEvaluation
-		for _, evaluation := range fresh.Status.NodeEvaluations {
-			if existingNodes[evaluation.NodeName] {
-				freshNodeEvaluations = append(freshNodeEvaluations, evaluation)
-			}
-		}
-
-		var freshFailedNodes []readinessv1alpha1.NodeFailure
-		for _, failure := range fresh.Status.FailedNodes {
-			if existingNodes[failure.NodeName] {
-				freshFailedNodes = append(freshFailedNodes, failure)
-			}
-		}
+		freshNodeEvaluations, freshFailedNodes := filterStatusForExistingNodes(
+			existingNodes,
+			fresh.Status.NodeEvaluations,
+			fresh.Status.FailedNodes,
+		)
 
 		if len(freshNodeEvaluations) == len(fresh.Status.NodeEvaluations) &&
 			len(freshFailedNodes) == len(fresh.Status.FailedNodes) {

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -222,7 +222,15 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 		}
 	}
 
-	if len(newNodeEvaluations) == len(rule.Status.NodeEvaluations) {
+	var newFailedNodes []readinessv1alpha1.NodeFailure
+	for _, failure := range rule.Status.FailedNodes {
+		if existingNodes[failure.NodeName] {
+			newFailedNodes = append(newFailedNodes, failure)
+		}
+	}
+
+	if len(newNodeEvaluations) == len(rule.Status.NodeEvaluations) &&
+		len(newFailedNodes) == len(rule.Status.FailedNodes) {
 		log.V(4).Info("No deleted nodes to clean up", "rule", rule.Name)
 		return nil
 	}
@@ -246,12 +254,21 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 			}
 		}
 
-		if len(freshNodeEvaluations) == len(fresh.Status.NodeEvaluations) {
+		var freshFailedNodes []readinessv1alpha1.NodeFailure
+		for _, failure := range fresh.Status.FailedNodes {
+			if existingNodes[failure.NodeName] {
+				freshFailedNodes = append(freshFailedNodes, failure)
+			}
+		}
+
+		if len(freshNodeEvaluations) == len(fresh.Status.NodeEvaluations) &&
+			len(freshFailedNodes) == len(fresh.Status.FailedNodes) {
 			return nil
 		}
 
 		patch := client.MergeFrom(fresh.DeepCopy())
 		fresh.Status.NodeEvaluations = freshNodeEvaluations
+		fresh.Status.FailedNodes = freshFailedNodes
 		return r.Status().Patch(ctx, fresh, patch)
 	})
 }

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -234,14 +234,14 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 	}
 
 	// Filter out deleted nodes
-	var newNodeEvaluations []readinessv1alpha1.NodeEvaluation
-	for _, evaluation := range rule.Status.NodeEvaluations {
-		if existingNodes[evaluation.NodeName] {
-			newNodeEvaluations = append(newNodeEvaluations, evaluation)
-		}
-	}
+	newNodeEvaluations, newFailedNodes := filterStatusForExistingNodes(
+		existingNodes,
+		rule.Status.NodeEvaluations,
+		rule.Status.FailedNodes,
+	)
 
-	if len(newNodeEvaluations) == len(rule.Status.NodeEvaluations) {
+	if len(newNodeEvaluations) == len(rule.Status.NodeEvaluations) &&
+		len(newFailedNodes) == len(rule.Status.FailedNodes) {
 		log.V(4).Info("No deleted nodes to clean up", "rule", rule.Name)
 		return nil
 	}
@@ -258,19 +258,20 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 			return err
 		}
 
-		var freshNodeEvaluations []readinessv1alpha1.NodeEvaluation
-		for _, evaluation := range fresh.Status.NodeEvaluations {
-			if existingNodes[evaluation.NodeName] {
-				freshNodeEvaluations = append(freshNodeEvaluations, evaluation)
-			}
-		}
+		freshNodeEvaluations, freshFailedNodes := filterStatusForExistingNodes(
+			existingNodes,
+			fresh.Status.NodeEvaluations,
+			fresh.Status.FailedNodes,
+		)
 
-		if len(freshNodeEvaluations) == len(fresh.Status.NodeEvaluations) {
+		if len(freshNodeEvaluations) == len(fresh.Status.NodeEvaluations) &&
+			len(freshFailedNodes) == len(fresh.Status.FailedNodes) {
 			return nil
 		}
 
 		patch := client.MergeFrom(fresh.DeepCopy())
 		fresh.Status.NodeEvaluations = freshNodeEvaluations
+		fresh.Status.FailedNodes = freshFailedNodes
 		return r.Status().Patch(ctx, fresh, patch)
 	})
 }

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -908,7 +908,18 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 		})
 
 		AfterEach(func() {
-			Expect(k8sClient.Delete(ctx, rule)).To(Succeed())
+			updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, updatedRule); err == nil {
+				updatedRule.Finalizers = nil
+				_ = k8sClient.Update(ctx, updatedRule)
+				_ = k8sClient.Delete(ctx, updatedRule)
+			}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, &nodereadinessiov1alpha1.NodeReadinessRule{})
+				return apierrors.IsNotFound(err)
+			}, time.Second*10).Should(BeTrue())
+
 			// node1 is already deleted in the test
 			_ = k8sClient.Delete(ctx, node2)
 		})
@@ -954,6 +965,65 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				}
 				return false
 			}, time.Second*5).Should(BeTrue())
+		})
+
+		It("removes failedNodes entries for deleted nodes", func() {
+			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "delete-node-rule"}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() int {
+				updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, updatedRule)
+				return len(updatedRule.Status.NodeEvaluations)
+			}, time.Second*5).Should(Equal(2))
+
+			seededRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, seededRule)).To(Succeed())
+			statusPatch := client.MergeFrom(seededRule.DeepCopy())
+			seededRule.Status.FailedNodes = append(seededRule.Status.FailedNodes, nodereadinessiov1alpha1.NodeFailure{
+				NodeName:           "node1",
+				Reason:             "EvaluationError",
+				Message:            "test failure",
+				LastEvaluationTime: metav1.Now(),
+			})
+			Expect(k8sClient.Status().Patch(ctx, seededRule, statusPatch)).To(Succeed())
+
+			Eventually(func() bool {
+				updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, updatedRule)
+				for _, f := range updatedRule.Status.FailedNodes {
+					if f.NodeName == "node1" {
+						return true
+					}
+				}
+				return false
+			}, time.Second*5).Should(BeTrue())
+			verifyRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, verifyRule)).To(Succeed())
+			for _, f := range verifyRule.Status.FailedNodes {
+				Expect(f.NodeName).NotTo(Equal("node2"), "setup should not add a failure for node2")
+			}
+
+			Expect(k8sClient.Delete(ctx, node1)).To(Succeed())
+
+			_, err = ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "delete-node-rule"}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, updatedRule)
+				for _, f := range updatedRule.Status.FailedNodes {
+					if f.NodeName == "node1" {
+						return false
+					}
+				}
+				return true
+			}, time.Second*5).Should(BeTrue())
+			patchedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, patchedRule)).To(Succeed())
+			for _, f := range patchedRule.Status.FailedNodes {
+				Expect(f.NodeName).NotTo(Equal("node2"), "cleanup should not introduce a failure for node2")
+			}
 		})
 	})
 

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -1652,7 +1652,18 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 		})
 
 		AfterEach(func() {
-			Expect(k8sClient.Delete(ctx, rule)).To(Succeed())
+			updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, updatedRule); err == nil {
+				updatedRule.Finalizers = nil
+				_ = k8sClient.Update(ctx, updatedRule)
+				_ = k8sClient.Delete(ctx, updatedRule)
+			}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, &nodereadinessiov1alpha1.NodeReadinessRule{})
+				return apierrors.IsNotFound(err)
+			}, time.Second*10).Should(BeTrue())
+
 			// node1 is already deleted in the test
 			_ = k8sClient.Delete(ctx, node2)
 		})
@@ -1698,6 +1709,65 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				}
 				return false
 			}, time.Second*5).Should(BeTrue())
+		})
+
+		It("removes failedNodes entries for deleted nodes", func() {
+			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "delete-node-rule"}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() int {
+				updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, updatedRule)
+				return len(updatedRule.Status.NodeEvaluations)
+			}, time.Second*5).Should(Equal(2))
+
+			seededRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, seededRule)).To(Succeed())
+			statusPatch := client.MergeFrom(seededRule.DeepCopy())
+			seededRule.Status.FailedNodes = append(seededRule.Status.FailedNodes, nodereadinessiov1alpha1.NodeFailure{
+				NodeName:           "node1",
+				Reason:             "EvaluationError",
+				Message:            "test failure",
+				LastEvaluationTime: metav1.Now(),
+			})
+			Expect(k8sClient.Status().Patch(ctx, seededRule, statusPatch)).To(Succeed())
+
+			Eventually(func() bool {
+				updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, updatedRule)
+				for _, f := range updatedRule.Status.FailedNodes {
+					if f.NodeName == "node1" {
+						return true
+					}
+				}
+				return false
+			}, time.Second*5).Should(BeTrue())
+			verifyRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, verifyRule)).To(Succeed())
+			for _, f := range verifyRule.Status.FailedNodes {
+				Expect(f.NodeName).NotTo(Equal("node2"), "setup should not add a failure for node2")
+			}
+
+			Expect(k8sClient.Delete(ctx, node1)).To(Succeed())
+
+			_, err = ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "delete-node-rule"}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, updatedRule)
+				for _, f := range updatedRule.Status.FailedNodes {
+					if f.NodeName == "node1" {
+						return false
+					}
+				}
+				return true
+			}, time.Second*5).Should(BeTrue())
+			patchedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "delete-node-rule"}, patchedRule)).To(Succeed())
+			for _, f := range patchedRule.Status.FailedNodes {
+				Expect(f.NodeName).NotTo(Equal("node2"), "cleanup should not introduce a failure for node2")
+			}
 		})
 	})
 


### PR DESCRIPTION
## Description
Prunes stale entries from `status.failedNodes` when nodes are deleted.

Currently, `cleanupDeletedNodes` only filters `nodeEvaluations`, so `failedNodes` can retain entries for nodes that no longer exist. This can cause the rule status to report failures for deleted nodes.

This ensures both `nodeEvaluations` and `failedNodes` stay in sync with the current cluster state.

## Related Issue
### **Fixes #203**

## Type of Change
/kind bug
/kind cleanup

## Testing
- Added a test to verify `failedNodes` entries are removed after a node is deleted
- Ensured no unintended entries are introduced during cleanup
- Ran:
    - `make test`
    - `make lint`

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?
Fixes an issue where `status.failedNodes` could include nodes that were already deleted.