### PR TITLE
controller: Track EvaluationError metric in NodeReconciler path

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -148,6 +148,7 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 				"node", node.Name, "rule", rule.Name)
 			// Continue with other rules even if one fails
 			r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
+			metrics.Failures.WithLabelValues(rule.Name, "EvaluationError").Inc()
 		}
 
 		// Persist the rule status


### PR DESCRIPTION
## Description
processNodeAgainstAllRules called recordNodeFailure on evaluation
errors but did not increment metrics.Failures counter, unlike
processAllNodesForRule which correctly does both. This caused failures
from node-triggered reconciliation to be silently missing from
node_readiness_failures_total Prometheus metric.

## Related Issue
Fixes #241

## Type of Change
/kind bug

## Testing
- go build ./... passes
- make lint passes (0 issues)
- go test ./internal/webhook/... passes

## Checklist
- [x] make test passes (webhook)
- [x] make lint passes

## Does this PR introduce a user-facing change?
```release-note
Fixed missing EvaluationError metric increment in NodeReconciler path.
Failures from node-triggered reconciliation are now correctly counted
in node_readiness_failures_total.
```