### PR TITLE
fix gcloud image tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,15 +1,18 @@
-# See https://cloud.google.com/cloud-build/docs/build-config
-
+# See https://cloud.google.com/cloud-build/docs/build-config for gcb schema
+# See https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing#build-example
+# for example config
+# See https://console.cloud.google.com/artifacts/docker/k8s-staging-test-infra/us/gcr.io/gcb-docker-gcloud
+# for available images
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
     entrypoint: ./scripts/build-and-publish-image.sh
     env:
     - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller
     - COMPONENT=controller
 
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
     entrypoint: ./scripts/build-and-publish-image.sh
     env:
     - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller


### PR DESCRIPTION
## Description
Fix post-node-readiness-controller-push-images job: https://testgrid.k8s.io/sig-node-image-pushes#post-node-readiness-controller-push-images

## Related Issue

Fixes https://github.com/kubernetes-sigs/node-readiness-controller/issues/302

## Type of Change

/kind bug
/kind regression

## Testing
Not testable. Verified the 'latest' image exists here:  https://console.cloud.google.com/artifacts/docker/k8s-staging-test-infra/us/gcr.io/gcb-docker-gcloud and follows sigs.k8s.io/kind cloudbuild convention: https://github.com/kubernetes-sigs/kind/pull/4068

## Checklist
- [ ] `make test` passes
- [ ] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```
