### PR TITLE
add options to tune concurrency, qps and burst

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -67,6 +67,10 @@ func main() {
 	var metricsCertDir string
 	var leaderElectionNamespace string
 	var enableNodeStateMetrics bool
+	var kubeAPIQPS float64
+	var kubeAPIBurst int
+	var nodeConcurrentReconciles int
+	var ruleConcurrentReconciles int
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -84,6 +88,16 @@ func main() {
 	flag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "", "The namespace where the leader election resource will be created.")
 	flag.BoolVar(&enableNodeStateMetrics, "enable-node-state-metrics", false,
 		"Enable aggregate node state metrics on node updates)")
+	flag.Float64Var(&kubeAPIQPS, "kube-api-qps", 20,
+		"Maximum queries per second to the API server from this client. "+
+			"Raise together with --kube-api-burst on large clusters.")
+	flag.IntVar(&kubeAPIBurst, "kube-api-burst", 30,
+		"Maximum burst for throttle between requests to the API server.")
+	flag.IntVar(&nodeConcurrentReconciles, "node-concurrent-reconciles", 1,
+		"Maximum number of Node objects reconciled concurrently. "+
+			"Raise on large clusters to reduce readiness-taint latency during node join/condition updates.")
+	flag.IntVar(&ruleConcurrentReconciles, "rule-concurrent-reconciles", 1,
+		"Maximum number of NodeReadinessRule objects reconciled concurrently.")
 
 	opts := zap.Options{
 		Development:     true,
@@ -107,7 +121,11 @@ func main() {
 		}(),
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.QPS = float32(kubeAPIQPS)
+	restConfig.Burst = kubeAPIBurst
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                  scheme,
 		Metrics:                 metricsServerOptions,
 		HealthProbeBindAddress:  probeAddr,
@@ -132,15 +150,17 @@ func main() {
 
 	// Create reconcilers linked to the main controller
 	ruleReconciler := &controller.RuleReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		Controller: readinessController,
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Controller:              readinessController,
+		MaxConcurrentReconciles: ruleConcurrentReconciles,
 	}
 
 	nodeReconciler := &controller.NodeReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		Controller: readinessController,
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Controller:              readinessController,
+		MaxConcurrentReconciles: nodeConcurrentReconciles,
 	}
 
 	// Setup controllers with manager

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,9 +45,29 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
+const (
+	defaultKubeAPIQPS               = 20.0
+	defaultKubeAPIBurst             = 30
+	defaultNodeConcurrentReconciles = 1
+	defaultRuleConcurrentReconciles = 1
+)
+
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	metricsAddr              string
+	enableLeaderElection     bool
+	probeAddr                string
+	enableWebhook            bool
+	metricsSecure            bool
+	metricsCertDir           string
+	leaderElectionNamespace  string
+	enableNodeStateMetrics   bool
+	kubeAPIQPS               float64
+	kubeAPIBurst             int
+	nodeConcurrentReconciles int
+	ruleConcurrentReconciles int
 )
 
 func init() {
@@ -59,19 +79,6 @@ func init() {
 
 //nolint:gocyclo
 func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var probeAddr string
-	var enableWebhook bool
-	var metricsSecure bool
-	var metricsCertDir string
-	var leaderElectionNamespace string
-	var enableNodeStateMetrics bool
-	var kubeAPIQPS float64
-	var kubeAPIBurst int
-	var nodeConcurrentReconciles int
-	var ruleConcurrentReconciles int
-
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.BoolVar(&metricsSecure, "metrics-secure", false,
@@ -88,15 +95,15 @@ func main() {
 	flag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "", "The namespace where the leader election resource will be created.")
 	flag.BoolVar(&enableNodeStateMetrics, "enable-node-state-metrics", false,
 		"Enable aggregate node state metrics on node updates)")
-	flag.Float64Var(&kubeAPIQPS, "kube-api-qps", 20,
+	flag.Float64Var(&kubeAPIQPS, "kube-api-qps", defaultKubeAPIQPS,
 		"Maximum queries per second to the API server from this client. "+
 			"Raise together with --kube-api-burst on large clusters.")
-	flag.IntVar(&kubeAPIBurst, "kube-api-burst", 30,
-		"Maximum burst for throttle between requests to the API server.")
-	flag.IntVar(&nodeConcurrentReconciles, "node-concurrent-reconciles", 1,
+	flag.IntVar(&kubeAPIBurst, "kube-api-burst", defaultKubeAPIBurst,
+		"Maximum number of queries that should be allowed in one burst.")
+	flag.IntVar(&nodeConcurrentReconciles, "node-concurrent-reconciles", defaultNodeConcurrentReconciles,
 		"Maximum number of Node objects reconciled concurrently. "+
 			"Raise on large clusters to reduce readiness-taint latency during node join/condition updates.")
-	flag.IntVar(&ruleConcurrentReconciles, "rule-concurrent-reconciles", 1,
+	flag.IntVar(&ruleConcurrentReconciles, "rule-concurrent-reconciles", defaultRuleConcurrentReconciles,
 		"Maximum number of NodeReadinessRule objects reconciled concurrently.")
 
 	opts := zap.Options{

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -39,8 +39,8 @@ import (
 // NodeReconciler reconciles a Node object.
 type NodeReconciler struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	Controller *RuleReadinessController
+	Scheme                  *runtime.Scheme
+	Controller              *RuleReadinessController
 	MaxConcurrentReconciles int // caps how many nodes are reconciled concurrently
 }
 

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -28,6 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -40,12 +41,15 @@ type NodeReconciler struct {
 	client.Client
 	Scheme     *runtime.Scheme
 	Controller *RuleReadinessController
+	MaxConcurrentReconciles int // caps how many nodes are reconciled concurrently
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	concurrency := max(r.MaxConcurrentReconciles, 1)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("node").
+		WithOptions(controller.Options{MaxConcurrentReconciles: concurrency}).
 		For(&corev1.Node{}, builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
 				log := ctrl.LoggerFrom(ctx)

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -64,8 +64,8 @@ type RuleReadinessController struct {
 // RuleReconciler handles NodeReadinessRule reconciliation.
 type RuleReconciler struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	Controller *RuleReadinessController
+	Scheme                  *runtime.Scheme
+	Controller              *RuleReadinessController
 	MaxConcurrentReconciles int // caps how many rules are reconciled concurrently
 }
 

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -66,6 +66,7 @@ type RuleReconciler struct {
 	client.Client
 	Scheme     *runtime.Scheme
 	Controller *RuleReadinessController
+	MaxConcurrentReconciles int // caps how many rules are reconciled concurrently
 }
 
 // NewRuleReadinessController creates a new controller.
@@ -82,9 +83,10 @@ func NewRuleReadinessController(mgr ctrl.Manager, clientset kubernetes.Interface
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RuleReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	concurrency := max(r.MaxConcurrentReconciles, 1)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("nodereadiness-controller").
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: concurrency}).
 		For(&readinessv1alpha1.NodeReadinessRule{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }


### PR DESCRIPTION
## Description
Add flags to the controller to tune controller-runtime knobs for scalability

## Related Issue
None

## Type of Change
/kind feature


## Testing
Manual test runs

## Checklist
- [X] `make test` passes
- [X] `make lint` passes

## Does this PR introduce a user-facing change?
Yes, adds command-flags to tune concurrency, qps and burst -- https://cluster-api.sigs.k8s.io/developer/core/tuning#runtime-tuning-options

Relevant for our ongoing scalability work.

```release-note
add new commandline-flags for tuning concurrency, qps and burst limits
```
