### PR TITLE
feat: Add reconciliation retry observability metrics

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
@@ -210,6 +211,9 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 			latestRule.Status.FailedNodes = updatedFailedNodes
 
 			if err := r.Status().Patch(ctx, latestRule, patch); err != nil {
+				if apierrors.IsConflict(err) {
+					metrics.APIConflicts.WithLabelValues(rule.Name, "process_node").Inc()
+				}
 				return err
 			}
 
@@ -283,6 +287,9 @@ func (r *RuleReadinessController) addTaintBySpec(ctx context.Context, node *core
 		stored := latestNode.DeepCopy()
 		latestNode.Spec.Taints = append(latestNode.Spec.Taints, taintSpec)
 		if err := r.Patch(ctx, latestNode, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
+			if apierrors.IsConflict(err) {
+				metrics.APIConflicts.WithLabelValues(ruleName, "add_taint").Inc()
+			}
 			return err
 		}
 
@@ -324,6 +331,9 @@ func (r *RuleReadinessController) removeTaintBySpec(ctx context.Context, node *c
 		}
 		latestNode.Spec.Taints = newTaints
 		if err := r.Patch(ctx, latestNode, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
+			if apierrors.IsConflict(err) {
+				metrics.APIConflicts.WithLabelValues(ruleName, "remove_taint").Inc()
+			}
 			return err
 		}
 
@@ -379,6 +389,9 @@ func (r *RuleReadinessController) markBootstrapCompleted(ctx context.Context, no
 
 		node.Annotations[annotationKey] = "true"
 		if err := r.Patch(ctx, node, patch); err != nil {
+			if apierrors.IsConflict(err) {
+				metrics.APIConflicts.WithLabelValues(ruleName, "mark_bootstrap").Inc()
+			}
 			return err
 		}
 

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -28,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
@@ -37,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nodereadinessiov1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
+	"sigs.k8s.io/node-readiness-controller/internal/metrics"
 )
 
 var _ = Describe("Node Controller", func() {
@@ -936,6 +938,285 @@ var _ = Describe("Node Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(patchCalled.Load()).To(BeFalse(),
 				"Patch should not be called when taint removal is a no-op")
+		})
+	})
+
+	Context("api_conflicts_total metric", func() {
+		var (
+			ctx        context.Context
+			testScheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			testScheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(testScheme)).To(Succeed())
+			Expect(nodereadinessiov1alpha1.AddToScheme(testScheme)).To(Succeed())
+		})
+
+		conflictErr := func(resource, name string) error {
+			return apierrors.NewConflict(schema.GroupResource{Resource: resource}, name, fmt.Errorf("conflict"))
+		}
+
+		It("should count one API conflict when addTaintBySpec retries after a conflict", func() {
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "conflict-metric-add-node"}}
+
+			var patchCount atomic.Int32
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if patchCount.Add(1) == 1 {
+							return conflictErr("nodes", obj.GetName())
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+
+			ruleName := "conflict-metric-add-rule"
+			counter := metrics.APIConflicts.WithLabelValues(ruleName, "add_taint")
+			before := counterValue(counter)
+
+			Expect(fc.Get(ctx, types.NamespacedName{Name: node.Name}, node)).To(Succeed())
+			err := controller.addTaintBySpec(ctx, node, corev1.Taint{
+				Key: "readiness.k8s.io/test", Effect: corev1.TaintEffectNoSchedule,
+			}, ruleName)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(counterValue(counter)).To(Equal(before + 1))
+		})
+
+		It("should count one API conflict when removeTaintBySpec retries after a conflict", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "conflict-metric-remove-node"},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{{Key: "readiness.k8s.io/test", Effect: corev1.TaintEffectNoSchedule}},
+				},
+			}
+
+			var patchCount atomic.Int32
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if patchCount.Add(1) == 1 {
+							return conflictErr("nodes", obj.GetName())
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+
+			ruleName := "conflict-metric-remove-rule"
+			counter := metrics.APIConflicts.WithLabelValues(ruleName, "remove_taint")
+			before := counterValue(counter)
+
+			Expect(fc.Get(ctx, types.NamespacedName{Name: node.Name}, node)).To(Succeed())
+			err := controller.removeTaintBySpec(ctx, node, corev1.Taint{
+				Key: "readiness.k8s.io/test", Effect: corev1.TaintEffectNoSchedule,
+			}, ruleName)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(counterValue(counter)).To(Equal(before + 1))
+		})
+
+		It("should count one API conflict when markBootstrapCompleted retries after a conflict", func() {
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "conflict-metric-bootstrap-node"}}
+
+			var patchCount atomic.Int32
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if patchCount.Add(1) == 1 {
+							return conflictErr("nodes", obj.GetName())
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+
+			ruleName := "conflict-metric-bootstrap-rule"
+			counter := metrics.APIConflicts.WithLabelValues(ruleName, "mark_bootstrap")
+			before := counterValue(counter)
+
+			controller.markBootstrapCompleted(ctx, node.Name, ruleName)
+
+			Expect(counterValue(counter)).To(Equal(before + 1))
+
+			updated := &corev1.Node{}
+			Expect(fc.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
+			Expect(updated.Annotations).To(HaveKeyWithValue("readiness.k8s.io/bootstrap-completed-"+ruleName, "true"))
+		})
+
+		It("should count one API conflict when persisting node evaluation status retries after a conflict", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "conflict-metric-process-node",
+					Labels: map[string]string{"env": "conflict-metric-process"},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{{Type: "Ready", Status: corev1.ConditionFalse}},
+				},
+			}
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "conflict-metric-process-rule"},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+					},
+					Taint: corev1.Taint{
+						Key:    "readiness.k8s.io/conflict-metric-process",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"env": "conflict-metric-process"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+
+			var patchCount atomic.Int32
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node, rule).
+				WithStatusSubresource(rule).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						if patchCount.Add(1) == 1 {
+							return conflictErr("nodereadinessrules", obj.GetName())
+						}
+						return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+			controller.updateRuleCache(ctx, rule)
+
+			nodeReconciler := &NodeReconciler{
+				Client:     fc,
+				Scheme:     testScheme,
+				Controller: controller,
+			}
+
+			counter := metrics.APIConflicts.WithLabelValues(rule.Name, "process_node")
+			before := counterValue(counter)
+
+			_, err := nodeReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: node.Name},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(counterValue(counter)).To(Equal(before + 1))
+		})
+
+		It("should not count API conflicts when a patch fails for a non-conflict reason", func() {
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "conflict-metric-nonconflict-node"}}
+
+			var patchCount atomic.Int32
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						patchCount.Add(1)
+						return fmt.Errorf("some non-conflict failure")
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+
+			ruleName := "conflict-metric-nonconflict-rule"
+			counter := metrics.APIConflicts.WithLabelValues(ruleName, "add_taint")
+			before := counterValue(counter)
+
+			Expect(fc.Get(ctx, types.NamespacedName{Name: node.Name}, node)).To(Succeed())
+			err := controller.addTaintBySpec(ctx, node, corev1.Taint{
+				Key: "readiness.k8s.io/test", Effect: corev1.TaintEffectNoSchedule,
+			}, ruleName)
+
+			Expect(err).To(HaveOccurred())
+			Expect(patchCount.Load()).To(Equal(int32(1)))
+			Expect(counterValue(counter)).To(Equal(before), "counter must not increment on a non-conflict error")
+		})
+
+		It("should count API conflicts on each retry when conflicts never resolve", func() {
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "conflict-metric-exhaust-node"}}
+
+			var patchCount atomic.Int32
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						patchCount.Add(1)
+						return conflictErr("nodes", obj.GetName())
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+
+			ruleName := "conflict-metric-exhaust-rule"
+			counter := metrics.APIConflicts.WithLabelValues(ruleName, "add_taint")
+			before := counterValue(counter)
+
+			Expect(fc.Get(ctx, types.NamespacedName{Name: node.Name}, node)).To(Succeed())
+			err := controller.addTaintBySpec(ctx, node, corev1.Taint{
+				Key: "readiness.k8s.io/test", Effect: corev1.TaintEffectNoSchedule,
+			}, ruleName)
+
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsConflict(err)).To(BeTrue())
+			Expect(counterValue(counter)).To(Equal(before + float64(patchCount.Load())))
+			Expect(patchCount.Load()).To(BeNumerically(">", 1))
 		})
 	})
 

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -155,12 +155,14 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// Update rule status
 	if err := r.Controller.updateRuleStatus(ctx, rule); err != nil {
 		log.Error(err, "Failed to update rule status", "rule", rule.Name)
+		metrics.ReconcileRequeue.WithLabelValues(rule.Name, "status_update_error").Inc()
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
 	// Clean up status for deleted nodes
 	if err := r.Controller.cleanupDeletedNodes(ctx, rule, nodeList); err != nil {
 		log.Error(err, "Failed to clean up deleted nodes", "rule", rule.Name)
+		metrics.ReconcileRequeue.WithLabelValues(rule.Name, "cleanup_error").Inc()
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
@@ -188,6 +190,7 @@ func (r *RuleReconciler) reconcileDelete(ctx context.Context, rule *readinessv1a
 	log.Info("Cleaning up taints for deleted rule", "rule", rule.Name)
 	if err := r.Controller.cleanupTaintsForRule(ctx, rule, nodeList); err != nil {
 		log.Error(err, "Failed to cleanup taints for rule", "rule", rule.Name)
+		metrics.ReconcileRequeue.WithLabelValues(rule.Name, "taint_cleanup_error").Inc()
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
@@ -216,6 +219,8 @@ func (r *RuleReconciler) reconcileDelete(ctx context.Context, rule *readinessv1a
 	metrics.ConditionEvaluationFailures.DeletePartialMatch(ruleLabel)
 	metrics.TaintOperations.DeletePartialMatch(ruleLabel)
 	metrics.ReconciliationLatency.DeletePartialMatch(ruleLabel)
+	metrics.APIConflicts.DeletePartialMatch(ruleLabel)
+	metrics.ReconcileRequeue.DeletePartialMatch(ruleLabel)
 
 	return ctrl.Result{}, nil
 }
@@ -267,7 +272,13 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 
 		patch := client.MergeFrom(fresh.DeepCopy())
 		fresh.Status.NodeEvaluations = freshNodeEvaluations
-		return r.Status().Patch(ctx, fresh, patch)
+		if err := r.Status().Patch(ctx, fresh, patch); err != nil {
+			if apierrors.IsConflict(err) {
+				metrics.APIConflicts.WithLabelValues(rule.Name, "cleanup_nodes").Inc()
+			}
+			return err
+		}
+		return nil
 	})
 }
 
@@ -563,6 +574,9 @@ func (r *RuleReadinessController) updateRuleStatus(ctx context.Context, rule *re
 			log.V(1).Info("Status patch conflict, will retry",
 				"rule", rule.Name,
 				"error", err.Error())
+			if apierrors.IsConflict(err) {
+				metrics.APIConflicts.WithLabelValues(rule.Name, "update_status").Inc()
+			}
 			return err
 		}
 

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -29,10 +30,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nodereadinessiov1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
@@ -2019,6 +2023,329 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				failedNames = append(failedNames, f.NodeName)
 			}
 			Expect(failedNames).NotTo(ContainElement("stale-recovery-node"))
+		})
+	})
+
+	// Covers api_conflicts_total for updateRuleStatus and cleanupDeletedNodes.
+	Context("api_conflicts_total metric (rule status call sites)", func() {
+		var (
+			fcCtx      context.Context
+			testScheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			fcCtx = context.Background()
+			testScheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(testScheme)).To(Succeed())
+			Expect(nodereadinessiov1alpha1.AddToScheme(testScheme)).To(Succeed())
+		})
+
+		conflictErr := func(name string) error {
+			return apierrors.NewConflict(schema.GroupResource{Resource: "nodereadinessrules"}, name, fmt.Errorf("conflict"))
+		}
+
+		It("should count one API conflict when updateRuleStatus retries after a conflict", func() {
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "conflict-metric-update-status-rule"},
+				Status: nodereadinessiov1alpha1.NodeReadinessRuleStatus{
+					AppliedNodes: []string{"node-a"},
+				},
+			}
+
+			var patchCount atomic.Int32
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(rule).
+				WithStatusSubresource(rule).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						if patchCount.Add(1) == 1 {
+							return conflictErr(obj.GetName())
+						}
+						return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+
+			counter := metrics.APIConflicts.WithLabelValues(rule.Name, "update_status")
+			before := counterValue(counter)
+
+			Expect(controller.updateRuleStatus(fcCtx, rule)).To(Succeed())
+			Expect(counterValue(counter)).To(Equal(before + 1))
+		})
+
+		It("should count one API conflict when cleanupDeletedNodes retries after a conflict", func() {
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "conflict-metric-cleanup-nodes-rule"},
+				Status: nodereadinessiov1alpha1.NodeReadinessRuleStatus{
+					NodeEvaluations: []nodereadinessiov1alpha1.NodeEvaluation{
+						{NodeName: "ghost-node"},
+					},
+				},
+			}
+
+			var patchCount atomic.Int32
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(rule).
+				WithStatusSubresource(rule).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						if patchCount.Add(1) == 1 {
+							return conflictErr(obj.GetName())
+						}
+						return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+
+			nodeList := &corev1.NodeList{}
+
+			counter := metrics.APIConflicts.WithLabelValues(rule.Name, "cleanup_nodes")
+			before := counterValue(counter)
+
+			Expect(controller.cleanupDeletedNodes(fcCtx, rule, nodeList)).To(Succeed())
+			Expect(counterValue(counter)).To(Equal(before + 1))
+		})
+	})
+
+	// Tests the three reconcile_requeue_total reasons
+	Context("reconcile_requeue_total metric", func() {
+		var testScheme *runtime.Scheme
+
+		BeforeEach(func() {
+			testScheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(testScheme)).To(Succeed())
+			Expect(nodereadinessiov1alpha1.AddToScheme(testScheme)).To(Succeed())
+		})
+
+		It("should count a reconcile requeue when updateRuleStatus fails", func() {
+			rqCtx := context.Background()
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "requeue-status-rule",
+					Finalizers: []string{finalizerName},
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/requeue-status", Effect: corev1.TaintEffectNoSchedule},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"env": "requeue-status"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(rule).
+				WithStatusSubresource(rule).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						return fmt.Errorf("status patch failed")
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+			reconciler := &RuleReconciler{Client: fc, Scheme: testScheme, Controller: controller}
+
+			counter := metrics.ReconcileRequeue.WithLabelValues(rule.Name, "status_update_error")
+			before := counterValue(counter)
+
+			result, err := reconciler.Reconcile(rqCtx, reconcile.Request{NamespacedName: types.NamespacedName{Name: rule.Name}})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+			Expect(counterValue(counter)).To(Equal(before + 1))
+		})
+
+		It("should count a reconcile requeue when cleanupDeletedNodes fails", func() {
+			rqCtx := context.Background()
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "requeue-cleanup-rule",
+					Finalizers: []string{finalizerName},
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/requeue-cleanup", Effect: corev1.TaintEffectNoSchedule},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"env": "requeue-cleanup"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+				Status: nodereadinessiov1alpha1.NodeReadinessRuleStatus{
+					NodeEvaluations: []nodereadinessiov1alpha1.NodeEvaluation{
+						{NodeName: "ghost-node"},
+					},
+				},
+			}
+
+			var patchCount atomic.Int32
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(rule).
+				WithStatusSubresource(rule).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						if patchCount.Add(1) == 1 {
+							return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+						}
+						return fmt.Errorf("cleanup status patch failed")
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+			reconciler := &RuleReconciler{Client: fc, Scheme: testScheme, Controller: controller}
+
+			counter := metrics.ReconcileRequeue.WithLabelValues(rule.Name, "cleanup_error")
+			before := counterValue(counter)
+
+			result, err := reconciler.Reconcile(rqCtx, reconcile.Request{NamespacedName: types.NamespacedName{Name: rule.Name}})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+			Expect(counterValue(counter)).To(Equal(before + 1))
+		})
+
+		It("should count a reconcile requeue when taint cleanup fails during rule deletion", func() {
+			rqCtx := context.Background()
+			now := metav1.Now()
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "requeue-taint-cleanup-node",
+					Labels: map[string]string{"env": "requeue-taint-cleanup"},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{{Key: "readiness.k8s.io/requeue-taint-cleanup", Effect: corev1.TaintEffectNoSchedule}},
+				},
+			}
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "requeue-taint-cleanup-rule",
+					Finalizers:        []string{finalizerName},
+					DeletionTimestamp: &now,
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/requeue-taint-cleanup", Effect: corev1.TaintEffectNoSchedule},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"env": "requeue-taint-cleanup"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node, rule).
+				WithStatusSubresource(rule).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if _, ok := obj.(*corev1.Node); ok {
+							return fmt.Errorf("taint removal patch failed")
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+			reconciler := &RuleReconciler{Client: fc, Scheme: testScheme, Controller: controller}
+
+			counter := metrics.ReconcileRequeue.WithLabelValues(rule.Name, "taint_cleanup_error")
+			before := counterValue(counter)
+
+			result, err := reconciler.Reconcile(rqCtx, reconcile.Request{NamespacedName: types.NamespacedName{Name: rule.Name}})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+			Expect(counterValue(counter)).To(Equal(before + 1))
+		})
+
+		It("should not count reconcile requeues on a successful reconcile", func() {
+			rqCtx := context.Background()
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "requeue-success-node",
+					Labels: map[string]string{"env": "requeue-success"},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{{Type: "Ready", Status: corev1.ConditionTrue}},
+				},
+			}
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "requeue-success-rule",
+					Finalizers: []string{finalizerName},
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/requeue-success", Effect: corev1.TaintEffectNoSchedule},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"env": "requeue-success"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node, rule).
+				WithStatusSubresource(rule).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: record.NewFakeRecorder(10),
+			}
+			reconciler := &RuleReconciler{Client: fc, Scheme: testScheme, Controller: controller}
+
+			reasons := []string{"status_update_error", "cleanup_error", "taint_cleanup_error"}
+			before := make(map[string]float64, len(reasons))
+			for _, reason := range reasons {
+				before[reason] = counterValue(metrics.ReconcileRequeue.WithLabelValues(rule.Name, reason))
+			}
+
+			result, err := reconciler.Reconcile(rqCtx, reconcile.Request{NamespacedName: types.NamespacedName{Name: rule.Name}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+			for _, reason := range reasons {
+				Expect(counterValue(metrics.ReconcileRequeue.WithLabelValues(rule.Name, reason))).To(Equal(before[reason]),
+					"reason %s should not have incremented on a successful reconcile", reason)
+			}
 		})
 	})
 })

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -117,6 +117,27 @@ var (
 		},
 		[]string{"rule"},
 	)
+
+	// Counts individual conflict retries inside RetryOnConflict closures, not exhaustion.
+	APIConflicts = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "node_readiness_api_conflicts_total",
+			Help: "Number of API conflict retries inside retry.RetryOnConflict closures. " +
+				"Increments per conflict, not per exhaustion (see node_readiness_failures_total for that). " +
+				"operation: add_taint|remove_taint|mark_bootstrap|process_node|cleanup_nodes|update_status",
+		},
+		[]string{"rule", "operation"},
+	)
+
+	// Counts error driven requeues in RuleReconciler, keyed by the failing stage.
+	ReconcileRequeue = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "node_readiness_reconcile_requeue_total",
+			Help: "Number of error driven requeues in RuleReconciler.Reconcile(), by failing stage. " +
+				"reason: status_update_error|cleanup_error|taint_cleanup_error",
+		},
+		[]string{"rule", "reason"},
+	)
 )
 
 func init() {
@@ -131,4 +152,6 @@ func init() {
 	metrics.Registry.MustRegister(NodesByState)
 	metrics.Registry.MustRegister(ConditionEvaluationFailures)
 	metrics.Registry.MustRegister(RuleLastReconciliationTime)
+	metrics.Registry.MustRegister(APIConflicts)
+	metrics.Registry.MustRegister(ReconcileRequeue)
 }


### PR DESCRIPTION
## Description
This PR adds two new metrics

### What each metric does


### `node_readiness_api_conflicts_total`

Tracks how many API conflicts occur during controller operations. Previously, only conflicts that exhausted all retries were visible through `node_readiness_failures_total`. If a retry succeeded, there was no signal that a conflict had happened. This metric makes those retries visible and helps identify API server contention earlier.

### `node_readiness_reconcile_requeue_total`
Tracks why a rule reconciliation is requeued. Right now, we know a rule is being requeued, but we don't know which stage caused it. This metric records the reason for the requeue, making it easier to identify where reconciliation is failing.

The metric is labeled by `reason`, currently covering:
- `status_update_error`
- `cleanup_error`
- `taint_cleanup_error`


### Related to Issue #182 

## Type of Change
/kind feature

## Testing
- Added tests coverages.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes