### PR TITLE
ci: add zizmor for linting gha workflows

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,26 @@
+name: Lint GitHub Actions Workflows
+on:
+  pull_request:
+    paths: 
+    - '.github/workflows/*.yml'
+    - '.github/workflows/*.yaml'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          min-confidence: medium
+          


### PR DESCRIPTION
This PR adds [Zizmor](https://github.com/zizmorcore/zizmor) to CI.

In short, Zizmor is a Static Analysis Tool that scans GitHub Actions workflows to detect security issues like unpinned version usage, excessive permissions and [many other issues](https://docs.zizmor.sh/audits/).

It will help us ensure existent and added workflows adhere to security best practices, including Kubernetes new GitHub Actions Security Policy.

About the chosen config:

- We set `advanced-security: false` to disable uploading results to GitHub's Advanced Security tab but instead print to the console and fail the run on CI if issues are found. See: https://github.com/zizmorcore/zizmor-action#advanced-security
- We set `min-confidence: medium` to ignore findings that are merely informational due to low confidence of the audit, just so they don't fail the run. See: https://github.com/zizmorcore/zizmor-action#min-confidence

Blocked by #200 