### PR TITLE
Add test-e2e-kind target with hack script and artifact collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -419,6 +419,12 @@ test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expect
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
+.PHONY: test-e2e-kind
+test-e2e-kind: manifests generate fmt vet ## Run e2e tests on a Kind cluster with artifact collection and log export.
+	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) \
+	USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) ARTIFACTS=$(ARTIFACTS) \
+	./hack/e2e-test.sh
+
 KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
 
 .PHONY: setup-envtest

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export KIND=${KIND:-kind}
+export KUBECTL=${KUBECTL:-kubectl}
+
+KIND_CLUSTER="${KIND_CLUSTER:-nrr-test}"
+USE_EXISTING_CLUSTER="${USE_EXISTING_CLUSTER:-false}"
+ARTIFACTS="${ARTIFACTS:-.}"
+E2E_KIND_VERSION="${E2E_KIND_VERSION:-v1.36}"
+
+if [[ "$E2E_KIND_VERSION" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+    K8S_VERSION=$(curl -sf --retry 3 --retry-delay 5 --max-time 30 \
+        "https://api.github.com/repos/kubernetes/kubernetes/git/matching-refs/tags/${E2E_KIND_VERSION}." \
+        | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(?=")' \
+        | sort -V | tail -1)
+    if [ -z "$K8S_VERSION" ]; then
+        echo "ERROR: could not resolve latest patch for ${E2E_KIND_VERSION}" >&2
+        exit 1
+    fi
+else
+    K8S_VERSION="$E2E_KIND_VERSION"
+fi
+
+# Use a temporary KUBECONFIG so that the script does not mess up the current user's kubeconfig.
+KUBECONFIG=""
+
+function cleanup {
+    if [ "$USE_EXISTING_CLUSTER" != 'true' ]; then
+        mkdir -p "$ARTIFACTS"
+        $KIND export logs "$ARTIFACTS" --name "$KIND_CLUSTER" || true
+        $KIND delete cluster --name "$KIND_CLUSTER" || true
+        [ -n "$KUBECONFIG" ] && rm -f "$KUBECONFIG"
+    fi
+}
+
+function build_node_image {
+    if [ "$USE_EXISTING_CLUSTER" != 'true' ]; then
+        $KIND build node-image "$K8S_VERSION" --image nrr/kind-node:"${K8S_VERSION}"
+    fi
+}
+
+function startup {
+    if [ "$USE_EXISTING_CLUSTER" != 'true' ]; then
+        KUBECONFIG="$(mktemp)"
+        if [ -z "$KUBECONFIG" ]; then
+            echo "Failed to generate temporary KUBECONFIG" 1>&2
+            exit 1
+        fi
+        export KUBECONFIG
+        $KIND create cluster --name "$KIND_CLUSTER" --image nrr/kind-node:"${K8S_VERSION}" --wait 1m
+        $KUBECTL get nodes > "$ARTIFACTS/kind-nodes.log" 2>/dev/null || true
+        $KUBECTL describe pods -n kube-system > "$ARTIFACTS/kube-system-pods.log" 2>/dev/null || true
+    fi
+}
+
+mkdir -p "$ARTIFACTS"
+trap cleanup EXIT
+build_node_image
+startup
+
+go test -tags=e2e ./test/e2e/ -v -ginkgo.v \
+    --ginkgo.junit-report="$ARTIFACTS/junit.xml"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -84,6 +84,25 @@ var _ = Describe("Manager", Ordered, func() {
 		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
 		_, _ = utils.Run(cmd)
 
+		// Collect controller logs and pod descriptions to ARTIFACTS before teardown.
+		if artifactsDir := os.Getenv("ARTIFACTS"); artifactsDir != "" {
+			By("collecting controller-manager logs to ARTIFACTS")
+			if logsOut, err := utils.Run(exec.Command("kubectl", "logs", "-n", namespace,
+				"deployment/nrr-controller-manager", "--all-containers")); err == nil {
+				if err := os.WriteFile(filepath.Join(artifactsDir, "nrr-controller-manager.log"),
+					[]byte(logsOut), 0o644); err != nil {
+					fmt.Fprintf(GinkgoWriter, "warning: failed to write controller-manager logs: %v\n", err)
+				}
+			}
+			By("collecting nrr-system pod descriptions to ARTIFACTS")
+			if descOut, err := utils.Run(exec.Command("kubectl", "describe", "pods", "-n", namespace)); err == nil {
+				if err := os.WriteFile(filepath.Join(artifactsDir, "nrr-system-pods.log"),
+					[]byte(descOut), 0o644); err != nil {
+					fmt.Fprintf(GinkgoWriter, "warning: failed to write pod descriptions: %v\n", err)
+				}
+			}
+		}
+
 		By("undeploying the controller-manager")
 		cmd = exec.Command("make", "undeploy")
 		_, _ = utils.Run(cmd)


### PR DESCRIPTION
Following the k/jobset repo's pattern - https://github.com/kubernetes/test-infra/blob/98798bcae0a846ab0c1938f81044844a7df148f3/config/jobs/kubernetes-sigs/jobset/jobset-periodics-main.yaml

PR is adding a new `hack/e2e-test.sh` and a `test-e2e-kind` makefile target, that handles Kind cluster creation, artifact collection, and log export in one place.

This is prep work for the PR https://github.com/kubernetes/test-infra/pull/37165, to give us periodic e2e test signals for NRC across all latest supported Kubernetes releases.

---

Note:

With this, the existing `test-e2e` target is redundant now, but it is still in use in the GH Action workflow (we can clean it up later once all our GH actions CI jobs are migrated to Prow).

/assign @ajaysundark 