### PR TITLE
cleanup(e2e): update bootstrap annotation cmd and assertion

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -245,14 +245,27 @@ status:
 				return !strings.Contains(output, "readiness.k8s.io/TestReady")
 			}, 30*time.Second, 2*time.Second).Should(BeTrue())
 
+			By("getting the bootstrap rule UID")
+			var ruleUID string
+			Eventually(func() string {
+				cmd := exec.Command("kubectl", "get", "nodereadinessrule", "bootstrap-test-rule", "-o", "jsonpath={.metadata.uid}")
+				uid, err := utils.Run(cmd)
+				if err != nil {
+					return ""
+				}
+				ruleUID = strings.TrimSpace(uid)
+				return ruleUID
+			}, 10*time.Second, 1*time.Second).Should(Not(BeEmpty()))
+
 			By("verifying node has bootstrap completion annotation")
 			Eventually(func() bool {
-				cmd := exec.Command("kubectl", "get", "node", nodeName, "-o", "jsonpath={.metadata.annotations.readiness\\.k8s\\.io/bootstrap-completed-bootstrap-test-rule}")
+				cmd := exec.Command("kubectl", "get", "node", nodeName, "-o", "jsonpath={.metadata.annotations}")
 				output, err := utils.Run(cmd)
 				if err != nil {
 					return false
 				}
-				return strings.Contains(output, "true")
+				expectedAnnotation := fmt.Sprintf("readiness.k8s.io/bootstrap-completed-%s", ruleUID)
+				return strings.Contains(output, expectedAnnotation)
 			}, 30*time.Second, 2*time.Second).Should(BeTrue())
 
 			By("updating node condition back to False")


### PR DESCRIPTION
## Description

This PR fixes the command used to retrieve the bootstrap annotation in e2e. 

The command was not returning any values, so the assertion would eventually timeout, failing the test case. 

You can see this failing in CI as well: https://github.com/kubernetes-sigs/node-readiness-controller/actions/runs/29067616799/job/86282441163?pr=296#step:7:141

## Related Issue

None

## Type of Change

/kind cleanup
/kind failing-test

## Testing

Ran e2e manually and observed the step not failing anymore.

## Checklist

- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

None