### PR TITLE
 fix:return evaluation errors from processAllNodesForRule

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -265,6 +266,7 @@ func (r *RuleReadinessController) processAllNodesForRule(ctx context.Context, ru
 	log.Info("Processing all nodes for rule", "rule", rule.Name, "totalNodes", len(nodeList.Items))
 
 	var appliedNodes []string
+	var errs []error
 	for _, node := range nodeList.Items {
 		if r.ruleAppliesTo(ctx, rule, &node) {
 			appliedNodes = append(appliedNodes, node.Name)
@@ -274,6 +276,7 @@ func (r *RuleReadinessController) processAllNodesForRule(ctx context.Context, ru
 				log.Error(err, "Failed to evaluate node for rule", "rule", rule.Name, "node", node.Name)
 				r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
 				metrics.Failures.WithLabelValues(rule.Name, "EvaluationError").Inc()
+				errs = append(errs, err)
 			}
 		}
 	}
@@ -287,7 +290,7 @@ func (r *RuleReadinessController) processAllNodesForRule(ctx context.Context, ru
 	}
 
 	log.Info("Completed processing nodes for rule", "rule", rule.Name, "processedCount", len(appliedNodes))
-	return nil
+	return errors.Join(errs...)
 }
 
 // evaluateRuleForNode evaluates a single rule against a single node.

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -145,6 +145,7 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	r.Controller.updateRuleCache(ctx, rule)
 
 	// Handle dry run
+	var processErr error
 	if rule.Spec.DryRun {
 		if err := r.Controller.processDryRun(ctx, rule, nodeList); err != nil {
 			log.Error(err, "Failed to process dry run", "rule", rule.Name)
@@ -154,14 +155,15 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		// Clear previous dry run results
 		rule.Status.DryRunResults = readinessv1alpha1.DryRunResults{}
 
-		// Process all applicable nodes for this rule
+		// Process all applicable nodes for this rule; save error so status
+		// is still updated before retrying.
 		if err := r.Controller.processAllNodesForRule(ctx, rule, nodeList); err != nil {
 			log.Error(err, "Failed to process nodes for rule", "rule", rule.Name)
-			return ctrl.Result{RequeueAfter: time.Minute}, err
+			processErr = err
 		}
 	}
 
-	// Update rule status
+	// Update rule status regardless of evaluation errors above
 	if err := r.Controller.updateRuleStatus(ctx, rule); err != nil {
 		log.Error(err, "Failed to update rule status", "rule", rule.Name)
 		return ctrl.Result{RequeueAfter: time.Minute}, err
@@ -173,6 +175,9 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
+	if processErr != nil {
+		return ctrl.Result{RequeueAfter: time.Minute}, processErr
+	}
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
## Description

`processAllNodesForRule` was catching errors from `evaluateRuleForNode` but always returning `nil`. This prevented `RuleReconciler.Reconcile` from seeing any failures, so controller-runtime never triggered a requeue on transient errors like API conflicts or patch failures.

This fix accumulates errors across the node loop and returns them via `errors.Join`, using the same pattern applied to `processNodeAgainstAllRules` in #222. The existing behavior of continuing evaluation across all nodes is preserved.

## Related Issue

Fixes #234

## Type of Change

/kind bug

## Testing

make test
make lint

## Checklist

- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
