### PR TITLE
fix: enhance uninstall target to wait for full deletion of CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,9 +320,12 @@ install: manifests $(KUSTOMIZE) ## Install CRDs into the K8s cluster specified i
 	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) apply -f -; else echo "No CRDs to install; skipping."; fi
 
 .PHONY: uninstall
-uninstall: manifests $(KUSTOMIZE) ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
-	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
+uninstall: manifests $(KUSTOMIZE) ## Uninstall CRDs from the K8s cluster and wait for full deletion. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	@set -euo pipefail; \
+	out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -z "$$out" ]; then echo "No CRDs to delete; skipping."; exit 0; fi; \
+	echo "$$out" | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -; \
+	echo "$$out" | $(KUBECTL) wait --for=delete --timeout=180s -f -
 
 .PHONY: deploy
 deploy: build-manifests-temp ## Deploy controller to the K8s cluster. Use ENABLE_METRICS=true and ENABLE_TLS=true to enable features.


### PR DESCRIPTION

## Description

This PR adds a wait step to the uninstall target in Makefile. 

Not waiting for a full deletion was causing e2e to fail when trying to create a CRD in a given step while the previous step hadn't finished uninstalling the CRD:

```
STEP: applying the bootstrap-only rule @ 07/10/26 00:41:41.226
  running: "kubectl apply -f test/e2e/testdata/bootstrap-only-rule.yaml"
  [FAILED] in [It] - /home/vitorfloriano/go/src/github.com/vitorfloriano/node-readiness-controller/test/e2e/e2e_test.go:232 @ 07/10/26 00:41:41.318

FAILED] [9.539 seconds]
Manager NodeReadinessRule [It] should handle bootstrap-only mode correctly
/home/vitorfloriano/go/src/github.com/vitorfloriano/node-readiness-controller/test/e2e/e2e_test.go:202

  [FAILED] Unexpected error:
      <*fmt.wrapError | 0xc0003c43a0>: 
      "kubectl apply -f test/e2e/testdata/bootstrap-only-rule.yaml" failed with error "Error from server (Forbidden): error when creating \"test/e2e/testdata/bootstrap-only-rule.yaml\": nodereadinessrules.readiness.node.x-k8s.io \"bootstrap-test-rule\" is forbidden: create not allowed while custom resource definition is terminating\n": exit status 1
      {
          msg: "\"kubectl apply -f test/e2e/testdata/bootstrap-only-rule.yaml\" failed with error \"Error from server (Forbidden): error when creating \\\"test/e2e/testdata/bootstrap-only-rule.yaml\\\": nodereadinessrules.readiness.node.x-k8s.io \\\"bootstrap-test-rule\\\" is forbidden: create not allowed while custom resource definition is terminating\\n\": exit status 1",
          err: <*exec.ExitError | 0xc0003c4380>{
              ProcessState: {
                  pid: 796641,
                  status: 256,
                  rusage: {
                      Utime: {Sec: 0, Usec: 91127},
                      Stime: {Sec: 0, Usec: 27276},
                      Maxrss: 47684,
                      Ixrss: 0,
                      Idrss: 0,
                      Isrss: 0,
                      Minflt: 4382,
                      Majflt: 0,
                      Nswap: 0,
                      Inblock: 0,
                      Oublock: 24,
                      Msgsnd: 0,
                      Msgrcv: 0,
                      Nsignals: 0,
                      Nvcsw: 640,
                      Nivcsw: 9,
                  },
              },
              Stderr: nil,
          },
      }
  occurred
  In [It] at: /home/vitorfloriano/go/src/github.com/vitorfloriano/node-readiness-controller/test/e2e/e2e_test.go:232 @ 07/10/26 00:41:41.318
```

## Related Issue

None

## Type of Change

/kind bug

## Testing

Ran e2e locally and observed the step succeed.

## Does this PR introduce a user-facing change?

Now uninstall waits for the full deletion of the CRD.

```release-note
`make uninstall` waits for full deletion of the CRD
```