### PR TITLE
docs: fix 404s and improve instructions for cluster creation

### DIFF
--- a/docs/book/src/examples/security-agent-readiness.md
+++ b/docs/book/src/examples/security-agent-readiness.md
@@ -33,17 +33,17 @@ Before starting, ensure the Node Readiness Controller is deployed. See the [Inst
 
 **2. Kubernetes Cluster with Worker Nodes:**
 
-This example requires at least one worker node with the startup taint. For kind clusters, use the provided configuration:
+This example requires at least one worker node with the startup taint. 
+
+For kind clusters, save the provided configuration in [`examples/security-agent-readiness/kind-cluster-config.yaml`](https://github.com/kubernetes-sigs/node-readiness-controller/blob/main/examples/security-agent-readiness/kind-cluster-config.yaml) to a file, then create the cluster using the following command:
 
 ```sh
-kind create cluster --config examples/security-agent-readiness/kind-cluster-config.yaml
+kind create cluster --config <your-kind-config-file.yaml>
 ```
 
 This creates a cluster with:
 - 1 control-plane node
 - 1 worker node pre-tainted with `readiness.k8s.io/security-agent-ready=pending:NoSchedule`
-
-See [`examples/security-agent-readiness/kind-cluster-config.yaml`](../../../../examples/security-agent-readiness/kind-cluster-config.yaml) for details.
 
 ### 1. Deploy the Readiness Condition Reporter
 
@@ -139,7 +139,7 @@ data:
     fi
 ```
 
-Then deploy NPD DaemonSet and RBAC. See complete NPD manifests in [`examples/security-agent-readiness/npd-variant/`](../../../../examples/security-agent-readiness/npd-variant/).
+Then deploy NPD DaemonSet and RBAC. See complete NPD manifests in [`examples/security-agent-readiness/npd-variant/`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/security-agent-readiness/npd-variant).
 
 ### 2. Create the Node Readiness Rule
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


## Description

This PR fixes two 404s in the docs:

- https://node-readiness-controller.sigs.k8s.io/examples/security-agent-readiness/kind-cluster-config.yaml
- https://node-readiness-controller.sigs.k8s.io/examples/security-agent-readiness/npd-variant/

It also rewords the instruction for creating a kind cluster to make it a little more explicit for less experienced developers.

## Related Issue

None

## Type of Change

/kind documentation

## Testing

The fix can be verified in the deploy preview.

## Checklist

- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note

```
Doc #(issue)