### PR TITLE
fix: return node evaluation errors to trigger reconcile retries

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -97,18 +98,22 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// Process node against all applicable rules
-	r.Controller.processNodeAgainstAllRules(ctx, node)
+	if err := r.Controller.processNodeAgainstAllRules(ctx, node); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	return ctrl.Result{}, nil
 }
 
 // processNodeAgainstAllRules processes a single node against all applicable rules.
-func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context, node *corev1.Node) {
+func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context, node *corev1.Node) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Get all known (cached) applicable rules for this node
 	applicableRules := r.getApplicableRulesForNode(ctx, node)
 	log.Info("Processing node against rules", "node", node.Name, "ruleCount", len(applicableRules))
+
+	var errs []error
 
 	for _, rule := range applicableRules {
 		log.V(4).Info("Processing rule from cache",
@@ -148,6 +153,7 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 				"node", node.Name, "rule", rule.Name)
 			// Continue with other rules even if one fails
 			r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
+			errs = append(errs, fmt.Errorf("rule %s: %w", rule.Name, err))
 		}
 
 		// Persist the rule status
@@ -211,6 +217,7 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 				"rule", rule.Name,
 				"resourceVersion", rule.ResourceVersion)
 			// continue with other rules
+			errs = append(errs, fmt.Errorf("rule %s status update: %w", rule.Name, err))
 		} else {
 			log.V(4).Info("Successfully persisted rule status from node reconciler",
 				"node", node.Name,
@@ -218,6 +225,8 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 				"newResourceVersion", rule.ResourceVersion)
 		}
 	}
+
+	return errors.Join(errs...)
 }
 
 // getConditionStatus gets the status of a condition on a node.

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -217,7 +217,9 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 				"rule", rule.Name,
 				"resourceVersion", rule.ResourceVersion)
 			// continue with other rules
-			errs = append(errs, fmt.Errorf("rule %s status update: %w", rule.Name, err))
+if isRetryable(err) {
+        retryableErrs = append(retryableErrs, err)
+    }
 		} else {
 			log.V(4).Info("Successfully persisted rule status from node reconciler",
 				"node", node.Name,

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -113,7 +113,7 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 	applicableRules := r.getApplicableRulesForNode(ctx, node)
 	log.Info("Processing node against rules", "node", node.Name, "ruleCount", len(applicableRules))
 
-	var errs []error
+	var retryableErrs []error
 
 	for _, rule := range applicableRules {
 		log.V(4).Info("Processing rule from cache",

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -692,6 +693,102 @@ var _ = Describe("Node Controller", func() {
 				return nodeEval.ConditionResults[0].CurrentStatus == corev1.ConditionTrue &&
 					nodeEval.TaintStatus == nodereadinessiov1alpha1.TaintStatusAbsent
 			}, time.Second*5).Should(BeTrue(), "NodeEvaluation should be updated with new condition and taint status")
+		})
+	})
+
+	Context("when rule evaluation fails", func() {
+		var (
+			ctx        context.Context
+			testScheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			testScheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(testScheme)).To(Succeed())
+			Expect(nodereadinessiov1alpha1.AddToScheme(testScheme)).To(Succeed())
+		})
+
+		It("should return an aggregated error from Reconcile to trigger requeue", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "error-node",
+					Labels: map[string]string{"env": "test"},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: "ErrorTestCondition", Status: corev1.ConditionFalse}, // Triggers addTaint
+					},
+				},
+			}
+
+			rule1 := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "error-rule-1"},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{Type: "ErrorTestCondition", RequiredStatus: corev1.ConditionTrue},
+					},
+					Taint: corev1.Taint{
+						Key:    "readiness.k8s.io/error-taint-1",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "test"},
+					},
+				},
+			}
+
+			rule2 := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "error-rule-2"},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{Type: "ErrorTestCondition", RequiredStatus: corev1.ConditionTrue},
+					},
+					Taint: corev1.Taint{
+						Key:    "readiness.k8s.io/error-taint-2",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "test"},
+					},
+				},
+			}
+
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node, rule1, rule2).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						// Always return an error on Patch to simulate failure during addTaint
+						return fmt.Errorf("simulated patch error for %s", obj.GetName())
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+			controller.updateRuleCache(ctx, rule1)
+			controller.updateRuleCache(ctx, rule2)
+
+			nodeReconciler := &NodeReconciler{
+				Client:     fc,
+				Scheme:     testScheme,
+				Controller: controller,
+			}
+
+			_, err := nodeReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "error-node"}})
+
+			Expect(err).To(HaveOccurred(), "Reconcile should return an error when evaluations fail")
+			Expect(err.Error()).To(ContainSubstring("rule error-rule-1: failed to add taint: simulated patch error for error-node"))
+			Expect(err.Error()).To(ContainSubstring("rule error-rule-2: failed to add taint: simulated patch error for error-node"))
 		})
 	})
 


### PR DESCRIPTION
This change ensures that node evaluation failures are propagated back to the reconcile loop instead of being silently ignored.

Previously, transient failures during rule evaluation or taint patching were only logged internally, preventing controller-runtime from requeueing the reconcile request.

This PR:

* aggregates evaluation/status update errors
* returns reconcile errors properly for retry/backoff handling
* preserves existing behavior by continuing evaluation across rules
* adds test coverage for aggregated reconcile failures

Related Issue

Fixes #220

Type of Change

/kind bug