### PR TITLE
docs: replace blockquotes with admonitions

### DIFF
--- a/docs/book/src/examples/cni-readiness.md
+++ b/docs/book/src/examples/cni-readiness.md
@@ -16,7 +16,8 @@ The high-level steps are:
 
 This example uses **Calico**, but the pattern applies to any CNI.
 
-> **Note**: You can find all the manifests used in this guide in the [`examples/cni-readiness`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/cni-readiness) directory.
+> [!NOTE]
+> You can find all the manifests used in this guide in the [`examples/cni-readiness`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/cni-readiness) directory.
 
 ### 1. Deploy the Readiness Condition Reporter
 

--- a/docs/book/src/examples/constrained-impersonation.md
+++ b/docs/book/src/examples/constrained-impersonation.md
@@ -8,7 +8,8 @@ This guide walks through a CNI readiness example that uses constrained impersona
 
 > **Prerequisites**: Kubernetes v1.35+ with the `ConstrainedImpersonation` feature gate enabled, or v1.36+ where it is Beta and enabled by default.
 
-> **Note**: You can find all the manifests used in this guide in the [`examples/constrained-impersonation`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/constrained-impersonation) directory.
+> [!NOTE]
+> You can find all the manifests used in this guide in the [`examples/constrained-impersonation`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/constrained-impersonation) directory.
 
 ## Step-by-Step Guide
 

--- a/docs/book/src/examples/security-agent-readiness.md
+++ b/docs/book/src/examples/security-agent-readiness.md
@@ -22,7 +22,8 @@ We can use the Node Readiness Controller to enforce a security readiness guardra
 
 This example uses **Falco** as a representative security agent, but the same pattern applies to any node-level security or monitoring agent.
 
-> **Note**:  All manifests referenced in this guide are available in the [`examples/security-agent-readiness`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/security-agent-readiness) directory.
+> [!NOTE]
+> All manifests referenced in this guide are available in the [`examples/security-agent-readiness`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/security-agent-readiness) directory.
 
 ### Prerequisites
 

--- a/docs/book/src/user-guide/getting-started.md
+++ b/docs/book/src/user-guide/getting-started.md
@@ -46,7 +46,8 @@ spec:
 ### 1. Select Target Nodes
 Use the `nodeSelector` to target specific nodes (eg., GPU nodes).
 
-> **Note**: These labels could be configured at node registration (e.g., via Kubelet `--node-labels`). Relying on labels added asynchronously by addons (like Node Feature Discovery) can create a race condition where the node remains schedulable until the labels appear.
+> [!NOTE] 
+> These labels could be configured at node registration (e.g., via Kubelet `--node-labels`). Relying on labels added asynchronously by addons (like Node Feature Discovery) can create a race condition where the node remains schedulable until the labels appear.
 
 ### 2. Define Readiness Conditions
 The `conditions` list defines the criteria. The controller watches the Node's status for these conditions.
@@ -69,11 +70,11 @@ Define the taint that will block scheduling.
     *   `PreferNoSchedule`: Tries to avoid scheduling.
     *   `NoExecute`: Evicts running pods if they don't tolerate the taint.
 
-> **Note**: To eliminate startup race conditions, register nodes with this taint (e.g., via Kubelet `--register-with-taints`). The controller will remove it once conditions are met.
+> [!NOTE]
+> To eliminate startup race conditions, register nodes with this taint (e.g., via Kubelet `--register-with-taints`). The controller will remove it once conditions are met.
 
-> **Caution**: When using `NoExecute` with `continuous` mode: if a condition
-> fails momentarily, all workloads on the node (without tolerations) will be
-> immediately evicted, which can cause service disruption.
+> [!CAUTION]
+> When using `NoExecute` with `continuous` mode: if a condition fails momentarily, all workloads on the node (without tolerations) will be immediately evicted, which can cause service disruption.
 
 
 The admission webhook warns when using `NoExecute` taint:

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -103,7 +103,8 @@ example on deploying the controller as a static pod in a kind cluster.
 
 After installation, verify that the controller is running successfully. 
 
-> **Note**: Replace `${NAMESPACE}` with the namespace where the controller is deployed (typically `nrr-system` for standard deployments, or `kube-system` for static pods).
+> [!NOTE] 
+> Replace `${NAMESPACE}` with the namespace where the controller is deployed (typically `nrr-system` for standard deployments, or `kube-system` for static pods).
 
 1.  **Check Pod Status**:
     ```sh
@@ -131,11 +132,13 @@ After installation, verify that the controller is running successfully.
 
 ## Uninstallation
 
-> **IMPORTANT**: Follow this order to avoid "stuck" resources.
+> [!IMPORTANT] 
+> Follow this order to avoid "stuck" resources.
 
 The controller uses a **finalizer** (`readiness.node.x-k8s.io/cleanup-taints`) on `NodeReadinessRule` resources to ensure taints are safely removed from nodes before a rule is deleted.
 
-**You must delete all rule objects *before* deleting the controller.**
+> [!CAUTION]
+> You must delete all rule objects *before* deleting the controller.
 
 1.  **Delete all Rules**:
     ```sh


### PR DESCRIPTION
mbBook has native support for admonitions (callouts), which are a little nicer for grabing the reader's attention to a specific piece of content.

We're replacing the sidenotes and alerts in blockquotes with the built-in callouts.

The only ones I couldn't replace were the "Requirements" blockquotes, since there's no equivalent admonition to replace them with.

The admonitions can be seen here:
| current | preview |
|--------|--------|
| https://node-readiness-controller.sigs.k8s.io/user-guide/installation.html#verification | https://deploy-preview-274--node-readiness-controller.netlify.app/user-guide/installation.html#verification|
| https://node-readiness-controller.sigs.k8s.io/user-guide/installation.html#uninstallation | https://deploy-preview-274--node-readiness-controller.netlify.app/user-guide/installation.html#uninstallation|
| https://node-readiness-controller.sigs.k8s.io/user-guide/getting-started.html#1-select-target-nodes | https://deploy-preview-274--node-readiness-controller.netlify.app/user-guide/getting-started.html#1-select-target-nodes|
| https://node-readiness-controller.sigs.k8s.io/user-guide/getting-started.html#4-configure-the-taint | https://deploy-preview-274--node-readiness-controller.netlify.app/user-guide/getting-started.html#4-configure-the-taint |
| https://node-readiness-controller.sigs.k8s.io/examples/cni-readiness.html#step-by-step-guide | https://deploy-preview-274--node-readiness-controller.netlify.app/examples/cni-readiness.html#step-by-step-guide | 
| https://node-readiness-controller.sigs.k8s.io/examples/security-agent-readiness.html#step-by-step-guide-falco-example | https://deploy-preview-274--node-readiness-controller.netlify.app/examples/security-agent-readiness.html#step-by-step-guide-falco-example | 
| https://node-readiness-controller.sigs.k8s.io/examples/constrained-impersonation.html#secure-status-reporting | https://deploy-preview-274--node-readiness-controller.netlify.app/examples/constrained-impersonation.html#secure-status-reporting | 

/kind documentation