### PR TITLE
fix: pass NodeList to processAllNodesForRule in tests

### DIFF
--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -1878,7 +1878,8 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				EventRecorder: record.NewFakeRecorder(10),
 			}
 
-			Expect(failController.processAllNodesForRule(ctx, rule)).To(Succeed())
+			nodeList := &corev1.NodeList{Items: []corev1.Node{*failNode}}
+			Expect(failController.processAllNodesForRule(ctx, rule, nodeList)).To(Succeed())
 
 			Expect(rule.Status.AppliedNodes).NotTo(ContainElement("fail-path-node"))
 
@@ -1934,7 +1935,8 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				EventRecorder: record.NewFakeRecorder(10),
 			}
 
-			Expect(successController.processAllNodesForRule(ctx, rule)).To(Succeed())
+			nodeList := &corev1.NodeList{Items: []corev1.Node{*successNode}}
+			Expect(successController.processAllNodesForRule(ctx, rule, nodeList)).To(Succeed())
 
 			Expect(rule.Status.AppliedNodes).To(ContainElement("stale-recovery-node"))
 


### PR DESCRIPTION
## Description

`main` is currently broken. Lint, Tests and E2E all fail at `go vet`:

```
vet: internal/controller/nodereadinessrule_controller_test.go:1881:58: not enough arguments in call to failController.processAllNodesForRule
	have (context.Context, *NodeReadinessRule)
	want (context.Context, *NodeReadinessRule, *corev1.NodeList)
```

#226 changed `processAllNodesForRule` to take a `*corev1.NodeList`, but the two new tests added in #216 still call it with the old two-argument signature. Both PRs were green on their own branches; the test file only stopped compiling once #216 landed on top of #226 on `main`.

Fix wraps the test node in a `*corev1.NodeList` and passes it through, same as `reconcileNormal` does. Filtering still happens inside the function, so behaviour is unchanged.

## Related Issue

None

## Type of Change

/kind bug
/kind failing-test

## Testing

- `make lint` clean
- `make test` passes

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```