### PR TITLE
Fix: remove dead nil selector check

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -645,13 +645,7 @@ func (r *RuleReadinessController) cleanupNodesAfterSelectorChange(ctx context.Co
 	var errors []string
 	for _, node := range nodeList.Items {
 		// Check if node matched old selector
-		matchedOld := false
-		if oldSelector == nil {
-			// nil selector matches all nodes
-			matchedOld = true
-		} else {
-			matchedOld = oldSelector.Matches(labels.Set(node.Labels))
-		}
+		matchedOld := oldSelector.Matches(labels.Set(node.Labels))
 
 		// Check if node matches new selector (use newRule for current evaluation)
 		matchesNew := r.ruleAppliesTo(ctx, newRule, &node)


### PR DESCRIPTION
## Description

`metav1.LabelSelectorAsSelector` is called with `&oldRule.Spec.NodeSelector`, where `NodeSelector` is a struct value, not a pointer. It never returns `nil, nil` ; an empty struct yields `labels.Everything()`, which correctly matches all nodes. The subsequent `if oldSelector == nil` branch was therefore dead code and could never be reached.

Remove the nil check and call `oldSelector.Matches(...)` directly.

## Related Issue

Fixes #230

## Type of Change

/kind cleanup

## Testing

make test
make lint

## Checklist

- [x] make test passes
- [x] make lint passes

## Does this PR introduce a user-facing change?

NONE
