### PR TITLE
feat: add optional DefaultStatus field to ConditionRequirement for missing node conditions

### DIFF
--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -128,13 +128,13 @@ type ConditionRequirement struct {
 	// defaultStatus is the status a condition is evaluated to if the condition
 	// is not found in a node.
 	//
-	// Accepted values True, False, Unknown. It is optional.
-	// If no value is provided, then Unknown becomes the default value.
+	// Accepted values are True, False, Unknown. It is optional.
+	// When omitted, the effective default is Unknown, applied transparently by
+	// the controller at evaluation time.
 	//
 	// +optional
-	// +kubebuilder:default="Unknown"
 	// +kubebuilder:validation:Enum=True;False;Unknown
-	DefaultStatus corev1.ConditionStatus `json:"defaultStatus,omitempty"`
+	DefaultStatus corev1.ConditionStatus `json:"defaultStatus,omitempty"` // Use GetDefaultStatus() for safe access; field may be empty even when a default applies.
 }
 
 // NodeReadinessRuleStatus defines the observed state of NodeReadinessRule.
@@ -349,6 +349,21 @@ type NodeReadinessRuleList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of NodeReadinessRule.
 	Items []NodeReadinessRule `json:"items"`
+}
+
+// GetDefaultStatus returns the effective default status for a condition that is
+// not found on a node. If the field is unset (empty string), it falls back to
+// corev1.ConditionUnknown.
+//
+// Always use this method instead of reading DefaultStatus directly. The field
+// is intentionally left without an OpenAPI schema default (kubebuilder:default
+// is forbidden by project policy) and the Spec is immutable, so defaulting
+// must happen at read time via this accessor.
+func (c *ConditionRequirement) GetDefaultStatus() corev1.ConditionStatus {
+	if c.DefaultStatus == "" {
+		return corev1.ConditionUnknown
+	}
+	return c.DefaultStatus
 }
 
 func init() {

--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -107,7 +107,8 @@ type NodeReadinessRuleSpec struct {
 }
 
 // ConditionRequirement defines a specific Node condition and the status value
-// required to trigger the controller's action.
+// required to trigger the controller's action. It also contains an optional
+// default status value.
 type ConditionRequirement struct {
 	// type of Node condition
 	//
@@ -123,6 +124,17 @@ type ConditionRequirement struct {
 	// +required
 	// +kubebuilder:validation:Enum=True;False;Unknown
 	RequiredStatus corev1.ConditionStatus `json:"requiredStatus,omitempty"`
+
+	// defaultStatus is the status a condition is evaluated to if the condition
+	// is not found in a node.
+	//
+	// Accepted values True, False, Unknown. It is optional.
+	// If no value is provided, then Unknown becomes the default value.
+	//
+	// +optional
+	// +kubebuilder:default="Unknown"
+	// +kubebuilder:validation:Enum=True;False;Unknown
+	DefaultStatus corev1.ConditionStatus `json:"defaultStatus,omitempty"`
 }
 
 // NodeReadinessRuleStatus defines the observed state of NodeReadinessRule.

--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -267,6 +267,14 @@ type ConditionEvaluationResult struct {
 	// +required
 	// +kubebuilder:validation:Enum=True;False;Unknown
 	RequiredStatus corev1.ConditionStatus `json:"requiredStatus,omitempty"`
+
+	// defaultStatus is the status a condition is evaluated to if the condition
+	// is not found in a node. Reflects the defaultStatus configured in the rule
+	// spec.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum=True;False;Unknown
+	DefaultStatus corev1.ConditionStatus `json:"defaultStatus,omitempty"`
 }
 
 // DryRunResults provides a summary of the actions the controller would perform if DryRun mode is enabled.

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -70,8 +70,22 @@ spec:
                 items:
                   description: |-
                     ConditionRequirement defines a specific Node condition and the status value
-                    required to trigger the controller's action.
+                    required to trigger the controller's action. It also contains an optional
+                    default status value.
                   properties:
+                    defaultStatus:
+                      description: |-
+                        defaultStatus is the status a condition is evaluated to if the condition
+                        is not found in a node.
+
+                        Accepted values are True, False, Unknown. It is optional.
+                        When omitted, the effective default is Unknown, applied transparently by
+                        the controller at evaluation time.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
                     requiredStatus:
                       description: requiredStatus is status of the condition, one
                         of True, False, Unknown.

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -377,6 +377,16 @@ spec:
                             - "False"
                             - Unknown
                             type: string
+                          defaultStatus:
+                            description: |-
+                              defaultStatus is the status a condition is evaluated to if the condition
+                              is not found in a node. Reflects the defaultStatus configured in the rule
+                              spec.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
                           requiredStatus:
                             description: requiredStatus is the status value defined
                               in the rule that must be matched, one of True, False,

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -25,6 +25,7 @@ With this controller you can:
 
 - **Multi-condition Rules**: Define rules that require ALL specified conditions to be satisfied
 - **Flexible Enforcement**: Support for bootstrap-only and continuous enforcement modes
+- **Default Condition Status**: Per-condition control over how absent node conditions are evaluated, enabling problem-gate (default-allow) scenarios
 - **Conflict Prevention**: Validation webhook prevents conflicting taint configurations
 - **Dry Run Mode**: Preview rule impact before applying changes
 - **Comprehensive Status**: Detailed observability into rule evaluation and node readiness status

--- a/docs/book/src/reference/api-spec.md
+++ b/docs/book/src/reference/api-spec.md
@@ -30,6 +30,7 @@ _Appears in:_
 | `type` _string_ | type corresponds to the Node condition type being evaluated. |  | MaxLength: 316 <br />MinLength: 1 <br /> |
 | `currentStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | currentStatus is the actual status value observed on the Node, one of True, False, Unknown. |  | Enum: [True False Unknown] <br /> |
 | `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is the status value defined in the rule that must be matched, one of True, False, Unknown. |  | Enum: [True False Unknown] <br /> |
+| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the fallback status value configured in the rule spec, which is used for evaluation if the condition is not present on the Node. |  | Enum: [True False Unknown] <br /> |
 
 
 #### ConditionRequirement
@@ -48,6 +49,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _string_ | type of Node condition<br />Following kubebuilder validation is referred from https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition |  | MaxLength: 316 <br />MinLength: 1 <br /> |
 | `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is status of the condition, one of True, False, Unknown. |  | Enum: [True False Unknown] <br /> |
+| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the fallback status assumed when the condition is completely missing from the Node's status. | Unknown | Enum: [True False Unknown] <br /> |
 
 
 #### DryRunResults

--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -24,6 +24,29 @@ Typical taint keys look like:
 
 The segment after `readiness.k8s.io/` should describe the dependency or subsystem whose readiness is being guarded (for example, a CNI plugin, storage backend, or security agent). Treat this domain as reserved for the controller and closely related components, and avoid reusing it for unrelated taints.
 
+### Default Condition Status (`defaultStatus`)
+
+When defining readiness conditions, you can configure an optional `defaultStatus` field (one of `True`, `False`, or `Unknown`) under `spec.conditions[]`. This field determines how a condition is evaluated when it is completely absent from the Node's status.
+
+If `defaultStatus` is omitted, the controller assumes a fallback status of `Unknown`.
+
+#### Use Case: Problem Gating (Default-Allow)
+By default, the controller operates in a "default-deny" fashion. If a guarded condition is missing from a new node, it resolves to `Unknown`, which typically does not satisfy `requiredStatus: True` or `requiredStatus: False`, causing the node to be tainted.
+
+However, for problem-detection conditions (like those reported by Node Problem Detector), you want a "default-allow" behavior: the node should start as healthy, and only be tainted if the problem condition explicitly triggers (e.g., `MaintenanceRequired=True`). 
+
+By setting `requiredStatus: False` and `defaultStatus: False`, an absent `MaintenanceRequired` condition evaluates to `False`. It matches the required status, allowing the node to bootstrap without being blocked by race conditions or initialization delays.
+
+#### Important Implication: Enforcement Modes
+The choice of `defaultStatus` has critical interaction with the rule's `enforcementMode`:
+
+> [!WARNING]
+> **Do not use a satisfying `defaultStatus` with `bootstrap-only` rules.**
+> 
+> If a rule is `bootstrap-only` and the absent condition evaluates to a status that matches `requiredStatus` (e.g. `requiredStatus: False` and `defaultStatus: False`), the controller will immediately mark the bootstrap as completed (`bootstrap-completed-<ruleName>=true`) and remove the taint. 
+> 
+> Since `bootstrap-only` rules are never re-evaluated once marked complete, the gate is permanently bypassed, even if a reporter eventually updates the condition to an unsatisfied status. For `bootstrap-only` rules, leaving the default status as `Unknown` is almost always the correct approach to guarantee the controller waits for the actual condition to be reported.
+
 ## Enforcement Modes
 
 The controller supports two distinct modes of enforcement, configured via `spec.enforcementMode`, to handle different operational needs.

--- a/docs/book/src/user-guide/getting-started.md
+++ b/docs/book/src/user-guide/getting-started.md
@@ -53,6 +53,7 @@ Use the `nodeSelector` to target specific nodes (eg., GPU nodes).
 The `conditions` list defines the criteria. The controller watches the Node's status for these conditions.
 *   `type`: The exact string matching the NodeCondition type.
 *   `requiredStatus`: The status required (`True`, `False`, or `Unknown`).
+*   `defaultStatus`: (Optional) The status to assume if the condition is completely missing from the Node's status. (`True`, `False`, or `Unknown`, defaults to `Unknown` if not provided). (See [Concepts](./concepts.md#default-condition-status-defaultstatus) for usage implications).
 
 ### 3. Choose an Enforcement Mode
 The `enforcementMode` determines how the controller manages the taint lifecycle.

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -229,13 +229,17 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 }
 
 // getConditionStatus gets the status of a condition on a node.
-func (r *RuleReadinessController) getConditionStatus(node *corev1.Node, conditionType string) corev1.ConditionStatus {
+func (r *RuleReadinessController) getConditionStatus(
+	node *corev1.Node,
+	conditionType string,
+	defaultStatus corev1.ConditionStatus,
+) (corev1.ConditionStatus, bool) {
 	for _, condition := range node.Status.Conditions {
 		if string(condition.Type) == conditionType {
-			return condition.Status
+			return condition.Status, true
 		}
 	}
-	return corev1.ConditionUnknown
+	return defaultStatus, false
 }
 
 // hasTaintBySpec checks if a node has a specific taint.

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -651,6 +651,7 @@ var _ = Describe("Node Controller", func() {
 			Expect(nodeEval.ConditionResults[0].Type).To(Equal("StatusTestCondition"))
 			Expect(nodeEval.ConditionResults[0].CurrentStatus).To(Equal(corev1.ConditionFalse))
 			Expect(nodeEval.ConditionResults[0].RequiredStatus).To(Equal(corev1.ConditionTrue))
+			Expect(nodeEval.ConditionResults[0].DefaultStatus).To(Equal(corev1.ConditionUnknown))
 			Expect(nodeEval.TaintStatus).To(Equal(nodereadinessiov1alpha1.TaintStatusPresent))
 			Expect(nodeEval.LastEvaluationTime.IsZero()).To(BeFalse(), "LastEvaluationTime should be set")
 		})

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -298,7 +298,7 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 	conditionResults := make([]readinessv1alpha1.ConditionEvaluationResult, 0, len(rule.Spec.Conditions))
 
 	for _, condReq := range rule.Spec.Conditions {
-		currentStatus, _ := r.getConditionStatus(node, condReq.Type, condReq.DefaultStatus)
+		currentStatus, _ := r.getConditionStatus(node, condReq.Type, condReq.GetDefaultStatus())
 		satisfied := currentStatus == condReq.RequiredStatus
 
 		if !satisfied {
@@ -519,7 +519,7 @@ func (r *RuleReadinessController) processDryRun(ctx context.Context, rule *readi
 			currentStatus, conditionFound := r.getConditionStatus(
 				&node,
 				condReq.Type,
-				condReq.DefaultStatus,
+				condReq.GetDefaultStatus(),
 			)
 			if !conditionFound {
 				missingConditions++

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -324,7 +324,8 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 		})
 
 		log.V(1).Info("Condition evaluation", "node", node.Name, "rule", rule.Name,
-			"conditionType", condReq.Type, "current", observedStatus, "required", condReq.RequiredStatus,
+			"conditionType", condReq.Type, "observed", observedStatus,
+			"effective", effectiveStatus, "required", condReq.RequiredStatus,
 			"satisfied", satisfied)
 	}
 

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -298,7 +298,7 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 	conditionResults := make([]readinessv1alpha1.ConditionEvaluationResult, 0, len(rule.Spec.Conditions))
 
 	for _, condReq := range rule.Spec.Conditions {
-		currentStatus := r.getConditionStatus(node, condReq.Type)
+		currentStatus, _ := r.getConditionStatus(node, condReq.Type, condReq.DefaultStatus)
 		satisfied := currentStatus == condReq.RequiredStatus
 
 		if !satisfied {
@@ -516,8 +516,12 @@ func (r *RuleReadinessController) processDryRun(ctx context.Context, rule *readi
 		missingConditions := 0
 
 		for _, condReq := range rule.Spec.Conditions {
-			currentStatus := r.getConditionStatus(&node, condReq.Type)
-			if currentStatus == corev1.ConditionUnknown {
+			currentStatus, conditionFound := r.getConditionStatus(
+				&node,
+				condReq.Type,
+				condReq.DefaultStatus,
+			)
+			if !conditionFound {
 				missingConditions++
 			}
 			if currentStatus != condReq.RequiredStatus {

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -298,8 +298,19 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 	conditionResults := make([]readinessv1alpha1.ConditionEvaluationResult, 0, len(rule.Spec.Conditions))
 
 	for _, condReq := range rule.Spec.Conditions {
-		currentStatus, _ := r.getConditionStatus(node, condReq.Type, condReq.GetDefaultStatus())
-		satisfied := currentStatus == condReq.RequiredStatus
+		effectiveStatus, conditionFound := r.getConditionStatus(
+			node,
+			condReq.Type,
+			condReq.GetDefaultStatus(),
+		)
+		satisfied := effectiveStatus == condReq.RequiredStatus
+
+		// observedStatus is the condition status of a node without applying the default
+		// fallback in case the condition is not found.
+		observedStatus := effectiveStatus
+		if !conditionFound {
+			observedStatus = corev1.ConditionUnknown
+		}
 
 		if !satisfied {
 			allConditionsSatisfied = false
@@ -307,12 +318,13 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 
 		conditionResults = append(conditionResults, readinessv1alpha1.ConditionEvaluationResult{
 			Type:           condReq.Type,
-			CurrentStatus:  currentStatus,
+			CurrentStatus:  observedStatus,
 			RequiredStatus: condReq.RequiredStatus,
+			DefaultStatus:  condReq.GetDefaultStatus(),
 		})
 
 		log.V(1).Info("Condition evaluation", "node", node.Name, "rule", rule.Name,
-			"conditionType", condReq.Type, "current", currentStatus, "required", condReq.RequiredStatus,
+			"conditionType", condReq.Type, "current", observedStatus, "required", condReq.RequiredStatus,
 			"satisfied", satisfied)
 	}
 

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -846,15 +846,15 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 			}
 
 			// Test condition exists and matches
-			status := readinessController.getConditionStatus(node, "Ready")
+			status, _ := readinessController.getConditionStatus(node, "Ready", "Unknown")
 			Expect(status).To(Equal(corev1.ConditionTrue))
 
 			// Test condition exists but doesn't match
-			status = readinessController.getConditionStatus(node, "NetworkReady")
+			status, _ = readinessController.getConditionStatus(node, "NetworkReady", "Unknown")
 			Expect(status).To(Equal(corev1.ConditionFalse))
 
 			// Test missing condition
-			status = readinessController.getConditionStatus(node, "StorageReady")
+			status, _ = readinessController.getConditionStatus(node, "StorageReady", "Unknown")
 			Expect(status).To(Equal(corev1.ConditionUnknown))
 		})
 

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -567,6 +567,103 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 			}, time.Second*5).Should(ContainSubstring("missing conditions"))
 		})
 
+		It("should count riskyOps and taintsToRemove when absent condition is satisfied via defaultStatus", func() {
+			// Absent condition + defaultStatus:False + requiredStatus:False:
+			// conditionFound=false → missingConditions++ → riskyOps++ (condition absent = risky)
+			// effectiveStatus=False == requiredStatus=False → allConditionsSatisfied=true
+			// node already has the taint → taintsToRemove++
+			const (
+				nodeName = "dry-run-default-status-node"
+				ruleName = "dry-run-default-status-rule"
+				labelKey = "env"
+				labelVal = "default-status-dry-run"
+				taintKey = "readiness.k8s.io/maintenance"
+			)
+
+			testNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{labelKey: labelVal},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{Key: taintKey, Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+				// Intentionally NO Status.Conditions — MaintenanceRequired is absent.
+			}
+			Expect(k8sClient.Create(ctx, testNode)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, testNode) }()
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       ruleName,
+					Finalizers: []string{finalizerName},
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					DryRun: true,
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{labelKey: labelVal},
+					},
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{
+							Type:           "MaintenanceRequired",
+							RequiredStatus: corev1.ConditionFalse,
+							DefaultStatus:  corev1.ConditionFalse, // absent → False → satisfied, but still risky
+						},
+					},
+					Taint: corev1.Taint{
+						Key:    taintKey,
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, rule) }()
+
+			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: ruleName},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Absent condition is always risky even if the default satisfies the rule.
+			Eventually(func() *int32 {
+				updated := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: ruleName}, updated); err != nil {
+					return nil
+				}
+				return updated.Status.DryRunResults.RiskyOperations
+			}, time.Second*5).Should(SatisfyAll(
+				Not(BeNil()),
+				HaveValue(BeNumerically(">=", int32(1))),
+			))
+
+			// Condition is satisfied via default → taint would be removed.
+			Eventually(func() *int32 {
+				updated := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: ruleName}, updated); err != nil {
+					return nil
+				}
+				return updated.Status.DryRunResults.TaintsToRemove
+			}, time.Second*5).Should(SatisfyAll(
+				Not(BeNil()),
+				HaveValue(BeNumerically(">=", int32(1))),
+			))
+
+			// Taints to add should remain 0
+			Eventually(func() *int32 {
+				updated := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: ruleName}, updated); err != nil {
+					return nil
+				}
+				return updated.Status.DryRunResults.TaintsToAdd
+			}, time.Second*5).Should(SatisfyAll(
+				Not(BeNil()),
+				HaveValue(BeNumerically("==", int32(0))),
+			))
+		})
+
 		It("should not count a node that does not match the selector", func() {
 			// Node exists but its labels do NOT match the rule's NodeSelector → continue (skip)
 			// affectedNodes should be 0; all counters 0; summary "No changes needed"
@@ -758,6 +855,108 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				}, BeNumerically(">=", int32(1))),
 			))
 		})
+
+		It(
+			"should satisfy a rule when an absent condition matches via defaultStatus (problem-gate scenario)",
+			func() {
+				// Scenario: NPD-style gate — taint is added when a problem condition fires.
+				// When the condition is completely absent (node just bootstrapped, NPD hasn't
+				// written it yet), defaultStatus:False makes it satisfy requiredStatus:False
+				// and the taint should NOT be added (or be removed if pre-existing).
+				const (
+					nodeName = "default-status-gate-node"
+					ruleName = "default-status-gate-rule"
+					labelKey = "app"
+					labelVal = "default-status-test"
+					taintKey = "readiness.k8s.io/problem-gate"
+				)
+
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   nodeName,
+						Labels: map[string]string{labelKey: labelVal},
+						// Pre-add the taint so we can observe it being removed.
+					},
+					Spec: corev1.NodeSpec{
+						Taints: []corev1.Taint{
+							{Key: taintKey, Effect: corev1.TaintEffectNoSchedule},
+						},
+					},
+					// Intentionally NO Status.Conditions — MaintenanceRequired is absent.
+				}
+				Expect(k8sClient.Create(ctx, node)).To(Succeed())
+				defer func() { _ = k8sClient.Delete(ctx, node) }()
+
+				rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       ruleName,
+						Finalizers: []string{finalizerName},
+					},
+					Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+						NodeSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{labelKey: labelVal},
+						},
+						Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+							{
+								Type:           "MaintenanceRequired",
+								RequiredStatus: corev1.ConditionFalse,
+								DefaultStatus:  corev1.ConditionFalse, // absent → treated as False → satisfied
+							},
+						},
+						Taint: corev1.Taint{
+							Key:    taintKey,
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+						EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+					},
+				}
+				Expect(k8sClient.Create(ctx, rule)).To(Succeed())
+				defer func() { _ = k8sClient.Delete(ctx, rule) }()
+
+				_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: ruleName},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// The pre-existing taint should be removed because the absent condition
+				// is satisfied via defaultStatus:False.
+				Eventually(func() bool {
+					updatedNode := &corev1.Node{}
+					if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, updatedNode); err != nil {
+						return true // assume taint still there on error
+					}
+					for _, taint := range updatedNode.Spec.Taints {
+						if taint.Key == taintKey {
+							return true
+						}
+					}
+					return false
+				}, time.Second*5).Should(BeFalse(), "taint should be removed when absent condition satisfies via defaultStatus")
+
+				// Validate that CurrentStatus is Unknown (observed status), RequiredStatus is False, and DefaultStatus is False.
+				Eventually(func() nodereadinessiov1alpha1.ConditionEvaluationResult {
+					updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+					if err := k8sClient.Get(ctx, types.NamespacedName{Name: ruleName}, updatedRule); err != nil {
+						return nodereadinessiov1alpha1.ConditionEvaluationResult{}
+					}
+					for _, ne := range updatedRule.Status.NodeEvaluations {
+						if ne.NodeName == nodeName && len(ne.ConditionResults) > 0 {
+							return ne.ConditionResults[0]
+						}
+					}
+					return nodereadinessiov1alpha1.ConditionEvaluationResult{}
+				}, time.Second*5).Should(SatisfyAll(
+					WithTransform(func(r nodereadinessiov1alpha1.ConditionEvaluationResult) corev1.ConditionStatus {
+						return r.CurrentStatus
+					}, Equal(corev1.ConditionUnknown)),
+					WithTransform(func(r nodereadinessiov1alpha1.ConditionEvaluationResult) corev1.ConditionStatus {
+						return r.RequiredStatus
+					}, Equal(corev1.ConditionFalse)),
+					WithTransform(func(r nodereadinessiov1alpha1.ConditionEvaluationResult) corev1.ConditionStatus {
+						return r.DefaultStatus
+					}, Equal(corev1.ConditionFalse)),
+				))
+			})
 	})
 
 	Context("Node Processing", func() {

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -503,22 +503,17 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 			))
 		})
 
-		It("should count riskyOps when a condition status is Unknown", func() {
-			// Node matches selector; condition status is Unknown → missingConditions++ → riskyOps++
-			// Unknown also means condition is not satisfied → taintsToAdd++ too (no pre-existing taint)
+		It("should count riskyOps when a condition is missing from a node", func() {
+			// Node matches selector but has NO Ready condition at all → conditionFound=false
+			// → missingConditions++ → riskyOps++
+			// Condition not found falls back to GetDefaultStatus() (Unknown), which doesn't
+			// satisfy RequiredStatus=True → taintsToAdd++ as well (no pre-existing taint)
 			testNode := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "dry-run-risky-node",
 					Labels: map[string]string{"env": "risky-test"},
 				},
-				Status: corev1.NodeStatus{
-					Conditions: []corev1.NodeCondition{
-						{
-							Type:   "Ready",
-							Status: corev1.ConditionUnknown, // triggers missingConditions++
-						},
-					},
-				},
+				// Intentionally no Status.Conditions — the Ready condition is absent
 			}
 			Expect(k8sClient.Create(ctx, testNode)).To(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, testNode) }()
@@ -683,11 +678,8 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 					Name:   "dry-run-multi-risky",
 					Labels: map[string]string{"env": "multi-test"},
 				},
-				Status: corev1.NodeStatus{
-					Conditions: []corev1.NodeCondition{
-						{Type: "Ready", Status: corev1.ConditionUnknown}, // risky branch
-					},
-				},
+				// Intentionally no Status.Conditions — the Ready condition is absent,
+				// making this a genuinely missing condition (riskyOps branch)
 			}
 			nodeSkip := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -846,16 +838,33 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 			}
 
 			// Test condition exists and matches
-			status, _ := readinessController.getConditionStatus(node, "Ready", "Unknown")
+			status, ok := readinessController.getConditionStatus(
+				node, "Ready", corev1.ConditionUnknown,
+			)
 			Expect(status).To(Equal(corev1.ConditionTrue))
+			Expect(ok).To(BeTrue())
 
 			// Test condition exists but doesn't match
-			status, _ = readinessController.getConditionStatus(node, "NetworkReady", "Unknown")
+			status, ok = readinessController.getConditionStatus(
+				node, "NetworkReady", corev1.ConditionUnknown,
+			)
 			Expect(status).To(Equal(corev1.ConditionFalse))
+			Expect(ok).To(BeTrue())
 
 			// Test missing condition
-			status, _ = readinessController.getConditionStatus(node, "StorageReady", "Unknown")
+			status, ok = readinessController.getConditionStatus(
+				node, "StorageReady", corev1.ConditionUnknown,
+			)
 			Expect(status).To(Equal(corev1.ConditionUnknown))
+			Expect(ok).To(BeFalse())
+
+			// Test missing condition with a non-Unknown default — condition is absent so
+			// conditionFound=false, but the returned status equals the supplied default.
+			status, ok = readinessController.getConditionStatus(
+				node, "NewCondition", corev1.ConditionTrue,
+			)
+			Expect(status).To(Equal(corev1.ConditionTrue))
+			Expect(ok).To(BeFalse())
 		})
 
 		It("should detect taints correctly", func() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


## Description
<!-- Brief description of changes -->

Issue #282 already describes why need the DefaultStatus field to act as a problem-gate during node bootstrap. This PR makes the following changes to implement that -

- Introduce a new optional `DefaultStatus` field in `ConditionRequirement`. Type `Corev1.ConditionStatus`.
- Introduce a `GetDefaultStatus()` accessor for safe access of that field. A kubebuilder schema default is not used due to project policy, so defaulting to `Unknown` happens at read-time via this method.
- Update the evaluator to use `defaultStatus` when matching a condition's effective status against `requiredStatus` for absent conditions.
- Report the actual observed condition status (`Unknown`) in `ConditionEvaluationResult.currentStatus` rather than the effective (default-applied) value, preserving the "observed" semantic of the field.
- Populate `ConditionEvaluationResult.defaultStatus` to reflect what default was configured in the spec, giving full visibility into evaluation decisions.
- Aligned the `DryRunResults.riskyOperations` logic to strictly count physically missing conditions (adhering to the API schema definition), rather than conflating them with explicitly reported Unknown statuses.
- Regenerate CRD manifests with `make manifests` to include the new `defaultStatus` property.

## Related Issue
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes #282 

## Type of Change

/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Testing
<!-- How was this tested? -->
**Unit/Integration Tests**:
- Added test case verifying `getConditionStatus` resolves to the configured default status when a condition is missing from a node.
- Added integration test verifying that a node with an absent condition satisfies a rule when the condition's `defaultStatus` matches `requiredStatus` (problem-gate scenario).
- Added dry-run integration test verifying that missing conditions on a node trigger `riskyOperations` increment, even if the condition is satisfied via `defaultStatus`, and correctly flags `taintsToRemove` while keeping `taintsToAdd` at `0`.

**Validation**:
- Verified code compiles, lints, and all tests pass with `make test` and `make lint`.
- Ran E2E suite (`make test-e2e`) locally; all 14 tests passed successfully, ensuring no regressions.


## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
  1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
  2. Add 'Doc #(issue)' after the block if there is a follow up
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added an optional `defaultStatus` field to `ConditionRequirement` (`spec.conditions[]`) in the `NodeReadinessRule` API. This field controls how an absent node condition is evaluated. When omitted, the effective default is `Unknown`, preserving existing behaviour. This enables NRC to function as a problem gate (default-allow) during node bootstrap when integrating with NPD or similar external condition controllers.
```

## Documentation
The following documentation files were updated:
- **`docs/book/src/introduction.md`**: Added `defaultStatus` as a Key Feature.
- **`docs/book/src/user-guide/getting-started.md`**: Added `defaultStatus` as a third field under "Define Readiness Conditions" with a link to Concepts for implications.
- **`docs/book/src/user-guide/concepts.md`**: Added a new `### Default Condition Status (defaultStatus)` subsection covering:
  - What the field does and what it defaults to when omitted
  - Problem-gate (default-allow) use case for NPD integration
  - `[!WARNING]` block explicitly documenting that a satisfying `defaultStatus` must **not** be used with `bootstrap-only` rules, as it permanently bypasses the gate
- **`docs/book/src/reference/api-spec.md`**: Added `defaultStatus` rows to both the `ConditionRequirement` and `ConditionEvaluationResult` tables, with the `Default: Unknown` column populated for `ConditionRequirement` (spec field), and left blank for `ConditionEvaluationResult` (status field).
