### PR TITLE
fix: reconcile retry on rule processing errors

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -97,17 +98,20 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// Process node against all applicable rules
-	r.Controller.processNodeAgainstAllRules(ctx, node)
+	if err := r.Controller.processNodeAgainstAllRules(ctx, node); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	return ctrl.Result{}, nil
 }
 
 // processNodeAgainstAllRules processes a single node against all applicable rules.
-func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context, node *corev1.Node) {
+func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context, node *corev1.Node) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Get all known (cached) applicable rules for this node
 	applicableRules := r.getApplicableRulesForNode(ctx, node)
+	var errs []error
 	log.Info("Processing node against rules", "node", node.Name, "ruleCount", len(applicableRules))
 
 	for _, rule := range applicableRules {
@@ -148,6 +152,7 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 				"node", node.Name, "rule", rule.Name)
 			// Continue with other rules even if one fails
 			r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
+			errs = append(errs, err)
 		}
 
 		// Persist the rule status
@@ -211,6 +216,7 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 				"rule", rule.Name,
 				"resourceVersion", rule.ResourceVersion)
 			// continue with other rules
+			errs = append(errs, err)
 		} else {
 			log.V(4).Info("Successfully persisted rule status from node reconciler",
 				"node", node.Name,
@@ -218,6 +224,8 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 				"newResourceVersion", rule.ResourceVersion)
 		}
 	}
+
+	return errors.Join(errs...)
 }
 
 // getConditionStatus gets the status of a condition on a node.

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -940,7 +940,7 @@ var _ = Describe("Node Controller", func() {
 	})
 
 	Context("when rule status patch fails during node reconciliation", func() {
-		It("should return an error so the workqueue requeues", func() {
+		It("should return an error when rule status patch fails", func() {
 			ctx := context.Background()
 
 			testScheme := runtime.NewScheme()

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -935,6 +936,75 @@ var _ = Describe("Node Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(patchCalled.Load()).To(BeFalse(),
 				"Patch should not be called when taint removal is a no-op")
+		})
+	})
+
+	Context("when rule status patch fails during node reconciliation", func() {
+		It("should return an error so the workqueue requeues", func() {
+			ctx := context.Background()
+
+			testScheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(testScheme)).To(Succeed())
+			Expect(nodereadinessiov1alpha1.AddToScheme(testScheme)).To(Succeed())
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "requeue-test-node",
+					Labels: map[string]string{"env": "requeue-test"},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: "Ready", Status: corev1.ConditionFalse},
+					},
+				},
+			}
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "requeue-test-rule"},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+					},
+					Taint: corev1.Taint{
+						Key:    "readiness.k8s.io/requeue-test",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"env": "requeue-test"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node, rule).
+				WithStatusSubresource(rule).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						return fmt.Errorf("status patch failed")
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+			controller.updateRuleCache(ctx, rule)
+
+			nodeReconciler := &NodeReconciler{
+				Client:     fc,
+				Scheme:     testScheme,
+				Controller: controller,
+			}
+
+			_, err := nodeReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "requeue-test-node"},
+			})
+			Expect(err).To(HaveOccurred(), "Reconcile should return an error when status patch fails")
+			Expect(err.Error()).To(ContainSubstring("status patch failed"))
 		})
 	})
 })


### PR DESCRIPTION
## Description

`processNodeAgainstAllRules` had no return value, so `Reconcile` always returned `ctrl.Result{}, nil` even when rule evaluation or status patch calls failed. This caused the workqueue to treat every reconciliation as successful, skipping backoff and requeue on transient errors. Node taint state could drift silently until an unrelated event triggered a new reconcile.

This change makes `processNodeAgainstAllRules` return an aggregated error via `errors.Join` and propagates it through `Reconcile`, consistent with how `RuleReconciler.processAllNodesForRule` already handles errors.

Adds a regression test that simulates a status patch failure using the interceptor pattern and verifies `Reconcile` returns a non-nil error.

## Related Issue

Fixes #220 

## Type of Change

/kind bug

## Testing

make test
make lint

## Checklist

- [x] make test passes
- [x] make lint passes

## Does this PR introduce a user-facing change?

NONE
