### PR TITLE
fix: data race in rule cache and stale failedNodes on recovery

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -148,6 +148,8 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 				"node", node.Name, "rule", rule.Name)
 			// Continue with other rules even if one fails
 			r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
+		} else {
+			r.clearNodeFailure(rule, node.Name)
 		}
 
 		// Persist the rule status

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -277,6 +277,8 @@ func (r *RuleReadinessController) processAllNodesForRule(ctx context.Context, ru
 				log.Error(err, "Failed to evaluate node for rule", "rule", rule.Name, "node", node.Name)
 				r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
 				metrics.Failures.WithLabelValues(rule.Name, "EvaluationError").Inc()
+			} else {
+				r.clearNodeFailure(rule, node.Name)
 			}
 		}
 	}
@@ -422,7 +424,7 @@ func (r *RuleReadinessController) getApplicableRulesForNode(ctx context.Context,
 
 	for _, rule := range r.ruleCache {
 		if r.ruleAppliesTo(ctx, rule, node) {
-			applicableRules = append(applicableRules, rule)
+			applicableRules = append(applicableRules, rule.DeepCopy())
 		}
 	}
 
@@ -705,4 +707,15 @@ func (r *RuleReadinessController) getPreviousNodeEvaluation(rule *readinessv1alp
 		}
 	}
 	return nil
+}
+
+// clearNodeFailure removes any failure record for a specific node from the rule status.
+func (r *RuleReadinessController) clearNodeFailure(rule *readinessv1alpha1.NodeReadinessRule, nodeName string) {
+	var failedNodes []readinessv1alpha1.NodeFailure
+	for _, failure := range rule.Status.FailedNodes {
+		if failure.NodeName != nodeName {
+			failedNodes = append(failedNodes, failure)
+		}
+	}
+	rule.Status.FailedNodes = failedNodes
 }


### PR DESCRIPTION
## Description

Fix two bugs in the controller's rule processing path:

**1. Data race in `getApplicableRulesForNode`**

`getApplicableRulesForNode` returned direct pointers into `ruleCache` while only holding the read lock during iteration. These pointers were then mutated by `evaluateRuleForNode` (via `updateNodeEvaluationStatus` and `recordNodeFailure`) outside of `ruleCacheMutex`. Since `RuleReconciler` and `NodeReconciler` run in separate goroutines, a concurrent `updateRuleCache` call can race with ongoing status writes to the same cached object, causing a concurrent slice-append panic or silent status corruption.

Fixed by returning `rule.DeepCopy()` for each matched rule so callers work on an isolated copy.

**2. Stale `FailedNodes` not cleared on successful evaluation**

When `evaluateRuleForNode` errored, `recordNodeFailure` added a `NodeFailure` entry to `rule.Status.FailedNodes`. However if the node later recovered, the failure was never removed, the node would be permanently stuck in `FailedNodes` even after successful evaluations.

Added `clearNodeFailure` and call it whenever `evaluateRuleForNode` succeeds, in both `processAllNodesForRule` and `processNodeAgainstAllRules`.

> **Note:** PR #204 removes stale `failedNodes` entries for *deleted* nodes. This PR handles the complementary case, still-living nodes that recover from a transient evaluation error.

## Related Issue

None

## Type of Change

Bug

## Testing

- `go build ./...` passes
- `go vet ./...` passes
- Webhook unit tests (`internal/webhook`) pass

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Fix data race in getApplicableRulesForNode where direct cache pointers were
mutated concurrently without holding the cache mutex. Fix stale FailedNodes
entries that were never cleared when a node recovered from an evaluation error.
