### PR TITLE
docs: add Problem-Gate Readiness example using defaultStatus

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
 - [Security Agent](./examples/security-agent-readiness.md)
 <!-- - [Device Drivers](./examples/dra-readiness.md) -->
 - [Constrained Impersonation](./examples/constrained-impersonation.md)
+- [Problem-Gate Readiness](./examples/problem-gate-readiness.md)
 
 # Releases
 

--- a/docs/book/src/examples/problem-gate-readiness.md
+++ b/docs/book/src/examples/problem-gate-readiness.md
@@ -1,0 +1,141 @@
+# Problem-Gate Readiness (`defaultStatus`)
+
+This guide demonstrates how to use the `defaultStatus` field on a
+`ConditionRequirement` to build a **problem gate**: a rule guarded by a
+problem-oriented Node condition — reported in the style of
+[Node Problem Detector (NPD)](https://github.com/kubernetes/node-problem-detector)
+— that should default to healthy when the condition hasn't been reported yet,
+rather than blocking the node.
+
+## The Problem
+
+Problem-oriented conditions (like `MemoryPressure`, `DiskPressure`, or a
+custom `MaintenanceRequired` condition reported by NPD) are only ever written
+to a Node's status *when a problem is detected*. On a freshly bootstrapped
+node, NPD may not have run yet, so the condition is completely absent from
+`status.conditions` — not `False`, just missing.
+
+By default, the Node Readiness Controller resolves an absent condition to
+`Unknown`. If a rule requires `requiredStatus: "False"` on that condition,
+`Unknown` does not satisfy it, and the node stays tainted until NPD reports
+the condition at least once. For a problem gate, that's backwards: the
+absence of a problem report should mean "no known problem," not "blocked."
+
+## The Solution
+
+Set `defaultStatus: "False"` alongside `requiredStatus: "False"` on the
+guarded condition:
+
+- If the condition is **absent**, it evaluates to `False` (the configured
+  default) — satisfying `requiredStatus: "False"` — so the node is not
+  gated by the reporter's startup race.
+- If NPD later reports the condition as `True` (a problem was detected), the
+  rule is no longer satisfied and the taint is (re-)applied.
+- The controller still reports the *observed* status (`Unknown` when
+  absent) separately in `status.nodeEvaluations[].conditionResults[].currentStatus`,
+  so you retain full visibility into whether a value came from the Node or
+  from the configured default.
+
+See [Core Concepts: Default Condition Status](../user-guide/concepts.md#default-condition-status-defaultstatus)
+for the full semantics, including why `defaultStatus` is rejected by the
+validating webhook when `enforcementMode` is `bootstrap-only`.
+
+> [!NOTE]
+> All manifests referenced in this guide are available in the
+> [`examples/problem-gate-readiness`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/problem-gate-readiness)
+> directory.
+
+### Prerequisites
+
+Before starting, ensure the Node Readiness Controller is deployed. See the
+[Installation Guide](../user-guide/installation.md) for details.
+
+### 1. Deploy the Problem Reporter (Node Problem Detector)
+
+Deploy NPD with a custom plugin that reports a `MaintenanceRequired`
+condition, defaulting to healthy (`False`) unless a maintenance flag file is
+present on the node:
+
+```yaml
+# npd-maintenance-config.yaml (excerpt)
+maintenance-plugin.json: |
+  {
+    "plugin": "custom",
+    "source": "maintenance-monitor",
+    "conditions": [
+      { "type": "MaintenanceRequired", "reason": "NoMaintenanceScheduled", ... }
+    ],
+    "rules": [
+      { "type": "permanent", "condition": "MaintenanceRequired", "path": "/config/plugin/check-maintenance.sh" }
+    ]
+  }
+```
+
+```sh
+kubectl apply -f examples/problem-gate-readiness/npd-rbac.yaml
+kubectl apply -f examples/problem-gate-readiness/npd-maintenance-config.yaml
+kubectl apply -f examples/problem-gate-readiness/npd-maintenance-daemonset.yaml
+```
+
+### 2. Create the Node Readiness Rule
+
+```yaml
+# maintenance-readiness-rule.yaml
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: maintenance-problem-gate-rule
+spec:
+  conditions:
+    - type: "MaintenanceRequired"
+      requiredStatus: "False"
+      defaultStatus: "False"
+
+  taint:
+    key: "readiness.k8s.io/problem-gate"
+    effect: "NoSchedule"
+
+  # defaultStatus is not supported with "bootstrap-only" rules.
+  enforcementMode: "continuous"
+
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker: ""
+```
+
+```sh
+kubectl apply -f examples/problem-gate-readiness/maintenance-readiness-rule.yaml
+```
+
+## Verification
+
+1. **Before NPD has reported anything**, confirm the node is not tainted even
+   though `MaintenanceRequired` is absent from its conditions:
+
+   ```sh
+   kubectl get node <node-name> -o jsonpath='{.status.conditions[?(@.type=="MaintenanceRequired")]}'
+   kubectl get node <node-name> -o jsonpath='{.spec.taints}'
+   ```
+
+2. **Flag the node for maintenance** (simulated by creating a file the
+   plugin's check script looks for) and confirm the taint is applied:
+
+   ```sh
+   # on the node
+   sudo mkdir -p /var/run/maintenance && sudo touch /var/run/maintenance/scheduled
+   ```
+
+   ```sh
+   kubectl get node <node-name> -o jsonpath='{.status.conditions[?(@.type=="MaintenanceRequired")]}' | jq .
+   kubectl get node <node-name> -o jsonpath='{.spec.taints}'
+   ```
+
+   You should see `MaintenanceRequired=True` and the
+   `readiness.k8s.io/problem-gate=NoSchedule` taint applied.
+
+3. **Clear the flag** and confirm the taint is removed again:
+
+   ```sh
+   # on the node
+   sudo rm /var/run/maintenance/scheduled
+   ```

--- a/examples/problem-gate-readiness/README.md
+++ b/examples/problem-gate-readiness/README.md
@@ -1,0 +1,59 @@
+# Problem-Gate Readiness (defaultStatus)
+
+This example demonstrates the `defaultStatus` field on a `ConditionRequirement`,
+used to implement a "problem gate": a rule guarded by a problem-oriented
+condition (in the style of [Node Problem Detector](https://github.com/kubernetes/node-problem-detector))
+that should default to healthy when the condition is absent, rather than
+blocking the node until the reporter has run at least once.
+
+See the [Problem-Gate Readiness guide](https://kubernetes-sigs.github.io/node-readiness-controller/examples/problem-gate-readiness.html)
+for the full walkthrough, and
+[Core Concepts: Default Condition Status](https://kubernetes-sigs.github.io/node-readiness-controller/user-guide/concepts.html#default-condition-status-defaultstatus)
+for background on `defaultStatus`.
+
+## Files
+
+- `npd-maintenance-config.yaml` — NPD custom-plugin ConfigMap reporting a
+  `MaintenanceRequired` condition.
+- `npd-maintenance-daemonset.yaml` — NPD DaemonSet running the plugin above.
+- `npd-rbac.yaml` — ServiceAccount/ClusterRole/ClusterRoleBinding for the
+  DaemonSet to patch Node status.
+- `maintenance-readiness-rule.yaml` — `NodeReadinessRule` with
+  `requiredStatus: "False"` and `defaultStatus: "False"` on
+  `MaintenanceRequired`, `enforcementMode: "continuous"`.
+
+## Apply
+
+```sh
+kubectl apply -f npd-rbac.yaml
+kubectl apply -f npd-maintenance-config.yaml
+kubectl apply -f npd-maintenance-daemonset.yaml
+kubectl apply -f maintenance-readiness-rule.yaml
+```
+
+## Verify
+
+A node with no `MaintenanceRequired` condition yet (NPD hasn't run, or hasn't
+flagged anything) is not tainted:
+
+```sh
+kubectl get node <node-name> -o jsonpath='{.spec.taints}'
+```
+
+Simulate a maintenance flag on the node (this triggers the plugin's
+`check-maintenance.sh` to exit non-zero) and confirm the taint is applied:
+
+```sh
+# on the node
+sudo mkdir -p /var/run/maintenance && sudo touch /var/run/maintenance/scheduled
+
+kubectl get node <node-name> -o jsonpath='{.status.conditions[?(@.type=="MaintenanceRequired")]}' | jq .
+kubectl get node <node-name> -o jsonpath='{.spec.taints}'
+```
+
+Remove the flag and confirm the taint is removed again:
+
+```sh
+# on the node
+sudo rm /var/run/maintenance/scheduled
+```

--- a/examples/problem-gate-readiness/maintenance-readiness-rule.yaml
+++ b/examples/problem-gate-readiness/maintenance-readiness-rule.yaml
@@ -1,0 +1,31 @@
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: maintenance-problem-gate-rule
+spec:
+  # MaintenanceRequired is a problem-oriented condition (NPD-style): it is only
+  # ever reported when a problem is detected. On a freshly bootstrapped node,
+  # NPD may not have written this condition yet.
+  conditions:
+    - type: "MaintenanceRequired"
+      requiredStatus: "False"
+      # defaultStatus:False makes an absent condition evaluate as "no problem",
+      # so the node is not blocked by the reporter's startup race. Once NPD
+      # reports MaintenanceRequired=True, the taint is (re-)applied.
+      defaultStatus: "False"
+
+  # Taint managed by this rule
+  taint:
+    key: "readiness.k8s.io/problem-gate"
+    effect: "NoSchedule"
+
+  # "continuous" mode re-applies the taint any time MaintenanceRequired flips
+  # to True later in the node's lifecycle, not just during bootstrap.
+  # Note: defaultStatus is rejected by the validating webhook when
+  # enforcementMode is "bootstrap-only" (see docs/book/src/user-guide/concepts.md).
+  enforcementMode: "continuous"
+
+  # Update to target only the nodes that need this guardrail
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker: ""

--- a/examples/problem-gate-readiness/npd-maintenance-config.yaml
+++ b/examples/problem-gate-readiness/npd-maintenance-config.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: npd-maintenance-config
+  namespace: kube-system
+data:
+  # NPD uses problem-oriented conditions. MaintenanceRequired=True means an
+  # operator (or an external signal, such as a cloud provider maintenance
+  # notice) has flagged the node for maintenance.
+  maintenance-plugin.json: |
+    {
+      "plugin": "custom",
+      "pluginConfig": {
+        "invoke_interval": "30s",
+        "timeout": "5s",
+        "max_output_length": 80,
+        "concurrency": 1
+      },
+      "source": "maintenance-monitor",
+      "conditions": [
+        {
+          "type": "MaintenanceRequired",
+          "reason": "NoMaintenanceScheduled",
+          "message": "No maintenance has been scheduled for this node"
+        }
+      ],
+      "rules": [
+        {
+          "type": "permanent",
+          "condition": "MaintenanceRequired",
+          "reason": "MaintenanceScheduled",
+          "path": "/config/plugin/check-maintenance.sh"
+        }
+      ]
+    }
+
+  check-maintenance.sh: |
+    #!/bin/bash
+    # Exit 0 when no maintenance is scheduled (MaintenanceRequired=False).
+    # Exit 1 when maintenance has been flagged (MaintenanceRequired=True).
+    if [ -f /var/run/maintenance/scheduled ]; then
+      echo "Maintenance has been flagged for this node"
+      exit 1
+    fi
+    exit 0

--- a/examples/problem-gate-readiness/npd-maintenance-daemonset.yaml
+++ b/examples/problem-gate-readiness/npd-maintenance-daemonset.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-problem-detector-maintenance
+  namespace: kube-system
+  labels:
+    app: node-problem-detector
+    component: maintenance-monitor
+spec:
+  selector:
+    matchLabels:
+      app: node-problem-detector
+      component: maintenance-monitor
+  template:
+    metadata:
+      labels:
+        app: node-problem-detector
+        component: maintenance-monitor
+    spec:
+      serviceAccountName: node-problem-detector-maintenance
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute
+      containers:
+      - name: node-problem-detector
+        image: registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.19
+        command:
+        - /node-problem-detector
+        - --logtostderr
+        - --config.custom-plugin-monitor=/config/maintenance-plugin.json
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: config
+          mountPath: /config
+          readOnly: true
+        - name: plugin
+          mountPath: /config/plugin
+          readOnly: true
+        - name: maintenance-flag
+          mountPath: /var/run/maintenance
+          readOnly: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+      volumes:
+      - name: config
+        configMap:
+          name: npd-maintenance-config
+          items:
+          - key: maintenance-plugin.json
+            path: maintenance-plugin.json
+      - name: plugin
+        configMap:
+          name: npd-maintenance-config
+          defaultMode: 0755
+          items:
+          - key: check-maintenance.sh
+            path: check-maintenance.sh
+      - name: maintenance-flag
+        hostPath:
+          path: /var/run/maintenance
+          type: DirectoryOrCreate

--- a/examples/problem-gate-readiness/npd-rbac.yaml
+++ b/examples/problem-gate-readiness/npd-rbac.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-problem-detector-maintenance
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-problem-detector-maintenance
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-problem-detector-maintenance
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-problem-detector-maintenance
+subjects:
+- kind: ServiceAccount
+  name: node-problem-detector-maintenance
+  namespace: kube-system


### PR DESCRIPTION
## Description

Adds a new worked example demonstrating the `defaultStatus` field introduced in #283, as requested in #289.

The example uses the exact scenario already covered by the integration test in `internal/controller/nodereadinessrule_controller_test.go` ("should satisfy a rule when an absent condition matches via defaultStatus (problem-gate scenario)") and documented conceptually in `docs/book/src/user-guide/concepts.md` ("Use Case: Problem Gating (Default-Allow)"): an NPD-style `MaintenanceRequired` condition that should default to healthy when absent, so a freshly bootstrapped node isn't gated by the reporter's startup race, following the same format as the existing CNI/Security Agent examples.

Adds:
- `examples/problem-gate-readiness/`: NPD custom-plugin ConfigMap + DaemonSet + RBAC reporting `MaintenanceRequired`, and a `NodeReadinessRule` with `requiredStatus: "False"` / `defaultStatus: "False"` / `enforcementMode: "continuous"`, plus a README with apply/verify steps.
- `docs/book/src/examples/problem-gate-readiness.md`: the full guide, linked from `SUMMARY.md` under "Examples".

Docs-only change; no Go code, CRD, or API types touched. YAML manifests validated with `yaml.safe_load_all`.

## Related Issue

Fixes #289

## Type of Change

/kind documentation