### PR TITLE
fix: verify-govulncheck should handle Prow's shallow checkout and non-main base branches

### DIFF
--- a/hack/verify-govulncheck.sh
+++ b/hack/verify-govulncheck.sh
@@ -26,8 +26,15 @@ if ! command -v govulncheck &>/dev/null; then
   go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
 fi
 
-# NRC_VERIFY_GIT_BRANCH is populated in verify CI jobs (e.g. GITHUB_BASE_REF).
-BRANCH="${NRC_VERIFY_GIT_BRANCH:-main}"
+# NRC_VERIFY_GIT_BRANCH is populated in verify CI jobs (e.g. GITHUB_BASE_REF
+# for GitHub Actions, PULL_BASE_REF for Prow).
+BRANCH="${NRC_VERIFY_GIT_BRANCH:-${PULL_BASE_REF:-main}}"
+
+# Prow (and other shallow/single-branch checkouts) may not have the base
+# branch available as a local ref, so fetch it if needed.
+if ! git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  git fetch --quiet origin "${BRANCH}:${BRANCH}"
+fi
 
 # Create a temp directory and clean it up on exit.
 TMPDIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary
`hack/verify-govulncheck.sh` hardcoded a fallback base branch of `main` and assumed it already existed as a local git ref. That holds for the GitHub Actions `govulncheck` workflow (NRC_VERIFY_GIT_BRANCH` set from `github.base_ref`), but does not work for Prow.

eg: in  #304  `pull-node-readiness-controller-verify-all` job failed on `release-0.4.0`: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_node-readiness-controller/304/pull-node-readiness-controller-verify-all/2076116037765435392.

```
Creating worktree for base branch 'main'...
fatal: invalid reference: main
```

This is because`NRC_VERIFY_GIT_BRANCH` is never set

Fix:

- Prefer Prow's `PULL_BASE_REF` env var when `NRC_VERIFY_GIT_BRANCH` isn't set.
- Fetch the base branch if it isn't already present as a local ref and Prow's checkout doesn't have it.

This was root-caused and patch generated by LLM, I verified env value set in pod yaml

```
    - name: PULL_BASE_REF
      value: release-v0.4.0
```


## Test plan
- [x] `bash -n hack/verify-govulncheck.sh`
- [x] Same fix applied to `release-v0.4.0` in #304 to unblock that PR's `verify-all` job