### PR TITLE
cleanup: remove duplicate KIND_CLUSTER definition in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,6 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
-KIND_CLUSTER ?= nrr-test-e2e
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist


### PR DESCRIPTION
## Description
`KIND_CLUSTER` was defined twice with `?=`. The first definition (`nrr-test`)
always wins, so the second (`nrr-test-e2e`, above the e2e targets) never took
effect. This removes the dead line. No behavior change.

## Related Issue
None

## Type of Change
/kind cleanup

## Testing
`make -p -n | grep '^KIND_CLUSTER ='` reports `nrr-test` before and after.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```
