### PR TITLE
fix: webhook fails closed when rule listing errors

### DIFF
--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -80,9 +80,13 @@ func (w *NodeReadinessRuleWebhook) validateTaintConflicts(ctx context.Context, r
 	// List all existing rules
 	ruleList := &readinessv1alpha1.NodeReadinessRuleList{}
 	if err := w.List(ctx, ruleList); err != nil {
-		// If we can't list rules, allow the operation but log the issue
+		// Fail closed: if we can't list rules, we cannot safely validate
+		// for conflicts. Reject the request so the client can retry.
 		ctrl.Log.Error(err, "Failed to list rules for conflict validation")
-		return allErrs
+		return append(allErrs, field.InternalError(
+			field.NewPath("spec", "taint", "key"),
+			fmt.Errorf("failed to validate taint %q against existing rules: %w", rule.Spec.Taint.Key, err),
+		))
 	}
 
 	taintField := field.NewPath("spec", "taint", "key")


### PR DESCRIPTION
Fixes #251

When `validateTaintConflicts` cannot list existing rules, it previously logged the error and allowed the request through (fail-open). 
This means two rules with the same taint key/effect and overlapping selectors could be created during an API degradation window, causing taints to flip-flop indefinitely on affected nodes.

This change returns an `InternalError` instead, rejecting the request with a clear message so the client can retry when the system is healthy.
This aligns with the Kubernetes admission webhook best-practice offail-closed validation.
