### PR TITLE
cleanup: fix format and godot lint issue

### DIFF
--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+//nolint:godot
 const (
 	// bootstrapAnnotationPrefix is the common prefix for all bootstrap completion
 	// annotations on a Node. The suffix is the rule's metadata.uid (RFC 4122 UUID,
@@ -51,8 +52,6 @@ func bootstrapAnnotationValue(ruleName string) string {
 	}
 	return string(b)
 }
-
-
 
 // legacyBootstrapAnnotationKey returns the old-format annotation key used
 // before the UID migration: readiness.k8s.io/bootstrap-completed-<ruleName>.

--- a/internal/controller/helper_unit_test.go
+++ b/internal/controller/helper_unit_test.go
@@ -52,5 +52,3 @@ func TestLegacyBootstrapAnnotationKey(t *testing.T) {
 	key := legacyBootstrapAnnotationKey("my-rule")
 	g.Expect(key).To(Equal("readiness.k8s.io/bootstrap-completed-my-rule"))
 }
-
-

--- a/internal/controller/node_controller_reproduction_test.go
+++ b/internal/controller/node_controller_reproduction_test.go
@@ -130,5 +130,4 @@ var _ = Describe("Node Controller Reproduction", func() {
 		})
 	})
 
-
 })

--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -73,7 +73,7 @@ func (w *NodeReadinessRuleWebhook) validateSpec(
 		allErrs = append(allErrs, field.Required(field.NewPath("spec", "nodeSelector"), "nodeSelector must not be empty"))
 	}
 
-	// skip below checks for update because both `enforcementMode` and `conditions` 
+	// skip below checks for update because both `enforcementMode` and `conditions`
 	// are immutable as constrained by CEL XValidation rules
 	if isUpdate {
 		return allErrs


### PR DESCRIPTION
## Description

This PR adds the formatting applied by `go fmt` when running `make build`. 

It also adds a `nolint:godot` directive to a constant with a comment that is failing on CI for missing a dot. 
Edit: I tried adding a dot, moving words around, changing the sequence of words in the paragraph, but there seems to be a bug in this linter that I could only get it to pass with the nolint directive.

## Related Issue

None

## Type of Change

/kind cleanup

## Checklist

- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

None