### PR TITLE
refactor: extract bootstrapAnnotationKey helper function

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -317,6 +317,12 @@ func (r *RuleReadinessController) removeTaintBySpec(ctx context.Context, node *c
 }
 
 // Bootstrap completion tracking.
+// bootstrapAnnotationKey returns the annotation key used to track bootstrap
+// completion for a given rule.
+func bootstrapAnnotationKey(ruleName string) string {
+	return fmt.Sprintf("readiness.k8s.io/bootstrap-completed-%s", ruleName)
+}
+
 func (r *RuleReadinessController) isBootstrapCompleted(ctx context.Context, nodeName, ruleName string) bool {
 	// Check node annotation
 	node := &corev1.Node{}
@@ -324,7 +330,7 @@ func (r *RuleReadinessController) isBootstrapCompleted(ctx context.Context, node
 		return false
 	}
 
-	annotationKey := fmt.Sprintf("readiness.k8s.io/bootstrap-completed-%s", ruleName)
+	annotationKey := bootstrapAnnotationKey(ruleName)
 	_, exists := node.Annotations[annotationKey]
 	return exists
 }
@@ -332,7 +338,7 @@ func (r *RuleReadinessController) isBootstrapCompleted(ctx context.Context, node
 func (r *RuleReadinessController) markBootstrapCompleted(ctx context.Context, nodeName, ruleName string) {
 	log := ctrl.LoggerFrom(ctx)
 
-	annotationKey := fmt.Sprintf("readiness.k8s.io/bootstrap-completed-%s", ruleName)
+	annotationKey := bootstrapAnnotationKey(ruleName)
 	marked := false
 
 	// retry to handle conflict with concurrent node updates


### PR DESCRIPTION
## Description
The annotation key format string for bootstrap completion tracking was
duplicated in isBootstrapCompleted and markBootstrapCompleted in
internal/controller/node_controller.go. Extract into a single
bootstrapAnnotationKey(ruleName string) helper function to prevent
silent divergence if one is updated independently.

## Related Issue
Fixes #232

## Type of Change
/kind cleanup

## Testing
- go build ./... passes cleanly
- make lint passes with 0 issues

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?
```release-note
NONE
```