### PR TITLE
refactor(readiness-condition-reporter): swap context.TODO() for content.Background()

### DIFF
--- a/cmd/readiness-condition-reporter/main_test.go
+++ b/cmd/readiness-condition-reporter/main_test.go
@@ -66,7 +66,7 @@ func TestCheckHealth(t *testing.T) {
 			}
 
 			httpClient := &http.Client{Timeout: 1 * time.Second}
-			health, err := checkHealth(context.TODO(), httpClient, endpoint)
+			health, err := checkHealth(context.Background(), httpClient, endpoint)
 			if err != nil {
 				if !tt.expectError {
 					t.Errorf("checkHealth() error = %v", err)
@@ -162,7 +162,7 @@ func TestUpdateNodeCondition(t *testing.T) {
 				t.Errorf("updateNodeCondition() error = %v", err)
 			}
 
-			updatedNode, err := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+			updatedNode, err := client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to get node: %v", err)
 			}


### PR DESCRIPTION
## Description
This PR replaces the usage of `context.TODO()` with `context.Background()` in `cmd/readiness-condition-reporter/main_test.go`. 
This change cleans up the codebase and enforces Go's best practices. It does not alter any existing application logic or data flows.

## Related Issue
None

## Type of Change

/kind cleanup

## Testing
- Verified that the change is isolated entirely to the test suite (`main_test.go`).
- Ran local unit tests to ensure `TestCheckHealth`, `TestCheckHealthCancelledContext`, and `TestUpdateNodeCondition` continue to pass successfully with the updated context.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE