### PR TITLE
cleanup: move shebang to first line in post-install.sh

### DIFF
--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
 set -x
 
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)


### PR DESCRIPTION
This PR moves the shebang in `.devcontainer/post-install.sh` to the first line of the script so the OS can actually detect it.

/kind cleanup
