### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug Report
+description: Report an issue with the node-readiness-controller's behavior.
+title: "[BUG] <Short description of the issue>"
+labels: ["kind/bug", "triage/needs-information"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this! 
+        Before submitting, please ensure you have searched the [existing issues](https://github.com/kubernetes-sigs/node-readiness-controller/issues) to avoid duplicates.
+
+  - type: markdown
+    attributes:
+      value: |
+        While AI-assisted submissions are acceptable, you should understand the issue and describe it in your own words.
+        To learn more, please refer to Kubernetes AI usage policy: https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug. What did the controller do (or fail to do)?
+      placeholder: The controller did abc to the node even though xyz...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this behavior? Please include all relevant info.
+      placeholder: |
+        1. Deploy the controller using...
+        2. Apply the following Node configuration...
+        3. Observe the readiness condition by running...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: The controller was supposed to xyz...
+    validations:
+      required: true
+
+  - type: input
+    id: controller-version
+    attributes:
+      label: Controller Version / Image Tag
+      description: Which version or container image tag of the node-readiness-controller are you running?
+      placeholder: vX.Y.Z or main (commit abc1234)
+    validations:
+      required: true
+
+  - type: input
+    id: k8s-version
+    attributes:
+      label: Kubernetes Version
+      description: Provide the output of `kubectl version`.
+      placeholder: Client Version vX.Y.Z
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Controller Logs
+      description: |
+        Please provide the relevant logs from the controller pod. 
+        `kubectl logs deployment/node-readiness-controller -n <namespace>`
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Additional Environment Details
+      description: Any other relevant details.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: true
+
+contact_links:  
+  - name: Support & Discussions
+    url: https://github.com/kubernetes-sigs/node-readiness-controller/discussions
+    about: If you need help with configuration, have questions, or want to propose an idea, start here.
+
+  - name: Kubernetes Slack
+    url: https://kubernetes.slack.com/messages/sig-node-readiness-controller
+    about: Join our dedicated channel on the Kubernetes Slack workspace for instant chat.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for the node-readiness-controller.
+title: "[FEATURE] <Short description of the feature>"
+labels: ["kind/feature", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting an improvement!
+        Please ensure you have checked the [existing issues](https://github.com/kubernetes-sigs/node-readiness-controller/issues) and [Discussions](https://github.com/kubernetes-sigs/node-readiness-controller/discussions) to see if this has already been proposed.
+
+  - type: markdown
+    attributes:
+      value: |
+        While AI-assisted submissions are acceptable, you should understand the issue and describe it in your own words.
+        To learn more, please refer to Kubernetes AI usage policy: https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Is your feature request related to a problem or existing issue? Please describe.
+      description: A clear and concise description of what the problem is.
+      placeholder: When dealing with custom node taints, the controller currently...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen. If you have API changes in mind, please provide YAML examples.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/tracking.yml
+++ b/.github/ISSUE_TEMPLATE/tracking.yml
@@ -1,0 +1,54 @@
+name: Tracking Issue
+description: Create a tracking issue for a larger initiative, epic, or multi-step feature.
+title: "[TRACKING] <Short description of the initiative>"
+labels: ["area/community-meeting"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is intended for maintainers and contributors to track the progress of an epic, cross-cutting feature, or major refactor that requires multiple PRs or sub-tasks.
+
+  - type: markdown
+    attributes:
+      value: |
+        While AI-assisted submissions are acceptable, you should understand the issue and describe it in your own words.
+        To learn more, please refer to Kubernetes AI usage policy: https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary / Objective
+      description: What is the overall goal of this initiative? Provide high-level context and why this work is necessary.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Checklist / Sub-tasks
+      description: List the required steps, sub-tasks, or related issues/PRs needed to complete this initiative. Use markdown checkboxes.
+      placeholder: |
+        - [ ] Design and architecture (Link KEP or PR)
+        - [ ] Implementation phase 1: [...]
+        - [ ] Implementation phase 2: [...]
+        - [ ] Add unit and e2e tests
+        - [ ] Documentation updates
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: Design Documents & References
+      description: Link to any relevant KEPs (Kubernetes Enhancement Proposals), architectural diagrams, or prior discussions.
+    validations:
+      required: false
+
+  - type: input
+    id: target-milestone
+    attributes:
+      label: Target Milestone / Release
+      description: Which upcoming release is this work targeted for?
+      placeholder: vX.Y.Z or Next
+    validations:
+      required: false


### PR DESCRIPTION
This PR adds Issue Templates to the repository.

We're adding templates (technically, they are forms) for bug report, feature request and issue tracking. 

We're also allowing blank issues as an escape hatch, just in case.

Follow-up to https://github.com/kubernetes-sigs/node-readiness-controller/issues/227#issuecomment-4477414611
