### PR TITLE
fix: trigger reconcile on rule deletion-timestamp updates

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	readinessv1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
@@ -78,12 +79,27 @@ func NewRuleReadinessController(mgr ctrl.Manager, clientset kubernetes.Interface
 	}
 }
 
+// Like GenerationChangedPredicate, but also fires when DeletionTimestamp is
+// set so finalizer deletion events aren't dropped.
+var rulePredicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if e.ObjectOld == nil || e.ObjectNew == nil {
+			return false
+		}
+		if e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration() {
+			return true
+		}
+		return e.ObjectOld.GetDeletionTimestamp().IsZero() &&
+			!e.ObjectNew.GetDeletionTimestamp().IsZero()
+	},
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *RuleReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("nodereadiness-controller").
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
-		For(&readinessv1alpha1.NodeReadinessRule{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&readinessv1alpha1.NodeReadinessRule{}, builder.WithPredicates(rulePredicate)).
 		Complete(r)
 }
 

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -79,8 +79,8 @@ func NewRuleReadinessController(mgr ctrl.Manager, clientset kubernetes.Interface
 	}
 }
 
-// Like GenerationChangedPredicate, but also fires when DeletionTimestamp is
-// set so finalizer deletion events aren't dropped.
+// rulePredicate behaves like GenerationChangedPredicate, but also allows the
+// update that first sets DeletionTimestamp so finalizer cleanup is reconciled.
 var rulePredicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		if e.ObjectOld == nil || e.ObjectNew == nil {

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nodereadinessiov1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
@@ -1378,6 +1379,48 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				}
 				return len(updatedRule.Status.AppliedNodes) > 0
 			}, time.Second*5).Should(BeTrue(), "All AppliedNodes should have corresponding NodeEvaluations")
+		})
+	})
+
+	Context("rulePredicate", func() {
+		newRule := func(generation int64, deletionTimestamp *metav1.Time) *nodereadinessiov1alpha1.NodeReadinessRule {
+			return &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "predicate-rule",
+					Generation:        generation,
+					DeletionTimestamp: deletionTimestamp,
+				},
+			}
+		}
+
+		It("passes updates that bump generation", func() {
+			Expect(rulePredicate.Update(event.UpdateEvent{
+				ObjectOld: newRule(1, nil),
+				ObjectNew: newRule(2, nil),
+			})).To(BeTrue())
+		})
+
+		It("passes updates that set the deletion timestamp without bumping generation", func() {
+			now := metav1.Now()
+			Expect(rulePredicate.Update(event.UpdateEvent{
+				ObjectOld: newRule(1, nil),
+				ObjectNew: newRule(1, &now),
+			})).To(BeTrue(), "deletion-marker updates must trigger reconcile so the finalizer can be removed")
+		})
+
+		It("ignores status-only updates", func() {
+			Expect(rulePredicate.Update(event.UpdateEvent{
+				ObjectOld: newRule(1, nil),
+				ObjectNew: newRule(1, nil),
+			})).To(BeFalse())
+		})
+
+		It("ignores updates while the rule is already terminating", func() {
+			now := metav1.Now()
+			Expect(rulePredicate.Update(event.UpdateEvent{
+				ObjectOld: newRule(1, &now),
+				ObjectNew: newRule(1, &now),
+			})).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
## Description

`RuleReconciler` was set up with a bare `predicate.GenerationChangedPredicate{}`. When a `NodeReadinessRule` with the cleanup-taints finalizer is deleted, the API server only sets `metadata.deletionTimestamp` - it does not bump `metadata.generation`. The predicate filtered out that Update event, so `Reconcile` was never enqueued, `reconcileDelete` never ran, the finalizer was never removed, and the managed taints were left orphaned on nodes

Replace the predicate with one that also passes Update events where `DeletionTimestamp` transitions from unset to set, while keeping the Generation-based filtering for normal updates so status writes still don't trigger reconciles

The existing deletion test calls `Reconcile` directly and bypasses the predicate, so it didn't catch this. Added unit coverage that exercises the predicate so a regression to a bare `GenerationChangedPredicate` fails the build

## Related Issue

Fixes #213

## Type of Change

/kind bug

## Testing

- `make test` passes locally (envtest, Kubernetes 1.34)
- `make lint` passes locally
- New `rulePredicate` unit tests cover: generation bump, deletion-timestamp transition, status-only update (filtered), update while already terminating (filtered)

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Fix a bug where deleting a NodeReadinessRule with the cleanup-taints finalizer left the rule stuck in Terminating and the managed taint orphaned on nodes, because the controller's watch predicate filtered out deletion-timestamp updates
```