### PR TITLE
fix: only append to appliedNodes after successful node evaluation

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -270,13 +270,20 @@ func (r *RuleReadinessController) processAllNodesForRule(ctx context.Context, ru
 	var appliedNodes []string
 	for _, node := range nodeList.Items {
 		if r.ruleAppliesTo(ctx, rule, &node) {
-			appliedNodes = append(appliedNodes, node.Name)
 			log.Info("Processing node for rule", "rule", rule.Name, "node", node.Name)
 			if err := r.evaluateRuleForNode(ctx, rule, &node); err != nil {
-				// Log error but continue with other nodes
 				log.Error(err, "Failed to evaluate node for rule", "rule", rule.Name, "node", node.Name)
 				r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
 				metrics.Failures.WithLabelValues(rule.Name, "EvaluationError").Inc()
+			} else {
+				appliedNodes = append(appliedNodes, node.Name)
+				var updatedFailedNodes []readinessv1alpha1.NodeFailure
+				for _, f := range rule.Status.FailedNodes {
+					if f.NodeName != node.Name {
+						updatedFailedNodes = append(updatedFailedNodes, f)
+					}
+				}
+				rule.Status.FailedNodes = updatedFailedNodes
 			}
 		}
 	}

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -45,6 +46,19 @@ func counterValue(counter interface{ Write(*dto.Metric) error }) float64 {
 	metric := &dto.Metric{}
 	Expect(counter.Write(metric)).To(Succeed())
 	return metric.GetCounter().GetValue()
+}
+
+// errorInjectingClient forces Patch to fail for selected nodes.
+type errorInjectingClient struct {
+	client.Client
+	failNodeNames map[string]bool
+}
+
+func (c *errorInjectingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if node, ok := obj.(*corev1.Node); ok && c.failNodeNames[node.Name] {
+		return fmt.Errorf("patch failed for node %s", node.Name)
+	}
+	return c.Client.Patch(ctx, obj, patch, opts...)
 }
 
 var _ = Describe("NodeReadinessRule Controller", func() {
@@ -1407,6 +1421,114 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				}
 				return len(updatedRule.Status.AppliedNodes) > 0
 			}, time.Second*5).Should(BeTrue(), "All AppliedNodes should have corresponding NodeEvaluations")
+		})
+	})
+
+	Context("when evaluation fails for a node", func() {
+		It("should not include the failed node in appliedNodes and include in failedNodes", func() {
+			failNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "fail-path-node",
+					Labels: map[string]string{"fail-path": "true"},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: "Ready", Status: corev1.ConditionFalse},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, failNode)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, failNode) }()
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "fail-path-rule"},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+					},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/fail-path-taint", Effect: corev1.TaintEffectNoSchedule},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"fail-path": "true"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+
+			errClient := &errorInjectingClient{
+				Client:        k8sClient,
+				failNodeNames: map[string]bool{"fail-path-node": true},
+			}
+			failController := &RuleReadinessController{
+				Client:        errClient,
+				Scheme:        scheme,
+				clientset:     fakeClientset,
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+
+			Expect(failController.processAllNodesForRule(ctx, rule)).To(Succeed())
+
+			Expect(rule.Status.AppliedNodes).NotTo(ContainElement("fail-path-node"))
+
+			failedNames := make([]string, 0, len(rule.Status.FailedNodes))
+			for _, f := range rule.Status.FailedNodes {
+				failedNames = append(failedNames, f.NodeName)
+			}
+			Expect(failedNames).To(ContainElement("fail-path-node"))
+		})
+
+		It("should remove stale failedNodes entry when evaluation succeeds and include the node in appliedNodes", func() {
+			successNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "stale-recovery-node",
+					Labels: map[string]string{"stale-recovery": "true"},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: "Ready", Status: corev1.ConditionTrue},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, successNode)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, successNode) }()
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "stale-recovery-rule"},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+					},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/stale-recovery-taint", Effect: corev1.TaintEffectNoSchedule},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"stale-recovery": "true"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+				Status: nodereadinessiov1alpha1.NodeReadinessRuleStatus{
+					FailedNodes: []nodereadinessiov1alpha1.NodeFailure{
+						{
+							NodeName:           "stale-recovery-node",
+							Reason:             "EvaluationError",
+							Message:            "stale from previous reconcile",
+							LastEvaluationTime: metav1.Now(),
+						},
+					},
+				},
+			}
+
+			successController := &RuleReadinessController{
+				Client:        k8sClient,
+				Scheme:        scheme,
+				clientset:     fakeClientset,
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+
+			Expect(successController.processAllNodesForRule(ctx, rule)).To(Succeed())
+
+			Expect(rule.Status.AppliedNodes).To(ContainElement("stale-recovery-node"))
+
+			failedNames := make([]string, 0, len(rule.Status.FailedNodes))
+			for _, f := range rule.Status.FailedNodes {
+				failedNames = append(failedNames, f.NodeName)
+			}
+			Expect(failedNames).NotTo(ContainElement("stale-recovery-node"))
 		})
 	})
 })


### PR DESCRIPTION
## Description
This change prevents nodes from appearing in both `status.appliedNodes` and `status.failedNodes` during rule reconciliation.

Previously, nodes were added to `appliedNodes` before `evaluateRuleForNode` ran. If evaluation fails, the same node ends up in `failedNodes` as well. so it shows up in both lists in a single reconcile.

There’s also a related case where a node that previously failed but later succeeds can still have a stale entry in `failedNodes`, so it continues to appear in both lists even after recovery.

To fix this:
- only add nodes to `appliedNodes` when `evaluateRuleForNode` succeeds
- remove any existing `failedNodes` entry for a node when it evaluates successfully
- add tests covering both failure and recovery scenarios

This keeps `appliedNodes` aligned with its intended meaning (nodes where the taint was successfully managed) and avoids overlap with `failedNodes`.

## Related Issue
### **Fixes #215**

## Type of Change
/kind bug

## Testing
- Added tests to cover:
  - evaluation failure: node is not added to `appliedNodes` and appears in `failedNodes`
  - recovery case: stale `failedNodes` entry is removed and node is added to `appliedNodes`
- Ran:
  - `make test`
  - `make lint`

## Checklist
- [x] `make test` passes
- [x] `make lint` passes