### PR TITLE
feat: collector-based rule_matched_nodes and typed failure reasons

### DIFF
--- a/docs/book/src/operations/monitoring.md
+++ b/docs/book/src/operations/monitoring.md
@@ -106,6 +106,24 @@ Number of nodes currently held or released by each `NodeReadinessRule`, collecte
 | `rule` | `NodeReadinessRule` name | Any non-dry-run rule name with a valid selector |
 | `state` | Whether matching nodes are still tainted by the rule or have had the taint removed | `held`, `released` |
 
+### `node_readiness_rule_matched_nodes`
+
+*Available starting from the v0.6.0 release.*
+
+Number of nodes matching each `NodeReadinessRule`'s `nodeSelector`, collected at scrape time.
+
+| Property | Value |
+| --- | --- |
+| Type | `gauge` |
+| Labels | `rule` |
+| Recorded when | Computed on each Prometheus scrape from the cached node list |
+
+#### Labels
+
+| Label | Description | Values |
+| --- | --- | --- |
+| `rule` | `NodeReadinessRule` name | Any rule name with a valid selector |
+
 ### `node_readiness_bootstrap_completed_total`
 
 Total number of nodes that have completed bootstrap.

--- a/internal/controller/collector_bench_test.go
+++ b/internal/controller/collector_bench_test.go
@@ -99,3 +99,25 @@ func BenchmarkListRuleNodeStates(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkListRuleMatchedNodes(b *testing.B) {
+	nodeCounts := []int{100, 1000, 5000, 15000}
+	ruleCounts := []int{5, 20, 50}
+
+	for _, nodeCount := range nodeCounts {
+		for _, ruleCount := range ruleCounts {
+			b.Run(fmt.Sprintf("nodes=%d/rules=%d", nodeCount, ruleCount), func(b *testing.B) {
+				c := buildBenchController(b, nodeCount, ruleCount)
+				ctx := b.Context()
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				for range b.N {
+					if _, err := c.ListRuleMatchedNodes(ctx); err != nil {
+						b.Fatalf("ListRuleMatchedNodes failed: %v", err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -156,7 +156,7 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 			log.Error(err, "Failed to evaluate rule for node",
 				"node", node.Name, "rule", rule.Name)
 			// Continue with other rules even if one fails
-			r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
+			r.recordNodeFailure(rule, node.Name, string(metrics.FailureReasonEvaluationError), err.Error())
 			errs = append(errs, err)
 			metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonEvaluationError)).Inc()
 		}
@@ -483,6 +483,7 @@ func (r *RuleReadinessController) markBootstrapCompleted(ctx context.Context, no
 	switch {
 	case err != nil:
 		log.Error(err, "Failed to mark bootstrap completed", "node", nodeName, "rule", rule.Name, "uid", rule.GetUID())
+		metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonAnnotationPatchFailed)).Inc()
 	case deferred:
 		log.Info("Deferring bootstrap completion - rule taint still present on node",
 			"node", nodeName, "rule", rule.Name, "taint", rule.Spec.Taint.Key)

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -138,19 +138,9 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// Update rule cache (after cleanup)
 	r.Controller.updateRuleCache(ctx, rule)
 
-	// Filter nodes once and update node_readiness_rule_matched_nodes.
-	var matchedNodes []corev1.Node
-	for i := range nodeList.Items {
-		if r.Controller.ruleAppliesTo(ctx, rule, &nodeList.Items[i]) {
-			matchedNodes = append(matchedNodes, nodeList.Items[i])
-		}
-	}
-	metrics.RuleMatchedNodes.WithLabelValues(rule.Name).Set(float64(len(matchedNodes)))
-	filteredList := &corev1.NodeList{Items: matchedNodes}
-
 	// Handle dry run
 	if rule.Spec.DryRun {
-		if err := r.Controller.processDryRun(ctx, rule, filteredList); err != nil {
+		if err := r.Controller.processDryRun(ctx, rule, nodeList); err != nil {
 			log.Error(err, "Failed to process dry run", "rule", rule.Name)
 			return ctrl.Result{RequeueAfter: time.Minute}, err
 		}
@@ -159,7 +149,7 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		rule.Status.DryRunResults = readinessv1alpha1.DryRunResults{}
 
 		// Process all applicable nodes for this rule
-		if err := r.Controller.processAllNodesForRule(ctx, rule, filteredList); err != nil {
+		if err := r.Controller.processAllNodesForRule(ctx, rule, nodeList); err != nil {
 			log.Error(err, "Failed to process nodes for rule", "rule", rule.Name)
 			return ctrl.Result{RequeueAfter: time.Minute}, err
 		}
@@ -223,7 +213,6 @@ func (r *RuleReconciler) reconcileDelete(ctx context.Context, rule *readinessv1a
 	metrics.BootstrapCompleted.DeleteLabelValues(rule.Name)
 	metrics.BootstrapDuration.DeleteLabelValues(rule.Name)
 	metrics.EvaluationDuration.DeleteLabelValues(rule.Name)
-	metrics.RuleMatchedNodes.DeleteLabelValues(rule.Name)
 
 	// For multi-label metrics, use DeletePartialMatch to wipe all combinations
 	metrics.NodesByState.DeletePartialMatch(ruleLabel)
@@ -293,7 +282,7 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 func (r *RuleReadinessController) processAllNodesForRule(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule, nodeList *corev1.NodeList) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	log.Info("Processing all nodes for rule", "rule", rule.Name, "matchedNodes", len(nodeList.Items))
+	log.Info("Processing all nodes for rule", "rule", rule.Name, "totalNodes", len(nodeList.Items))
 
 	var appliedNodes []string
 	for _, node := range nodeList.Items {
@@ -590,6 +579,43 @@ func (r *RuleReadinessController) ListRuleNodeStates(ctx context.Context) (map[s
 	return counts, nil
 }
 
+// ListRuleMatchedNodes returns the number of nodes matching each rule's NodeSelector.
+func (r *RuleReadinessController) ListRuleMatchedNodes(ctx context.Context) (map[string]float64, error) {
+	ruleList := &readinessv1alpha1.NodeReadinessRuleList{}
+	if err := r.List(ctx, ruleList); err != nil {
+		return nil, err
+	}
+
+	nodeList := &corev1.NodeList{}
+	if err := r.List(ctx, nodeList); err != nil {
+		return nil, err
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+
+	counts := make(map[string]float64, len(ruleList.Items))
+	for i := range ruleList.Items {
+		rule := &ruleList.Items[i]
+
+		// Parse the selector once per rule.
+		selector, err := metav1.LabelSelectorAsSelector(&rule.Spec.NodeSelector)
+		if err != nil {
+			log.V(2).Info("Invalid node selector for rule", "rule", rule.Name, "error", err)
+			continue
+		}
+
+		var matched float64
+		for i := range nodeList.Items {
+			if selector.Matches(labels.Set(nodeList.Items[i].Labels)) {
+				matched++
+			}
+		}
+		counts[rule.Name] = matched
+	}
+
+	return counts, nil
+}
+
 // ruleAppliesTo checks if a rule applies to a node.
 func (r *RuleReadinessController) ruleAppliesTo(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule, node *corev1.Node) bool {
 	log := ctrl.LoggerFrom(ctx)
@@ -672,6 +698,10 @@ func (r *RuleReadinessController) processDryRun(ctx context.Context, rule *readi
 	var summaryParts []string
 
 	for _, node := range nodeList.Items {
+		if !r.ruleAppliesTo(ctx, rule, &node) {
+			continue
+		}
+
 		affectedNodes++
 
 		// Simulate rule evaluation using the rule's conditionPolicy

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -138,9 +138,19 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// Update rule cache (after cleanup)
 	r.Controller.updateRuleCache(ctx, rule)
 
+	// Filter nodes once and update node_readiness_rule_matched_nodes.
+	var matchedNodes []corev1.Node
+	for i := range nodeList.Items {
+		if r.Controller.ruleAppliesTo(ctx, rule, &nodeList.Items[i]) {
+			matchedNodes = append(matchedNodes, nodeList.Items[i])
+		}
+	}
+	metrics.RuleMatchedNodes.WithLabelValues(rule.Name).Set(float64(len(matchedNodes)))
+	filteredList := &corev1.NodeList{Items: matchedNodes}
+
 	// Handle dry run
 	if rule.Spec.DryRun {
-		if err := r.Controller.processDryRun(ctx, rule, nodeList); err != nil {
+		if err := r.Controller.processDryRun(ctx, rule, filteredList); err != nil {
 			log.Error(err, "Failed to process dry run", "rule", rule.Name)
 			return ctrl.Result{RequeueAfter: time.Minute}, err
 		}
@@ -149,7 +159,7 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		rule.Status.DryRunResults = readinessv1alpha1.DryRunResults{}
 
 		// Process all applicable nodes for this rule
-		if err := r.Controller.processAllNodesForRule(ctx, rule, nodeList); err != nil {
+		if err := r.Controller.processAllNodesForRule(ctx, rule, filteredList); err != nil {
 			log.Error(err, "Failed to process nodes for rule", "rule", rule.Name)
 			return ctrl.Result{RequeueAfter: time.Minute}, err
 		}
@@ -213,6 +223,7 @@ func (r *RuleReconciler) reconcileDelete(ctx context.Context, rule *readinessv1a
 	metrics.BootstrapCompleted.DeleteLabelValues(rule.Name)
 	metrics.BootstrapDuration.DeleteLabelValues(rule.Name)
 	metrics.EvaluationDuration.DeleteLabelValues(rule.Name)
+	metrics.RuleMatchedNodes.DeleteLabelValues(rule.Name)
 
 	// For multi-label metrics, use DeletePartialMatch to wipe all combinations
 	metrics.NodesByState.DeletePartialMatch(ruleLabel)
@@ -282,7 +293,7 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 func (r *RuleReadinessController) processAllNodesForRule(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule, nodeList *corev1.NodeList) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	log.Info("Processing all nodes for rule", "rule", rule.Name, "totalNodes", len(nodeList.Items))
+	log.Info("Processing all nodes for rule", "rule", rule.Name, "matchedNodes", len(nodeList.Items))
 
 	var appliedNodes []string
 	for _, node := range nodeList.Items {
@@ -290,16 +301,18 @@ func (r *RuleReadinessController) processAllNodesForRule(ctx context.Context, ru
 			log.Info("Processing node for rule", "rule", rule.Name, "node", node.Name)
 			if err := r.evaluateRuleForNode(ctx, rule, &node); err != nil {
 				log.Error(err, "Failed to evaluate node for rule", "rule", rule.Name, "node", node.Name)
-				r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
+				r.recordNodeFailure(rule, node.Name, string(metrics.FailureReasonEvaluationError), err.Error())
 				metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonEvaluationError)).Inc()
 			} else {
 				appliedNodes = append(appliedNodes, node.Name)
+
 				var updatedFailedNodes []readinessv1alpha1.NodeFailure
 				for _, f := range rule.Status.FailedNodes {
 					if f.NodeName != node.Name {
 						updatedFailedNodes = append(updatedFailedNodes, f)
 					}
 				}
+
 				rule.Status.FailedNodes = updatedFailedNodes
 			}
 		}
@@ -659,10 +672,6 @@ func (r *RuleReadinessController) processDryRun(ctx context.Context, rule *readi
 	var summaryParts []string
 
 	for _, node := range nodeList.Items {
-		if !r.ruleAppliesTo(ctx, rule, &node) {
-			continue
-		}
-
 		affectedNodes++
 
 		// Simulate rule evaluation using the rule's conditionPolicy

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -55,6 +55,12 @@ func histogramSampleCount(histogram interface{ Write(*dto.Metric) error }) uint6
 	return metric.GetHistogram().GetSampleCount()
 }
 
+func gaugeValue(gauge interface{ Write(*dto.Metric) error }) float64 {
+	metric := &dto.Metric{}
+	Expect(gauge.Write(metric)).To(Succeed())
+	return metric.GetGauge().GetValue()
+}
+
 // errorInjectingClient forces Patch to fail for selected nodes.
 type errorInjectingClient struct {
 	client.Client
@@ -2533,6 +2539,144 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 
 			// Taint should be removed because all conditions are satisfied
 			Expect(readinessController.hasTaintBySpec(anyOfNode, rule.Spec.Taint)).To(BeFalse())
+		})
+	})
+
+	Context("Metric: node_readiness_rule_matched_nodes", func() {
+		It("should set gauge to matched node count after reconcile", func() {
+			ruleName := "sel-gauge-match-rule"
+			matchLabel := "sel-gauge-match"
+
+			nodeA := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "sel-gauge-node-a", Labels: map[string]string{matchLabel: "true"}}}
+			nodeB := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "sel-gauge-node-b", Labels: map[string]string{matchLabel: "true"}}}
+			nodeC := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "sel-gauge-node-c", Labels: map[string]string{"other": "label"}}}
+			for _, n := range []*corev1.Node{nodeA, nodeB, nodeC} {
+				Expect(k8sClient.Create(ctx, n)).To(Succeed())
+			}
+			defer func() {
+				for _, n := range []*corev1.Node{nodeA, nodeB, nodeC} {
+					_ = k8sClient.Delete(ctx, n)
+				}
+			}()
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: ruleName, Finalizers: []string{finalizerName}},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/sel-gauge-taint", Effect: corev1.TaintEffectNoSchedule},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{matchLabel: "true"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, rule) }()
+
+			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: ruleName}})
+			Expect(err).NotTo(HaveOccurred())
+
+			gauge, err := metrics.RuleMatchedNodes.GetMetricWith(prometheus.Labels{"rule": ruleName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gaugeValue(gauge)).To(Equal(2.0))
+		})
+
+		It("should set gauge to 0 when no nodes match the selector", func() {
+			ruleName := "sel-gauge-nomatch-rule"
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: ruleName, Finalizers: []string{finalizerName}},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/sel-nomatch-taint", Effect: corev1.TaintEffectNoSchedule},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"definitely-no-such-label": "true"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, rule) }()
+
+			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: ruleName}})
+			Expect(err).NotTo(HaveOccurred())
+
+			gauge, err := metrics.RuleMatchedNodes.GetMetricWith(prometheus.Labels{"rule": ruleName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gaugeValue(gauge)).To(Equal(0.0))
+		})
+
+		It("should clean up label values on rule deletion", func() {
+			ruleName := "sel-gauge-del-rule"
+			matchLabel := "sel-gauge-del"
+
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "sel-gauge-del-node", Labels: map[string]string{matchLabel: "true"}}}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, node) }()
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: ruleName, Finalizers: []string{finalizerName}},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/sel-del-taint", Effect: corev1.TaintEffectNoSchedule},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{matchLabel: "true"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
+
+			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: ruleName}})
+			Expect(err).NotTo(HaveOccurred())
+
+			gauge, err := metrics.RuleMatchedNodes.GetMetricWith(prometheus.Labels{"rule": ruleName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gaugeValue(gauge)).To(Equal(1.0), "gauge should be 1 before deletion")
+
+			Expect(k8sClient.Delete(ctx, rule)).To(Succeed())
+
+			// Deletion reconcile triggers reconcileDelete, which calls DeleteLabelValues.
+			Eventually(func() bool {
+				_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: ruleName}})
+				Expect(err).NotTo(HaveOccurred())
+				readinessController.ruleCacheMutex.RLock()
+				_, exists := readinessController.ruleCache[ruleName]
+				readinessController.ruleCacheMutex.RUnlock()
+				return !exists
+			}).Should(BeTrue())
+
+			// After DeleteLabelValues, GetMetricWith allocates a fresh gauge at 0 (old value removed).
+			freshGauge, err := metrics.RuleMatchedNodes.GetMetricWith(prometheus.Labels{"rule": ruleName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gaugeValue(freshGauge)).To(Equal(0.0))
+		})
+	})
+
+	Context("Metric: failures_total (reason=AnnotationPatchFailed)", func() {
+		It("should increment counter when annotation write fails", func() {
+			ruleName := "bce-error-rule"
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: ruleName, UID: types.UID("33333333-3333-3333-3333-333333333333")},
+			}
+
+			before := counterValue(metrics.Failures.WithLabelValues(ruleName, string(metrics.FailureReasonAnnotationPatchFailed)))
+
+			readinessController.markBootstrapCompleted(ctx, "nonexistent-node-for-bce-test", rule)
+
+			Expect(counterValue(metrics.Failures.WithLabelValues(ruleName, string(metrics.FailureReasonAnnotationPatchFailed)))).To(Equal(before + 1))
+		})
+
+		It("should not increment counter on successful annotation write", func() {
+			nodeName := "bce-success-node"
+			ruleName := "bce-success-rule"
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: ruleName, UID: types.UID("44444444-4444-4444-4444-444444444444")},
+			}
+
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, node) }()
+
+			before := counterValue(metrics.Failures.WithLabelValues(ruleName, string(metrics.FailureReasonAnnotationPatchFailed)))
+
+			readinessController.markBootstrapCompleted(ctx, nodeName, rule)
+
+			Expect(counterValue(metrics.Failures.WithLabelValues(ruleName, string(metrics.FailureReasonAnnotationPatchFailed)))).To(Equal(before))
 		})
 	})
 })

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -55,12 +55,6 @@ func histogramSampleCount(histogram interface{ Write(*dto.Metric) error }) uint6
 	return metric.GetHistogram().GetSampleCount()
 }
 
-func gaugeValue(gauge interface{ Write(*dto.Metric) error }) float64 {
-	metric := &dto.Metric{}
-	Expect(gauge.Write(metric)).To(Succeed())
-	return metric.GetGauge().GetValue()
-}
-
 // errorInjectingClient forces Patch to fail for selected nodes.
 type errorInjectingClient struct {
 	client.Client
@@ -2539,111 +2533,6 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 
 			// Taint should be removed because all conditions are satisfied
 			Expect(readinessController.hasTaintBySpec(anyOfNode, rule.Spec.Taint)).To(BeFalse())
-		})
-	})
-
-	Context("Metric: node_readiness_rule_matched_nodes", func() {
-		It("should set gauge to matched node count after reconcile", func() {
-			ruleName := "sel-gauge-match-rule"
-			matchLabel := "sel-gauge-match"
-
-			nodeA := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "sel-gauge-node-a", Labels: map[string]string{matchLabel: "true"}}}
-			nodeB := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "sel-gauge-node-b", Labels: map[string]string{matchLabel: "true"}}}
-			nodeC := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "sel-gauge-node-c", Labels: map[string]string{"other": "label"}}}
-			for _, n := range []*corev1.Node{nodeA, nodeB, nodeC} {
-				Expect(k8sClient.Create(ctx, n)).To(Succeed())
-			}
-			defer func() {
-				for _, n := range []*corev1.Node{nodeA, nodeB, nodeC} {
-					_ = k8sClient.Delete(ctx, n)
-				}
-			}()
-
-			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
-				ObjectMeta: metav1.ObjectMeta{Name: ruleName, Finalizers: []string{finalizerName}},
-				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
-					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
-					Taint:           corev1.Taint{Key: "readiness.k8s.io/sel-gauge-taint", Effect: corev1.TaintEffectNoSchedule},
-					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{matchLabel: "true"}},
-					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
-				},
-			}
-			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
-			defer func() { _ = k8sClient.Delete(ctx, rule) }()
-
-			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: ruleName}})
-			Expect(err).NotTo(HaveOccurred())
-
-			gauge, err := metrics.RuleMatchedNodes.GetMetricWith(prometheus.Labels{"rule": ruleName})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(gaugeValue(gauge)).To(Equal(2.0))
-		})
-
-		It("should set gauge to 0 when no nodes match the selector", func() {
-			ruleName := "sel-gauge-nomatch-rule"
-
-			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
-				ObjectMeta: metav1.ObjectMeta{Name: ruleName, Finalizers: []string{finalizerName}},
-				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
-					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
-					Taint:           corev1.Taint{Key: "readiness.k8s.io/sel-nomatch-taint", Effect: corev1.TaintEffectNoSchedule},
-					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"definitely-no-such-label": "true"}},
-					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
-				},
-			}
-			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
-			defer func() { _ = k8sClient.Delete(ctx, rule) }()
-
-			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: ruleName}})
-			Expect(err).NotTo(HaveOccurred())
-
-			gauge, err := metrics.RuleMatchedNodes.GetMetricWith(prometheus.Labels{"rule": ruleName})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(gaugeValue(gauge)).To(Equal(0.0))
-		})
-
-		It("should clean up label values on rule deletion", func() {
-			ruleName := "sel-gauge-del-rule"
-			matchLabel := "sel-gauge-del"
-
-			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "sel-gauge-del-node", Labels: map[string]string{matchLabel: "true"}}}
-			Expect(k8sClient.Create(ctx, node)).To(Succeed())
-			defer func() { _ = k8sClient.Delete(ctx, node) }()
-
-			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
-				ObjectMeta: metav1.ObjectMeta{Name: ruleName, Finalizers: []string{finalizerName}},
-				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
-					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
-					Taint:           corev1.Taint{Key: "readiness.k8s.io/sel-del-taint", Effect: corev1.TaintEffectNoSchedule},
-					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{matchLabel: "true"}},
-					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
-				},
-			}
-			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
-
-			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: ruleName}})
-			Expect(err).NotTo(HaveOccurred())
-
-			gauge, err := metrics.RuleMatchedNodes.GetMetricWith(prometheus.Labels{"rule": ruleName})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(gaugeValue(gauge)).To(Equal(1.0), "gauge should be 1 before deletion")
-
-			Expect(k8sClient.Delete(ctx, rule)).To(Succeed())
-
-			// Deletion reconcile triggers reconcileDelete, which calls DeleteLabelValues.
-			Eventually(func() bool {
-				_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: ruleName}})
-				Expect(err).NotTo(HaveOccurred())
-				readinessController.ruleCacheMutex.RLock()
-				_, exists := readinessController.ruleCache[ruleName]
-				readinessController.ruleCacheMutex.RUnlock()
-				return !exists
-			}).Should(BeTrue())
-
-			// After DeleteLabelValues, GetMetricWith allocates a fresh gauge at 0 (old value removed).
-			freshGauge, err := metrics.RuleMatchedNodes.GetMetricWith(prometheus.Labels{"rule": ruleName})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(gaugeValue(freshGauge)).To(Equal(0.0))
 		})
 	})
 

--- a/internal/controller/rule_matched_nodes_test.go
+++ b/internal/controller/rule_matched_nodes_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	readinessv1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
+)
+
+func TestListRuleMatchedNodes_NoRules(t *testing.T) {
+	g := NewWithT(t)
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleMatchedNodes(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(BeEmpty())
+}
+
+func TestListRuleMatchedNodes_ZeroMatches(t *testing.T) {
+	g := NewWithT(t)
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		gpuRule(),
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "cpu-node"}},
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleMatchedNodes(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(Equal(map[string]float64{"gpu-ready": 0}))
+}
+
+func TestListRuleMatchedNodes_MixedMatches(t *testing.T) {
+	g := NewWithT(t)
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		gpuRule(),
+		gpuNode("held-1", true),
+		gpuNode("held-2", true),
+		gpuNode("released-1", false),
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "non-matching"}},
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleMatchedNodes(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(Equal(map[string]float64{"gpu-ready": 3}))
+}
+
+func TestListRuleMatchedNodes_DryRunRuleIncluded(t *testing.T) {
+	g := NewWithT(t)
+	rule := gpuRule()
+	rule.Spec.DryRun = true
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		rule,
+		gpuNode("held-1", true),
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleMatchedNodes(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(Equal(map[string]float64{"gpu-ready": 1}))
+}
+
+func TestListRuleMatchedNodes_DeletingRuleIncluded(t *testing.T) {
+	g := NewWithT(t)
+	rule := gpuRule()
+	now := metav1.Now()
+	rule.DeletionTimestamp = &now
+	rule.Finalizers = []string{"readiness.node.x-k8s.io/cleanup-taints"}
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		rule,
+		gpuNode("held-1", true),
+		gpuNode("held-2", true),
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleMatchedNodes(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(Equal(map[string]float64{"gpu-ready": 2}))
+}
+
+func TestListRuleMatchedNodes_InvalidSelectorSkipped(t *testing.T) {
+	g := NewWithT(t)
+	validRule := gpuRule()
+	invalidRule := &readinessv1alpha1.NodeReadinessRule{
+		ObjectMeta: metav1.ObjectMeta{Name: "invalid-selector-rule"},
+		Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+			NodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "gpu", Operator: "BogusOperator", Values: []string{"true"}},
+				},
+			},
+			Taint: corev1.Taint{
+				Key:    "readiness.k8s.io/invalid-selector",
+				Effect: corev1.TaintEffectNoSchedule,
+			},
+		},
+	}
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		validRule,
+		invalidRule,
+		gpuNode("held-1", true),
+		gpuNode("released-1", false),
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleMatchedNodes(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).NotTo(HaveKey(invalidRule.Name))
+	g.Expect(counts).To(Equal(map[string]float64{"gpu-ready": 2}))
+}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -38,6 +38,17 @@ type RuleNodeStateLister interface {
 	ListRuleNodeStates(ctx context.Context) (map[string]RuleNodeCounts, error)
 }
 
+// RuleMatchedNodesLister lists the number of nodes matching each rule's NodeSelector.
+type RuleMatchedNodesLister interface {
+	ListRuleMatchedNodes(ctx context.Context) (map[string]float64, error)
+}
+
+// ReadinessLister aggregates the scrape-time lookups the collector needs.
+type ReadinessLister interface {
+	RuleNodeStateLister
+	RuleMatchedNodesLister
+}
+
 var ruleNodesDesc = prometheus.NewDesc(
 	"node_readiness_rule_nodes",
 	"Number of nodes currently gated or released by the rule.",
@@ -45,18 +56,26 @@ var ruleNodesDesc = prometheus.NewDesc(
 	nil,
 )
 
+var ruleMatchedNodesDesc = prometheus.NewDesc(
+	"node_readiness_rule_matched_nodes",
+	"Number of nodes matched by a rule's NodeSelector.",
+	[]string{"rule"},
+	nil,
+)
+
 // ReadinessCollector is a prometheus.Collector that reads at scrape time.
 type ReadinessCollector struct {
-	lister RuleNodeStateLister
+	lister ReadinessLister
 }
 
-func NewReadinessCollector(lister RuleNodeStateLister) *ReadinessCollector {
+func NewReadinessCollector(lister ReadinessLister) *ReadinessCollector {
 	return &ReadinessCollector{lister: lister}
 }
 
 // Describe implements prometheus.Collector.
 func (c *ReadinessCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- ruleNodesDesc
+	ch <- ruleMatchedNodesDesc
 }
 
 // Collect implements prometheus.Collector.
@@ -67,11 +86,19 @@ func (c *ReadinessCollector) Collect(ch chan<- prometheus.Metric) {
 	counts, err := c.lister.ListRuleNodeStates(ctx)
 	if err != nil {
 		ctrl.Log.V(2).Info("Failed to list rule node states", "error", err)
-		return
+	} else {
+		for rule, rc := range counts {
+			ch <- prometheus.MustNewConstMetric(ruleNodesDesc, prometheus.GaugeValue, rc.Held, rule, string(RuleNodeStateHeld))
+			ch <- prometheus.MustNewConstMetric(ruleNodesDesc, prometheus.GaugeValue, rc.Released, rule, string(RuleNodeStateReleased))
+		}
 	}
 
-	for rule, rc := range counts {
-		ch <- prometheus.MustNewConstMetric(ruleNodesDesc, prometheus.GaugeValue, rc.Held, rule, string(RuleNodeStateHeld))
-		ch <- prometheus.MustNewConstMetric(ruleNodesDesc, prometheus.GaugeValue, rc.Released, rule, string(RuleNodeStateReleased))
+	matched, err := c.lister.ListRuleMatchedNodes(ctx)
+	if err != nil {
+		ctrl.Log.V(2).Info("Failed to list rule matched nodes", "error", err)
+		return
+	}
+	for rule, count := range matched {
+		ch <- prometheus.MustNewConstMetric(ruleMatchedNodesDesc, prometheus.GaugeValue, count, rule)
 	}
 }

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -31,6 +31,9 @@ import (
 type stubLister struct {
 	counts map[string]RuleNodeCounts
 	err    error
+
+	matched    map[string]float64
+	matchedErr error
 }
 
 func (s *stubLister) ListRuleNodeStates(_ context.Context) (map[string]RuleNodeCounts, error) {
@@ -38,6 +41,13 @@ func (s *stubLister) ListRuleNodeStates(_ context.Context) (map[string]RuleNodeC
 		return nil, s.err
 	}
 	return s.counts, nil
+}
+
+func (s *stubLister) ListRuleMatchedNodes(_ context.Context) (map[string]float64, error) {
+	if s.matchedErr != nil {
+		return nil, s.matchedErr
+	}
+	return s.matched, nil
 }
 
 func TestReadinessCollector_NoRules(t *testing.T) {
@@ -105,6 +115,66 @@ func TestReadinessCollector_ListError(t *testing.T) {
 
 	expected := ``
 	if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "node_readiness_rule_nodes"); err != nil {
+		t.Fatalf("unexpected collect mismatch: %v", err)
+	}
+}
+
+func TestReadinessCollector_MatchedNodes(t *testing.T) {
+	c := NewReadinessCollector(&stubLister{
+		counts:  map[string]RuleNodeCounts{},
+		matched: map[string]float64{"gpu-ready": 3, "dry-run-rule": 5},
+	})
+
+	expected := `
+		# HELP node_readiness_rule_matched_nodes Number of nodes matched by a rule's NodeSelector.
+		# TYPE node_readiness_rule_matched_nodes gauge
+		node_readiness_rule_matched_nodes{rule="gpu-ready"} 3
+		node_readiness_rule_matched_nodes{rule="dry-run-rule"} 5
+	`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "node_readiness_rule_matched_nodes"); err != nil {
+		t.Fatalf("unexpected collect mismatch: %v", err)
+	}
+}
+
+func TestReadinessCollector_MatchedNodesListError_DoesNotBlockRuleNodes(t *testing.T) {
+	c := NewReadinessCollector(&stubLister{
+		counts:     map[string]RuleNodeCounts{"gpu-ready": {Held: 1, Released: 2}},
+		matchedErr: errors.New("cache not synced"),
+	})
+
+	expected := `
+		# HELP node_readiness_rule_nodes Number of nodes currently gated or released by the rule.
+		# TYPE node_readiness_rule_nodes gauge
+		node_readiness_rule_nodes{rule="gpu-ready",state="held"} 1
+		node_readiness_rule_nodes{rule="gpu-ready",state="released"} 2
+	`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "node_readiness_rule_nodes"); err != nil {
+		t.Fatalf("unexpected collect mismatch: %v", err)
+	}
+
+	expectedMatched := ``
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expectedMatched), "node_readiness_rule_matched_nodes"); err != nil {
+		t.Fatalf("unexpected collect mismatch: %v", err)
+	}
+}
+
+func TestReadinessCollector_RuleNodesListError_DoesNotBlockMatchedNodes(t *testing.T) {
+	c := NewReadinessCollector(&stubLister{
+		err:     errors.New("cache not synced"),
+		matched: map[string]float64{"gpu-ready": 4},
+	})
+
+	expected := ``
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "node_readiness_rule_nodes"); err != nil {
+		t.Fatalf("unexpected collect mismatch: %v", err)
+	}
+
+	expectedMatched := `
+		# HELP node_readiness_rule_matched_nodes Number of nodes matched by a rule's NodeSelector.
+		# TYPE node_readiness_rule_matched_nodes gauge
+		node_readiness_rule_matched_nodes{rule="gpu-ready"} 4
+	`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expectedMatched), "node_readiness_rule_matched_nodes"); err != nil {
 		t.Fatalf("unexpected collect mismatch: %v", err)
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -27,9 +27,10 @@ import (
 type FailureReason string
 
 const (
-	FailureReasonEvaluationError  FailureReason = "EvaluationError"
-	FailureReasonAddTaintError    FailureReason = "AddTaintError"
-	FailureReasonRemoveTaintError FailureReason = "RemoveTaintError"
+	FailureReasonEvaluationError       FailureReason = "EvaluationError"
+	FailureReasonAddTaintError         FailureReason = "AddTaintError"
+	FailureReasonRemoveTaintError      FailureReason = "RemoveTaintError"
+	FailureReasonAnnotationPatchFailed FailureReason = "AnnotationPatchFailed"
 )
 
 // TaintOperation represents a taint operation.
@@ -174,6 +175,15 @@ var (
 		},
 		func() float64 { return 1 },
 	)
+
+	// RuleMatchedNodes tracks how many nodes match each rule's selector.
+	RuleMatchedNodes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "node_readiness_rule_matched_nodes",
+			Help: "Number of nodes matched by a rule's NodeSelector",
+		},
+		[]string{"rule"},
+	)
 )
 
 func init() {
@@ -189,4 +199,5 @@ func init() {
 	metrics.Registry.MustRegister(ConditionEvaluationFailures)
 	metrics.Registry.MustRegister(RuleLastReconciliationTime)
 	metrics.Registry.MustRegister(BuildInfo)
+	metrics.Registry.MustRegister(RuleMatchedNodes)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -175,15 +175,6 @@ var (
 		},
 		func() float64 { return 1 },
 	)
-
-	// RuleMatchedNodes tracks how many nodes match each rule's selector.
-	RuleMatchedNodes = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "node_readiness_rule_matched_nodes",
-			Help: "Number of nodes matched by a rule's NodeSelector",
-		},
-		[]string{"rule"},
-	)
 )
 
 func init() {
@@ -199,5 +190,4 @@ func init() {
 	metrics.Registry.MustRegister(ConditionEvaluationFailures)
 	metrics.Registry.MustRegister(RuleLastReconciliationTime)
 	metrics.Registry.MustRegister(BuildInfo)
-	metrics.Registry.MustRegister(RuleMatchedNodes)
 }


### PR DESCRIPTION
## Description

Adds `node_readiness_rule_matched_nodes` metric to the scrape-time collector pattern introduced in #398.

The metric is computed on each scrape from the cached Node list, sharing the same snapshot as `node_readiness_rule_nodes`. Dry-run and deleting rules are also included.

#### (exisitng) `node_readiness_failures_total` (new reason: `AnnotationPatchFailed`)
Also adds `AnnotationPatchFailed` as a new reason for the existing `node_readiness_failures_total` metric. Tracks failures when writing the bootstrap-completion annotation, keeping all failure reporting under the existing `failures_total` counter.

### Changes
- Moved `node_readiness_rule_matched_nodes` to the scrape-time `ReadinessCollector`.
- Shares the Node list with `node_readiness_rule_nodes`.
- Includes dry-run and deleting rules.
- Added `AnnotationPatchFailed` to `node_readiness_failures_total`.
- Failure reasons (`EvaluationError`, `AddTaintError`, `RemoveTaintError`, `AnnotationPatchFailed`) are now defined as a type with named constants. 


### Related to #397 

## Type of Change
/kind feature

## Testing
- `make test`, `make lint`, `go test ./... -race` all pass
- Verified the metric against a live cluster and confirmed the counts match the current Node selectors.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes