### PR TITLE
feat: prevent setting defaultStatus in bootstrap-only enforcement mode within validation webhook

### DIFF
--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -132,6 +132,8 @@ type ConditionRequirement struct {
 	// When omitted, the effective default is Unknown, applied transparently by
 	// the controller at evaluation time.
 	//
+	// Note: This field must not be set when enforcementMode is bootstrap-only.
+	//
 	// +optional
 	// +kubebuilder:validation:Enum=True;False;Unknown
 	DefaultStatus corev1.ConditionStatus `json:"defaultStatus,omitempty"` // Use GetDefaultStatus() for safe access; field may be empty even when a default applies.

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -81,6 +81,8 @@ spec:
                         Accepted values are True, False, Unknown. It is optional.
                         When omitted, the effective default is Unknown, applied transparently by
                         the controller at evaluation time.
+
+                        Note: This field must not be set when enforcementMode is bootstrap-only.
                       enum:
                       - "True"
                       - "False"

--- a/docs/book/src/reference/api-spec.md
+++ b/docs/book/src/reference/api-spec.md
@@ -49,7 +49,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `type` _string_ | type of Node condition<br />Following kubebuilder validation is referred from https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition |  | MaxLength: 316 <br />MinLength: 1 <br /> |
 | `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is status of the condition, one of True, False, Unknown. |  | Enum: [True False Unknown] <br /> |
-| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the fallback status assumed when the condition is completely missing from the Node's status. | Unknown | Enum: [True False Unknown] <br /> |
+| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the fallback status assumed when the condition is completely missing from the Node's status. <br /><br />Note: This field must not be set when enforcementMode is bootstrap-only. | Unknown | Enum: [True False Unknown] <br /> |
 
 
 #### DryRunResults

--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -43,9 +43,15 @@ The choice of `defaultStatus` has critical interaction with the rule's `enforcem
 > [!IMPORTANT]
 > **`defaultStatus` is not supported with `bootstrap-only` rules.**
 >
-> There is no valid use case found so far for this combination. `defaultStatus` is useful when a condition may never appear on a node — but `bootstrap-only` mode exists precisely to *wait* for conditions to be explicitly reported before completing the bootstrap gate. The two features work against each other.
+> There is no valid use case found so far for this combination. `defaultStatus` is useful when a condition may never appear on a node in its healthy state — effectively treating its absence as a known-good signal. But `bootstrap-only` mode exists precisely to *wait* for conditions to be explicitly reported before completing the bootstrap gate. The two features work against each other.
 >
-> Depending on your configuration, using them together either prevents the bootstrap from completing indefinitely (because all the conditions have always been satisfied) or lets the bootstrap gate pass for a condition that was never actually verified on the node. The admission webhook rejects any such combination.
+> Depending on your configuration, combining them breaks the state machine in one of two ways:
+>
+> **Premature Completion:** The absent condition evaluates as satisfied via `defaultStatus`, allowing the bootstrap gate to pass without the condition ever being actually verified.
+>
+> **Infinite Hang:** If the node was never registered with the taint ([as prescribed here](./getting-started.md#4-configure-the-taint)), `defaultStatus` keeps the condition satisfied, meaning no taint removal will ever trigger to mark the bootstrap as complete.
+>
+> To prevent these invalid states, the admission webhook explicitly rejects this combination.
 
 ## Enforcement Modes
 

--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -43,15 +43,9 @@ The choice of `defaultStatus` has critical interaction with the rule's `enforcem
 > [!IMPORTANT]
 > **`defaultStatus` is not supported with `bootstrap-only` rules.**
 >
-> There is no valid use case found so far for this combination. `defaultStatus` is useful when a condition may never appear on a node in its healthy state — effectively treating its absence as a known-good signal. But `bootstrap-only` mode exists precisely to *wait* for conditions to be explicitly reported before completing the bootstrap gate. The two features work against each other.
+> `defaultStatus` is useful when a condition may never appear on a node in its healthy state, effectively treating its absence as a known-good signal. However, `bootstrap-only` mode exists precisely to *wait* for conditions to be explicitly reported before completing the bootstrap gate.
 >
-> Depending on your configuration, combining them breaks the state machine in one of two ways:
->
-> **Premature Completion:** The absent condition evaluates as satisfied via `defaultStatus`, allowing the bootstrap gate to pass without the condition ever being actually verified.
->
-> **Infinite Hang:** If the node was never registered with the taint ([as prescribed here](./getting-started.md#4-configure-the-taint)), `defaultStatus` keeps the condition satisfied, meaning no taint removal will ever trigger to mark the bootstrap as complete.
->
-> To prevent these invalid states, the admission webhook explicitly rejects this combination.
+ > Because these two features serve opposing purposes, using them together can lead to unintended behavior, such as completing the bootstrap phase before a condition is actually verified. To prevent  this, the admission webhook explicitly rejects this combination.
 
 ## Enforcement Modes
 

--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -40,12 +40,12 @@ By setting `requiredStatus: False` and `defaultStatus: False`, an absent `Mainte
 #### Important Implication: Enforcement Modes
 The choice of `defaultStatus` has critical interaction with the rule's `enforcementMode`:
 
-> [!WARNING]
-> **Do not use a satisfying `defaultStatus` with `bootstrap-only` rules.**
-> 
-> If a rule is `bootstrap-only` and the absent condition evaluates to a status that matches `requiredStatus` (e.g. `requiredStatus: False` and `defaultStatus: False`), the controller will immediately mark the bootstrap as completed (`bootstrap-completed-<ruleName>=true`) and remove the taint. 
-> 
-> Since `bootstrap-only` rules are never re-evaluated once marked complete, the gate is permanently bypassed, even if a reporter eventually updates the condition to an unsatisfied status. For `bootstrap-only` rules, leaving the default status as `Unknown` is almost always the correct approach to guarantee the controller waits for the actual condition to be reported.
+> [!IMPORTANT]
+> **`defaultStatus` is not supported with `bootstrap-only` rules.**
+>
+> There is no valid use case found so far for this combination. `defaultStatus` is useful when a condition may never appear on a node — but `bootstrap-only` mode exists precisely to *wait* for conditions to be explicitly reported before completing the bootstrap gate. The two features work against each other.
+>
+> Depending on your configuration, using them together either prevents the bootstrap from completing indefinitely (because all the conditions have always been satisfied) or lets the bootstrap gate pass for a condition that was never actually verified on the node. The admission webhook rejects any such combination.
 
 ## Enforcement Modes
 

--- a/docs/book/src/user-guide/getting-started.md
+++ b/docs/book/src/user-guide/getting-started.md
@@ -53,7 +53,7 @@ Use the `nodeSelector` to target specific nodes (eg., GPU nodes).
 The `conditions` list defines the criteria. The controller watches the Node's status for these conditions.
 *   `type`: The exact string matching the NodeCondition type.
 *   `requiredStatus`: The status required (`True`, `False`, or `Unknown`).
-*   `defaultStatus`: (Optional) The status to assume if the condition is completely missing from the Node's status. (`True`, `False`, or `Unknown`, defaults to `Unknown` if not provided). (See [Concepts](./concepts.md#default-condition-status-defaultstatus) for usage implications).
+*   `defaultStatus`: (Optional) The status to assume if the condition is completely missing from the Node's status. (`True`, `False`, or `Unknown`, defaults to `Unknown` if not provided). Must not be set in `bootstrap-only` mode. (See [Concepts](./concepts.md#default-condition-status-defaultstatus) for usage implications).
 
 ### 3. Choose an Enforcement Mode
 The `enforcementMode` determines how the controller manages the taint lifecycle.

--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -73,7 +73,8 @@ func (w *NodeReadinessRuleWebhook) validateSpec(
 		allErrs = append(allErrs, field.Required(field.NewPath("spec", "nodeSelector"), "nodeSelector must not be empty"))
 	}
 
-	// skip the next checks for update
+	// skip below checks for update because both `enforcementMode` and `conditions` 
+	// are immutable as constrained by CEL XValidation rules
 	if isUpdate {
 		return allErrs
 	}

--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -49,7 +49,7 @@ func (w *NodeReadinessRuleWebhook) validateNodeReadinessRule(ctx context.Context
 	allErrs := make(field.ErrorList, 0, 4)
 
 	// Validate basic fields
-	allErrs = append(allErrs, w.validateSpec(rule.Spec)...)
+	allErrs = append(allErrs, w.validateSpec(rule.Spec, isUpdate)...)
 
 	// Check for conflicting rules (same taint key)
 	allErrs = append(allErrs, w.validateTaintConflicts(ctx, rule, isUpdate)...)
@@ -58,7 +58,10 @@ func (w *NodeReadinessRuleWebhook) validateNodeReadinessRule(ctx context.Context
 }
 
 // validateSpec validates the spec fields that CRD CEL based XValidation cannot handle.
-func (w *NodeReadinessRuleWebhook) validateSpec(spec readinessv1alpha1.NodeReadinessRuleSpec) field.ErrorList {
+func (w *NodeReadinessRuleWebhook) validateSpec(
+	spec readinessv1alpha1.NodeReadinessRuleSpec,
+	isUpdate bool,
+) field.ErrorList {
 	var allErrs field.ErrorList
 
 	// validate that the nodeSelector isn't empty
@@ -70,6 +73,22 @@ func (w *NodeReadinessRuleWebhook) validateSpec(spec readinessv1alpha1.NodeReadi
 		allErrs = append(allErrs, field.Required(field.NewPath("spec", "nodeSelector"), "nodeSelector must not be empty"))
 	}
 
+	// skip the next checks for update
+	if isUpdate {
+		return allErrs
+	}
+
+	// validate defaultStatus is not used in bootstrap-only mode
+	if spec.EnforcementMode == readinessv1alpha1.EnforcementModeBootstrapOnly {
+		for i, cond := range spec.Conditions {
+			if cond.DefaultStatus != "" {
+				allErrs = append(allErrs, field.Forbidden(
+					field.NewPath("spec", "conditions").Index(i).Child("defaultStatus"),
+					"defaultStatus should not be used with bootstrap-only enforcementMode",
+				))
+			}
+		}
+	}
 	return allErrs
 }
 

--- a/internal/webhook/nodereadinessgaterule_webhook_test.go
+++ b/internal/webhook/nodereadinessgaterule_webhook_test.go
@@ -64,7 +64,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 				},
 			}
 
-			allErrs := webhook.validateSpec(rule.Spec)
+			allErrs := webhook.validateSpec(rule.Spec, false)
 			Expect(allErrs).To(HaveLen(1))
 			Expect(allErrs[0].Field).To(Equal("spec.nodeSelector"))
 		})
@@ -80,7 +80,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 				},
 			}
 
-			allErrs := webhook.validateSpec(rule.Spec)
+			allErrs := webhook.validateSpec(rule.Spec, false)
 			Expect(allErrs).To(BeEmpty())
 		})
 
@@ -99,7 +99,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 					},
 				}
 
-				allErrs := webhook.validateSpec(rule.Spec)
+				allErrs := webhook.validateSpec(rule.Spec, false)
 				Expect(allErrs).To(HaveLen(1))
 				Expect(allErrs[0].Field).To(Equal("spec.nodeSelector"))
 				Expect(allErrs[0].Type).To(Equal(field.ErrorTypeRequired))
@@ -123,7 +123,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 					},
 				}
 
-				allErrs := webhook.validateSpec(rule.Spec)
+				allErrs := webhook.validateSpec(rule.Spec, false)
 				Expect(allErrs).To(HaveLen(1))
 				Expect(allErrs[0].Field).To(Equal("spec.nodeSelector"))
 				Expect(allErrs[0].Type).To(Equal(field.ErrorTypeInvalid))
@@ -151,7 +151,7 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 				},
 			}
 
-			allErrs := webhook.validateSpec(rule.Spec)
+			allErrs := webhook.validateSpec(rule.Spec, false)
 			Expect(allErrs).To(BeEmpty())
 		})
 	})

--- a/internal/webhook/nodereadinessgaterule_webhook_test.go
+++ b/internal/webhook/nodereadinessgaterule_webhook_test.go
@@ -63,8 +63,8 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 					},
 				},
 			}
-
-			allErrs := webhook.validateSpec(rule.Spec, false)
+			// using isUpdate true to keep the test isolated to nodeSelector validation
+			allErrs := webhook.validateSpec(rule.Spec, true)
 			Expect(allErrs).To(HaveLen(1))
 			Expect(allErrs[0].Field).To(Equal("spec.nodeSelector"))
 		})
@@ -80,7 +80,8 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 				},
 			}
 
-			allErrs := webhook.validateSpec(rule.Spec, false)
+			// using isUpdate true to keep the test isolated to nodeSelector validation
+			allErrs := webhook.validateSpec(rule.Spec, true)
 			Expect(allErrs).To(BeEmpty())
 		})
 
@@ -99,7 +100,8 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 					},
 				}
 
-				allErrs := webhook.validateSpec(rule.Spec, false)
+				// using isUpdate true to keep the test isolated to nodeSelector validation
+				allErrs := webhook.validateSpec(rule.Spec, true)
 				Expect(allErrs).To(HaveLen(1))
 				Expect(allErrs[0].Field).To(Equal("spec.nodeSelector"))
 				Expect(allErrs[0].Type).To(Equal(field.ErrorTypeRequired))
@@ -123,11 +125,76 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 					},
 				}
 
-				allErrs := webhook.validateSpec(rule.Spec, false)
+				// using isUpdate true to keep the test isolated to nodeSelector validation
+				allErrs := webhook.validateSpec(rule.Spec, true)
 				Expect(allErrs).To(HaveLen(1))
 				Expect(allErrs[0].Field).To(Equal("spec.nodeSelector"))
 				Expect(allErrs[0].Type).To(Equal(field.ErrorTypeInvalid))
 			})
+		})
+
+		Context("defaultStatus enforcement", func() {
+			var spec readinessv1alpha1.NodeReadinessRuleSpec
+
+			BeforeEach(func() {
+				spec = readinessv1alpha1.NodeReadinessRuleSpec{
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+					Conditions: []readinessv1alpha1.ConditionRequirement{
+						{
+							Type:           "Ready",
+							RequiredStatus: corev1.ConditionTrue,
+							DefaultStatus:  corev1.ConditionTrue, // offending field
+						},
+					},
+					EnforcementMode: readinessv1alpha1.EnforcementModeBootstrapOnly,
+				}
+			})
+
+			It("should skip defaultStatus check on update (early return)", func() {
+				allErrs := webhook.validateSpec(spec, true)
+				Expect(allErrs).To(BeEmpty())
+			})
+
+			It("should skip defaultStatus check for continuous enforcement", func() {
+				spec.EnforcementMode = readinessv1alpha1.EnforcementModeContinuous
+				allErrs := webhook.validateSpec(spec, false)
+				Expect(allErrs).To(BeEmpty())
+			})
+
+			It("should forbid defaultStatus with bootstrap-only enforcement", func() {
+				allErrs := webhook.validateSpec(spec, false)
+				Expect(allErrs).To(HaveLen(1))
+				Expect(allErrs[0].Field).To(Equal("spec.conditions[0].defaultStatus"))
+				Expect(allErrs[0].Type).To(Equal(field.ErrorTypeForbidden))
+			})
+		})
+
+		It("should accumulate errors across nodeSelector and multiple defaultStatus violations", func() {
+			spec := readinessv1alpha1.NodeReadinessRuleSpec{
+				NodeSelector: metav1.LabelSelector{}, // empty → ErrorTypeRequired
+				Conditions: []readinessv1alpha1.ConditionRequirement{
+					{
+						Type:           "Ready",
+						RequiredStatus: corev1.ConditionTrue,
+						DefaultStatus:  corev1.ConditionFalse,
+					},
+					{Type: "NetworkReady",
+						RequiredStatus: corev1.ConditionTrue,
+						DefaultStatus:  corev1.ConditionTrue,
+					},
+				},
+				EnforcementMode: readinessv1alpha1.EnforcementModeBootstrapOnly,
+			}
+
+			allErrs := webhook.validateSpec(spec, false)
+			Expect(allErrs).To(HaveLen(3))
+			Expect(allErrs[0].Field).To(Equal("spec.nodeSelector"))
+			Expect(allErrs[1].Field).To(Equal("spec.conditions[0].defaultStatus"))
+			Expect(allErrs[2].Field).To(Equal("spec.conditions[1].defaultStatus"))
 		})
 
 		It("should pass validation for valid spec", func() {
@@ -801,6 +868,35 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 			allErrs = webhook.validateNodeReadinessRule(ctx, invalidRule, false)
 			Expect(allErrs).To(HaveLen(1)) // Empty nodeSelector validation
 			Expect(allErrs[0].Field).To(Equal("spec.nodeSelector"))
+
+			// Test defaultStatus used with bootstrap-only enforcement
+			bootstrapDefaultStatusRule := &readinessv1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "bootstrap-defaultstatus-comprehensive"},
+				Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+					Conditions: []readinessv1alpha1.ConditionRequirement{
+						{
+							Type:           "Ready",
+							RequiredStatus: corev1.ConditionTrue,
+							DefaultStatus:  corev1.ConditionFalse,
+						},
+					},
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+					Taint: corev1.Taint{
+						Key:    "readiness.k8s.io/test-key",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					EnforcementMode: readinessv1alpha1.EnforcementModeBootstrapOnly,
+				},
+			}
+
+			allErrs = webhook.validateNodeReadinessRule(ctx, bootstrapDefaultStatusRule, false)
+			Expect(allErrs).To(HaveLen(1))
+			Expect(allErrs[0].Field).To(Equal("spec.conditions[0].defaultStatus"))
+			Expect(allErrs[0].Type).To(Equal(field.ErrorTypeForbidden))
 		})
 	})
 })


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


## Description
<!-- Brief description of changes -->
Adds webhook validation to prevent defaultStatus from being set on any ConditionRequirement when enforcementMode is bootstrap-only.

There was no valid use case found for this combination. defaultStatus is useful when a condition may never appear on a node — but bootstrap-only mode exists precisely to wait for conditions to be explicitly reported before completing the bootstrap gate. The two features work against each other: depending on the configuration, using them together either lets the bootstrap gate pass for a condition that was never actually verified on the node, or prevents the bootstrap from completing indefinitely.

The check runs only on CREATE — updates are excluded via an early return since enforcementMode and conditions are effectively immutable after creation (enforced at the CEL/CRD level). Also updated the schema description with this information.

## Related Issue
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #290 

or

None
-->
Fixes #290 

## Type of Change
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Testing
<!-- How was this tested? -->
- Unit tests (validateSpec): three isolated tests covering the early return on update, the continuous-mode skip, and the single-condition forbidden error — all using a shared BeforeEach spec
- Accumulation test: standalone test verifying that an empty nodeSelector + two conditions each with defaultStatus on bootstrap-only produces all 3 errors simultaneously (no short-circuit)
- Integration test (validateNodeReadinessRule): end-to-end coverage of the new check through the full validation stack inside Full Validation Integration

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
  1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
  2. Add 'Doc #(issue)' after the block if there is a follow up
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Setting defaultStatus on a condition is now forbidden when enforcementMode is "bootstrap-only". The webhook will reject such configurations at creation time with a descriptive error on the offending spec.conditions[i].defaultStatus field.
```
## Documentation

docs/book/src/reference/api-spec.md: Updated the defaultStatus field description in the API reference table to include the same constraint
docs/book/src/user-guide/getting-started.md: Added "Must not be set in bootstrap-only mode" to the defaultStatus field description
docs/book/src/user-guide/concepts.md: Updated the callout from a WARNING to IMPORTANT and rewrote the explanation — from "do not use" guidance to a clear statement that the combination is unsupported and rejected by the admission webhook, with a concise explanation of why the two features work against each other