### PR TITLE
fix: avoid double-counting bootstrap completion metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/prometheus/client_golang v1.22.0
+	github.com/prometheus/client_model v0.6.1
 	go.uber.org/zap v1.27.0
 	k8s.io/api v0.34.0
 	k8s.io/apimachinery v0.34.0
@@ -52,7 +53,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -333,6 +333,7 @@ func (r *RuleReadinessController) markBootstrapCompleted(ctx context.Context, no
 	log := ctrl.LoggerFrom(ctx)
 
 	annotationKey := fmt.Sprintf("readiness.k8s.io/bootstrap-completed-%s", ruleName)
+	marked := false
 
 	// retry to handle conflict with concurrent node updates
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -356,14 +357,22 @@ func (r *RuleReadinessController) markBootstrapCompleted(ctx context.Context, no
 		}
 
 		node.Annotations[annotationKey] = "true"
-		return r.Patch(ctx, node, patch)
+		if err := r.Patch(ctx, node, patch); err != nil {
+			return err
+		}
+
+		marked = true
+		return nil
 	})
 
-	if err != nil {
+	switch {
+	case err != nil:
 		log.Error(err, "Failed to mark bootstrap completed", "node", nodeName, "rule", ruleName)
-	} else {
+	case marked:
 		log.Info("Marked bootstrap completed", "node", nodeName, "rule", ruleName)
 		metrics.BootstrapCompleted.WithLabelValues(ruleName).Inc()
+	default:
+		log.V(4).Info("Bootstrap already completed", "node", nodeName, "rule", ruleName)
 	}
 }
 

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,11 +34,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nodereadinessiov1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
+	"sigs.k8s.io/node-readiness-controller/internal/metrics"
 )
 
 const (
 	selectorChangeTaintKey = "readiness.k8s.io/selector-change-taint"
 )
+
+func counterValue(counter interface{ Write(*dto.Metric) error }) float64 {
+	metric := &dto.Metric{}
+	Expect(counter.Write(metric)).To(Succeed())
+	return metric.GetCounter().GetValue()
+}
 
 var _ = Describe("NodeReadinessRule Controller", func() {
 	var (
@@ -572,6 +580,27 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				g.Expect(updatedNode.Annotations).To(HaveKeyWithValue(
 					"existing-annotation", "should-be-preserved"))
 			}).Should(Succeed())
+		})
+
+		It("should increment bootstrap completed metric only when newly marked", func() {
+			nodeName := "bootstrap-metric-test-node"
+			ruleName := "bootstrap-metric-test-rule"
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, node) }()
+
+			counter := metrics.BootstrapCompleted.WithLabelValues(ruleName)
+			before := counterValue(counter)
+
+			readinessController.markBootstrapCompleted(ctx, nodeName, ruleName)
+			readinessController.markBootstrapCompleted(ctx, nodeName, ruleName)
+
+			Expect(counterValue(counter)).To(Equal(before + 1))
 		})
 	})
 


### PR DESCRIPTION
## Description

Fixes overcounting of `node_readiness_bootstrap_completed_total`.

`markBootstrapCompleted()` already skips patching a node when the bootstrap-completed annotation exists, but the metric was still incremented after that no-op path. This change tracks whether the annotation was newly written and increments `metrics.BootstrapCompleted` only after a successful new mark.

Adds a regression test that calls `markBootstrapCompleted()` twice for the same node/rule and verifies the metric increases only once.

## Related Issue

Fixes #205

## Type of Change

/kind bug

## Testing

```bash
make test
make lint
```

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```
