### PR TITLE
cleanup(e2e): reorder uninstall CRD to avoid getting stuck

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -103,12 +103,12 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 		}
 
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
 		By("uninstalling CRDs")
 		cmd = exec.Command("make", "uninstall")
+		_, _ = utils.Run(cmd)
+
+		By("undeploying the controller-manager")
+		cmd = exec.Command("make", "undeploy")
 		_, _ = utils.Run(cmd)
 
 		By("removing manager namespace")


### PR DESCRIPTION
## Description

This PR swaps the order in which the e2e test uninstalls the CRD and undeploys the controller, to avoid getting stuck in a pending state, causing flakes.

See: https://node-readiness-controller.sigs.k8s.io/user-guide/installation.html?highlight=finalizer#uninstallation

## Related Issue

None

## Type of Change

/kind cleanup
/kind failing-test
/kind flake

## Testing

Ran e2e locally.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

None