### PR TITLE
replace kb.io placeholder with NRC API domain in webhook name

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -12,7 +12,7 @@ webhooks:
       namespace: system
       path: /validate-readiness-node-x-k8s-io-v1alpha1-nodereadinessrule
   failurePolicy: Fail
-  name: vnodereadinessrule.kb.io
+  name: vnodereadinessrule.readiness.node.x-k8s.io
   rules:
   - apiGroups:
     - readiness.node.x-k8s.io

--- a/config/webhook/webhook_patch.yaml
+++ b/config/webhook/webhook_patch.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: nrr-system/nrr-serving-cert
 webhooks:
-- name: vnodereadinessrule.kb.io
+- name: vnodereadinessrule.readiness.node.x-k8s.io
   clientConfig:
     service:
       name: webhook-service

--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -149,7 +149,7 @@ func (w *NodeReadinessRuleWebhook) generateNoExecuteWarnings(spec readinessv1alp
 	return warnings
 }
 
-// +kubebuilder:webhook:path=/validate-readiness-node-x-k8s-io-v1alpha1-nodereadinessrule,mutating=false,failurePolicy=fail,sideEffects=None,groups=readiness.node.x-k8s.io,resources=nodereadinessrules,verbs=create;update,versions=v1alpha1,name=vnodereadinessrule.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-readiness-node-x-k8s-io-v1alpha1-nodereadinessrule,mutating=false,failurePolicy=fail,sideEffects=None,groups=readiness.node.x-k8s.io,resources=nodereadinessrules,verbs=create;update,versions=v1alpha1,name=vnodereadinessrule.readiness.node.x-k8s.io,admissionReviewVersions=v1
 // SetupWithManager sets up the webhook with the manager.
 func (w *NodeReadinessRuleWebhook) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).


### PR DESCRIPTION
minor cleanup!

Saw webhook validation errors outputs `vnodereadinessrule.kb.io` as the webhook name 
(while [every other field in the markers](https://github.com/kubernetes-sigs/node-readiness-controller/blob/8b11ed1180bb122db24d40462d5aeac6e14dc422/internal/webhook/nodereadinessgaterule_webhook.go#L152) are using the NRC API group)

> Error from server (Forbidden): error when creating "test-nrr.yaml": admission webhook "vnodereadinessrule.kb.io" denied the request: validation failed: [<nil>: Internal error: unable to validate taint conflicts, please retry]

/kind cleanup


/assign @ajaysundark 