### PR TITLE
webhook: improve nodeSelectorsOverlap to detect subset overlaps

### DIFF
--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -122,9 +123,12 @@ func (w *NodeReadinessRuleWebhook) nodeSelectorsOverlap(selector1, selector2 met
 		return true
 	}
 
-	// Simple heuristic: if selectors are identical, they definitely overlap
-	// For more complex overlap detection, we'd need to analyze the label requirements
-	return sel1.String() == sel2.String()
+	// Check overlap: if one selector's matchLabels is a subset of the other,
+	// a node could match both selectors, causing a conflict.
+	if sel1.Matches(labels.Set(selector2.MatchLabels)) {
+		return true
+	}
+	return sel2.Matches(labels.Set(selector1.MatchLabels))
 }
 
 // generateNoExecuteWarnings generates admission warnings for NoExecute taint usage.

--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -125,6 +125,8 @@ func (w *NodeReadinessRuleWebhook) nodeSelectorsOverlap(selector1, selector2 met
 
 	// Check overlap: if one selector's matchLabels is a subset of the other,
 	// a node could match both selectors, causing a conflict.
+	// Note: this only covers matchLabels-based overlap; selectors using
+	// matchExpressions may still overlap without being detected here.
 	if sel1.Matches(labels.Set(selector2.MatchLabels)) {
 		return true
 	}

--- a/internal/webhook/nodereadinessgaterule_webhook_test.go
+++ b/internal/webhook/nodereadinessgaterule_webhook_test.go
@@ -283,7 +283,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 			Expect(overlaps).To(BeTrue()) // Both nil = both match all nodes
 		})
 
-		It("should not overlap when one selector is nil", func() {
+		It("should overlap when one selector is empty (matches all nodes)", func() {
 			selector := metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"node-role.kubernetes.io/worker": "",
@@ -291,10 +291,10 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 			}
 
 			overlaps := webhook.nodeSelectorsOverlap(metav1.LabelSelector{}, selector)
-			Expect(overlaps).To(BeFalse())
+			Expect(overlaps).To(BeTrue())
 
 			overlaps = webhook.nodeSelectorsOverlap(selector, metav1.LabelSelector{})
-			Expect(overlaps).To(BeFalse())
+			Expect(overlaps).To(BeTrue())
 		})
 
 		It("should detect identical selectors as overlapping", func() {

--- a/internal/webhook/nodereadinessgaterule_webhook_test.go
+++ b/internal/webhook/nodereadinessgaterule_webhook_test.go
@@ -330,6 +330,18 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 			overlaps := webhook.nodeSelectorsOverlap(selector1, selector2)
 			Expect(overlaps).To(BeFalse()) // Different selectors don't overlap (simple heuristic)
 		})
+		It("should detect subset selectors as overlapping", func() {
+			// selector1 (env=prod) is subset of selector2 (env=prod,region=us)
+			// Both match nodes labeled env=prod,region=us => they overlap
+			selector1 := metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			}
+			selector2 := metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod", "region": "us"},
+			}
+			overlaps := webhook.nodeSelectorsOverlap(selector1, selector2)
+			Expect(overlaps).To(BeTrue()) // subset selectors overlap
+		})
 	})
 
 	Context("CustomValidator Interface", func() {


### PR DESCRIPTION
## Description
Improves the nodeSelectorsOverlap function in the validation webhook to detect partial/subset selector overlaps using sel.Matches() instead of string equality comparison.

## Related Issue
Fixes #211

## Type of Change
/kind bug

## Testing
- All webhook tests pass: go test ./internal/webhook/...
- Verified build compiles cleanly: go build ./...

## Checklist
- [x] `make test` passes (webhook tests)
- [x] `make lint` passes

## Does this PR introduce a user-facing change?
```release-note
Fixed webhook validation to correctly detect overlapping node selectors when one selector is a subset of another, preventing conflicting NodeReadinessRules from being created.
```