### PR TITLE
fix: resolve lint failures from dead code cleanup

### DIFF
--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -20,22 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-
-// stringMapEqual checks if two string maps are equal.
-func stringMapEqual(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for k, v := range a {
-		if b[k] != v {
-			return false
-		}
-	}
-
-	return true
-}
-
 // conditionsEqual checks if two condition slices are equal.
 func conditionsEqual(a, b []corev1.NodeCondition) bool {
 	if len(a) != len(b) {

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -130,7 +130,6 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return r.reconcileDelete(ctx, rule, nodeList)
 	}
 
-
 	// Update rule cache (after cleanup)
 	r.Controller.updateRuleCache(ctx, rule)
 
@@ -452,7 +451,6 @@ func (r *RuleReadinessController) updateRuleCache(ctx context.Context, rule *rea
 		"resourceVersion", ruleCopy.ResourceVersion)
 }
 
-
 // removeRuleFromCache removes a rule from cache.
 func (r *RuleReadinessController) removeRuleFromCache(ctx context.Context, ruleName string) {
 	log := ctrl.LoggerFrom(ctx)
@@ -598,7 +596,6 @@ func (r *RuleReadinessController) cleanupTaintsForRule(ctx context.Context, rule
 
 	return nil
 }
-
 
 func (r *RuleReconciler) ensureFinalizer(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule, finalizer string) (finalizerAdded bool, err error) {
 	// Finalizers can only be added when the deletionTimestamp is not set.


### PR DESCRIPTION
## Description
The dead-code cleanup in #250 removed the only caller of `stringMapEqual` and left behind double blank lines, breaking the lint CI on `main`:
- `gofmt`: extra blank lines in `helper.go` and `nodereadinessrule_controller.go`
- `unused`: `stringMapEqual` (a duplicate of `labelsEqual`)

This removes the now-dead function and fixes the formatting.

## Related Issue
None

## Type of Change
/kind cleanup
/kind failing-test

## Testing
`make lint` and `make test` both pass locally.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```
