### PR TITLE
fix gcloud image tag (backport of #303 to release-v0.4.0)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,15 +1,18 @@
-# See https://cloud.google.com/cloud-build/docs/build-config
-
+# See https://cloud.google.com/cloud-build/docs/build-config for gcb schema
+# See https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing#build-example
+# for example config
+# See https://console.cloud.google.com/artifacts/docker/k8s-staging-test-infra/us/gcr.io/gcb-docker-gcloud
+# for available images
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
     entrypoint: ./scripts/build-and-publish-image.sh
     env:
     - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller
     - COMPONENT=controller
 
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
     entrypoint: ./scripts/build-and-publish-image.sh
     env:
     - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller

--- a/hack/verify-govulncheck.sh
+++ b/hack/verify-govulncheck.sh
@@ -26,8 +26,15 @@ if ! command -v govulncheck &>/dev/null; then
   go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
 fi
 
-# NRC_VERIFY_GIT_BRANCH is populated in verify CI jobs (e.g. GITHUB_BASE_REF).
-BRANCH="${NRC_VERIFY_GIT_BRANCH:-main}"
+# NRC_VERIFY_GIT_BRANCH is populated in verify CI jobs (e.g. GITHUB_BASE_REF
+# for GitHub Actions, PULL_BASE_REF for Prow).
+BRANCH="${NRC_VERIFY_GIT_BRANCH:-${PULL_BASE_REF:-main}}"
+
+# Prow (and other shallow/single-branch checkouts) may not have the base
+# branch available as a local ref, so fetch it if needed.
+if ! git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  git fetch --quiet origin "${BRANCH}:${BRANCH}"
+fi
 
 # Create a temp directory and clean it up on exit.
 TMPDIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- Backports #303 to `release-v0.4.0`.
- `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20251211-3eba3d0954` was deleted from the registry, breaking the post-submit image push job (`post-node-readiness-controller-push-images`) on both `main` and `release-v0.4.0`.
- The fix landed on `main` via #303 but `release-v0.4.0` still has the broken pin, so the v0.4.0 staging image push has been failing since the release cut.

## Test plan
- [x] Cherry-picked cleanly from `main` (d45f1f4)
- [x] Confirm the post-submit image push job succeeds once merged and staging images for v0.4.0 appear in `k8s-staging-images/node-readiness-controller`