### PR TITLE
cleanup: remove dead cleanupNodesAfterSelectorChange code path

### DIFF
--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -17,45 +17,9 @@ limitations under the License.
 package controller
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// nodeSelectorChanged checks if nodeSelector has changed.
-func nodeSelectorChanged(current, previous metav1.LabelSelector) bool {
-	// Compare matchLabels
-	if !stringMapEqual(current.MatchLabels, previous.MatchLabels) {
-		return true
-	}
-
-	// Compare matchExpressions
-	if len(current.MatchExpressions) != len(previous.MatchExpressions) {
-		return true
-	}
-
-	// Create maps for comparison
-	currentExprs := make(map[string]metav1.LabelSelectorRequirement)
-	for _, expr := range current.MatchExpressions {
-		key := fmt.Sprintf("%s-%s-%v", expr.Key, expr.Operator, expr.Values)
-		currentExprs[key] = expr
-	}
-
-	previousExprs := make(map[string]metav1.LabelSelectorRequirement)
-	for _, expr := range previous.MatchExpressions {
-		key := fmt.Sprintf("%s-%s-%v", expr.Key, expr.Operator, expr.Values)
-		previousExprs[key] = expr
-	}
-
-	for key := range currentExprs {
-		if _, exists := previousExprs[key]; !exists {
-			return true
-		}
-	}
-
-	return false
-}
 
 // stringMapEqual checks if two string maps are equal.
 func stringMapEqual(a, b map[string]string) bool {

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -130,15 +130,6 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return r.reconcileDelete(ctx, rule, nodeList)
 	}
 
-	// Detect nodeSelector changes and cleanup old nodes
-	cachedRule := r.Controller.getCachedRule(rule.Name)
-	if cachedRule != nil && nodeSelectorChanged(rule.Spec.NodeSelector, cachedRule.Spec.NodeSelector) {
-		log.Info("NodeSelector changed, cleaning up nodes from old selector", "rule", rule.Name)
-		if err := r.Controller.cleanupNodesAfterSelectorChange(ctx, cachedRule, rule, nodeList); err != nil {
-			log.Error(err, "Failed to cleanup nodes after selector change", "rule", rule.Name)
-			return ctrl.Result{RequeueAfter: time.Minute}, err
-		}
-	}
 
 	// Update rule cache (after cleanup)
 	r.Controller.updateRuleCache(ctx, rule)
@@ -461,17 +452,6 @@ func (r *RuleReadinessController) updateRuleCache(ctx context.Context, rule *rea
 		"resourceVersion", ruleCopy.ResourceVersion)
 }
 
-// getCachedRule retrieves a rule from cache.
-func (r *RuleReadinessController) getCachedRule(ruleName string) *readinessv1alpha1.NodeReadinessRule {
-	r.ruleCacheMutex.RLock()
-	defer r.ruleCacheMutex.RUnlock()
-
-	rule, exists := r.ruleCache[ruleName]
-	if !exists {
-		return nil
-	}
-	return rule.DeepCopy()
-}
 
 // removeRuleFromCache removes a rule from cache.
 func (r *RuleReadinessController) removeRuleFromCache(ctx context.Context, ruleName string) {
@@ -619,52 +599,6 @@ func (r *RuleReadinessController) cleanupTaintsForRule(ctx context.Context, rule
 	return nil
 }
 
-// cleanupNodesAfterSelectorChange cleans up nodes that matched old selector but not new one.
-func (r *RuleReadinessController) cleanupNodesAfterSelectorChange(ctx context.Context, oldRule, newRule *readinessv1alpha1.NodeReadinessRule, nodeList *corev1.NodeList) error {
-	log := ctrl.LoggerFrom(ctx)
-
-	// Build old selector
-	oldSelector, err := metav1.LabelSelectorAsSelector(&oldRule.Spec.NodeSelector)
-	if err != nil {
-		return fmt.Errorf("failed to parse old node selector: %w", err)
-	}
-
-	// Clean up nodes that matched old selector but not new selector
-	var errors []string
-	for _, node := range nodeList.Items {
-		// Check if node matched old selector
-		matchedOld := false
-		if oldSelector == nil {
-			// nil selector matches all nodes
-			matchedOld = true
-		} else {
-			matchedOld = oldSelector.Matches(labels.Set(node.Labels))
-		}
-
-		// Check if node matches new selector (use newRule for current evaluation)
-		matchesNew := r.ruleAppliesTo(ctx, newRule, &node)
-
-		// If node matched old but not new, clean up the taint
-		if matchedOld && !matchesNew {
-			if r.hasTaintBySpec(&node, newRule.Spec.Taint) {
-				log.Info("Removing taint from node that no longer matches selector",
-					"node", node.Name,
-					"rule", newRule.Name,
-					"taint", newRule.Spec.Taint.Key)
-
-				if err := r.removeTaintBySpec(ctx, &node, newRule.Spec.Taint, newRule.Name); err != nil {
-					errors = append(errors, fmt.Sprintf("node %s: %v", node.Name, err))
-				}
-			}
-		}
-	}
-
-	if len(errors) > 0 {
-		return fmt.Errorf("failed to cleanup taints on some nodes: %s", strings.Join(errors, "; "))
-	}
-
-	return nil
-}
 
 func (r *RuleReconciler) ensureFinalizer(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule, finalizer string) (finalizerAdded bool, err error) {
 	// Finalizers can only be added when the deletionTimestamp is not set.

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -1479,6 +1479,7 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				MatchLabels: map[string]string{"env": "dev"},
 			}
 			err := k8sClient.Update(ctx, updatedRule)
+			By(fmt.Sprintf("CEL X-validation rejection error: %v", err))
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("nodeSelector is immutable"))
 		})


### PR DESCRIPTION
## Summary

Removes the unreachable `cleanupNodesAfterSelectorChange` code path and all associated helpers that became dead code after `nodeSelector` was made immutable.

## Background

`NodeReadinessRule.spec.nodeSelector` is immutable (enforced by the webhook since PR #164). Because the selector can never change after creation, the following code paths can never be triggered:

- The conditional block in `Reconcile` that detects selector changes and invokes the cleanup
- `getCachedRule` — only used by that block
- `cleanupNodesAfterSelectorChange` : the cleanup function itself
- `nodeSelectorChanged` in `helper.go` : the comparison helper

This was noted as a cleanup opportunity in issue #245.

## Changes

- `internal/controller/nodereadinessrule_controller.go`
  - Removed the selector-change detection block from `Reconcile`
  - Deleted `getCachedRule`
  - Deleted `cleanupNodesAfterSelectorChange`
- `internal/controller/helper.go`
  - Deleted `nodeSelectorChanged`
  - Removed now-unused `fmt` and `metav1` imports

## Testing

`go build ./...` passes cleanly with no unused import errors.

Closes #245