### PR TITLE
fix: add rule label to node_readiness_evaluation_duration_seconds metric

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -292,7 +292,7 @@ func (r *RuleReadinessController) processAllNodesForRule(ctx context.Context, ru
 
 // evaluateRuleForNode evaluates a single rule against a single node.
 func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule, node *corev1.Node) error {
-	timer := prometheus.NewTimer(metrics.EvaluationDuration)
+	timer := prometheus.NewTimer(metrics.EvaluationDuration.WithLabelValues(rule.Name))
 	defer timer.ObserveDuration()
 	log := ctrl.LoggerFrom(ctx)
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -40,12 +40,13 @@ var (
 	)
 
 	// EvaluationDuration tracks the duration of rule evaluations.
-	EvaluationDuration = prometheus.NewHistogram(
+	EvaluationDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "node_readiness_evaluation_duration_seconds",
-			Help:    "Duration of rule evaluations",
+			Help:    "Duration of rule evaluations per rule",
 			Buckets: prometheus.DefBuckets,
 		},
+		[]string{"rule"},
 	)
 
 	// Failures tracks the number of operational failures.


### PR DESCRIPTION
## Description
node_readiness_evaluation_duration_seconds was defined as a plain
Histogram with no labels. All other per-rule metrics include a rule
label. Without it, operators cannot identify which rule is slow in
multi-rule clusters.

## Related Issue
Fixes #243 

## Type of Change
/kind bug

## Testing
- go build ./... passes
- make lint passes (0 issues)
- go test ./internal/webhook/... passes (25/25)

## Checklist
- [x] make test passes
- [x] make lint passes

## Does this PR introduce a user-facing change?
```release-note
adds rule label to node_readiness_evaluation_duration_seconds metric
```