### PR TITLE
Remove duplicate bootstrap duration observation in taint removal path

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -399,17 +399,6 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 
 			// Only record the bootstrap duration if the node was created AFTER the rule.
 			// This prevents legacy nodes from poisoning the histogram with massive outliers.
-			if !node.CreationTimestamp.Time.Before(rule.CreationTimestamp.Time) {
-				duration := latestTransition.Time.Sub(node.CreationTimestamp.Time).Seconds()
-				metrics.BootstrapDuration.WithLabelValues(rule.Name).Observe(duration)
-			} else {
-				log.V(4).Info("Skipping bootstrap duration metric for legacy node",
-					"node", node.Name,
-					"rule", rule.Name)
-			}
-
-			// Only record the bootstrap duration if the node was created AFTER the rule.
-			// This prevents legacy nodes from poisoning the histogram with massive outliers.
 			if !node.CreationTimestamp.Time.Before(rule.CreationTimestamp.Time) && !latestTransition.IsZero() {
 				// Use ONLY API-server-generated timestamps to avoid Controller/Node clock skew
 				duration := latestTransition.Time.Sub(node.CreationTimestamp.Time).Seconds()

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,6 +47,12 @@ func counterValue(counter interface{ Write(*dto.Metric) error }) float64 {
 	metric := &dto.Metric{}
 	Expect(counter.Write(metric)).To(Succeed())
 	return metric.GetCounter().GetValue()
+}
+
+func histogramSampleCount(histogram interface{ Write(*dto.Metric) error }) uint64 {
+	metric := &dto.Metric{}
+	Expect(histogram.Write(metric)).To(Succeed())
+	return metric.GetHistogram().GetSampleCount()
 }
 
 // errorInjectingClient forces Patch to fail for selected nodes.
@@ -1029,6 +1036,72 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 			readinessController.markBootstrapCompleted(ctx, nodeName, ruleName)
 
 			Expect(counterValue(counter)).To(Equal(before + 1))
+		})
+
+		It("should observe bootstrap duration metric exactly once on taint removal", func() {
+			ruleName := "bootstrap-duration-metric-rule"
+			nodeName := "bootstrap-duration-metric-node"
+			taintKey := "readiness.k8s.io/bootstrap-duration-test"
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       ruleName,
+					Finalizers: []string{finalizerName},
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+					},
+					Taint: corev1.Taint{
+						Key:    taintKey,
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "bootstrap-duration"},
+					},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeBootstrapOnly,
+				},
+			}
+			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, rule) }()
+
+			transitionTime := metav1.NewTime(time.Now().Add(5 * time.Second))
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{"env": "bootstrap-duration"},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{Key: taintKey, Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, node) }()
+
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+					return err
+				}
+				node.Status.Conditions = []corev1.NodeCondition{
+					{
+						Type:               "Ready",
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: transitionTime,
+					},
+				}
+				return k8sClient.Status().Update(ctx, node)
+			}, time.Second*5, time.Millisecond*100).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ruleName}, rule)).To(Succeed())
+
+			histogram := metrics.BootstrapDuration.WithLabelValues(ruleName).(prometheus.Histogram)
+			before := histogramSampleCount(histogram)
+
+			Expect(readinessController.evaluateRuleForNode(ctx, rule, node)).To(Succeed())
+
+			Expect(histogramSampleCount(histogram)).To(Equal(before + 1))
 		})
 	})
 


### PR DESCRIPTION
## Description
cleanup: duplicate observation of node_readiness_bootstrap_duration_seconds in the bootstrap-only taint removal path.
Two consecutive observation blocks recording the same bootstrap completion event.

This is important because upcoming metrics, dashboards, and SLOs rely on this histogram for accurate calculations. Duplicate samples would skew those results.

### Files changed

| File | Change |
|------|--------|
| `internal/controller/nodereadinessrule_controller.go` | Remove duplicate Block |
| `internal/controller/nodereadinessrule_controller_test.go` | Add regression test + `histogramSampleCount` helper |


## Type of Change
/kind bug

## Testing
Added test to verify the histogram sample count increases by exactly one for a bootstrap completion event
- Ran:
  - `make test`
  - `make lint`

## Checklist
- [x] `make test` passes
- [x] `make lint` passes