### PR TITLE
docs: fix invalid taint key names

### DIFF
--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -18,9 +18,9 @@ When a rule is created, the controller continuously watches all matching nodes. 
 Node Readiness Controller uses the `readiness.k8s.io` domain for taints and annotations that it owns. All `spec.taint.key` values in `NodeReadinessRule` must start with the `readiness.k8s.io/` prefix; this is enforced by the CRD schema.
 
 Typical taint keys look like:
-- `readiness.k8s.io/cni.example.net/network-not-ready`
-- `readiness.k8s.io/csi.vendor.com/storage-driver-not-ready`
-- `readiness.k8s.io/<dns.subdomain>/<component-name>`
+- `readiness.k8s.io/network-not-ready`
+- `readiness.k8s.io/storage-driver-not-ready`
+- `readiness.k8s.io/<component-name>`
 
 The segment after `readiness.k8s.io/` should describe the dependency or subsystem whose readiness is being guarded (for example, a CNI plugin, storage backend, or security agent). Treat this domain as reserved for the controller and closely related components, and avoid reusing it for unrelated taints.
 

--- a/docs/book/src/user-guide/getting-started.md
+++ b/docs/book/src/user-guide/getting-started.md
@@ -34,7 +34,7 @@ spec:
 
   # The taint to apply if conditions are NOT met
   taint:
-    key: "readiness.k8s.io/vendor.com/nfs-unhealthy"
+    key: "readiness.k8s.io/nfs-unhealthy"
     effect: "NoSchedule"
 
   # When to enforce: 'bootstrap-only' (initial setup) or 'continuous' (ongoing health)
@@ -102,7 +102,7 @@ spec:
     matchLabels:
       feature.node.kubernetes.io/pci-10de.present: "true"
   taint:
-    key: "readiness.k8s.io/vendor.com/gpu-not-ready"
+    key: "readiness.k8s.io/gpu-not-ready"
     effect: "NoSchedule"
 
 # Rule 2 - This will be REJECTED
@@ -114,7 +114,7 @@ spec:
     matchLabels:
       feature.node.kubernetes.io/pci-10de.present: "true"
   taint:
-    key: "readiness.k8s.io/vendor.com/gpu-not-ready"  # Same (taint-key + effect) but different conditions = conflict
+    key: "readiness.k8s.io/gpu-not-ready"  # Same (taint-key + effect) but different conditions = conflict
     effect: "NoSchedule"
 ```
 
@@ -127,8 +127,8 @@ Use unique, descriptive taint keys for different readiness checks. Follow [Kuber
 **Valid:**
 ```yaml
 taint:
-  key: "readiness.k8s.io/vendor.com/network-not-ready"
-  key: "readiness.k8s.io/vendor.com/gpu-not-ready"
+  key: "readiness.k8s.io/network-not-ready"
+  key: "readiness.k8s.io/gpu-not-ready"
 ```
 
 **Invalid:**

--- a/examples/security-agent-readiness/nrr-variant/security-agent-readiness-dryrun-rule.yaml
+++ b/examples/security-agent-readiness/nrr-variant/security-agent-readiness-dryrun-rule.yaml
@@ -8,7 +8,7 @@ spec:
     - type: "falco.org/FalcoReady"
       requiredStatus: "True"
   taint:
-    key: "readiness.k8s.io/falco.org/security-agent-ready"
+    key: "readiness.k8s.io/security-agent-ready"
     effect: "NoSchedule"
     value: "pending"
   enforcementMode: "bootstrap-only"


### PR DESCRIPTION
This PR fixes some invalid taint keys present in the docs as examples.

Among other restrictions, taint keys MUST have exactly one separator (/).

Follow up to #155 

/kind documentation