### PR TITLE
Adding READMEs to improve discoverability of condition reporting patterns

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,69 @@
+# Node Readiness Controller Examples
+
+This directory contains examples demonstrating different ways to report node conditions that can be consumed by the Node Readiness Controller (NRC).
+
+NRC does not perform health checks itself. Instead, it watches `node.status.conditions` on Kubernetes Node objects and evaluates those conditions against configured `NodeReadinessRule` resources. When a rule matches, NRC applies or removes the corresponding readiness taints.
+
+The examples in this directory differ only in how the node condition is produced. In every case, the condition is published to `node.status.conditions`, and NRC reacts to the reported state without requiring any knowledge of the reporting component.
+
+## Shared Architecture
+
+Each example in this directory follows the same interaction model:
+
+```text
+Health Check
+      │
+      ▼
+Condition Producer
+      │
+      ▼
+node.status.conditions
+      │
+      ▼
+Node Readiness Controller
+      │
+      ▼
+Readiness Taints
+```
+
+The condition producer is responsible for determining the health of a node component and publishing the result as a node condition. The producer may be a dedicated reporting agent, the component itself, Node Problem Detector (NPD), or another implementation.
+
+## Available Examples
+
+The examples in this directory demonstrate different ways of producing node conditions for common node readiness scenarios. While the reporting mechanism varies, each example publishes a node condition that NRC evaluates through a `NodeReadinessRule`.
+
+### `cni-readiness/`
+
+Demonstrates using readiness-condition-reporter to monitor a CNI plugin (Calico) through its HTTP health endpoint and publish the result as a node condition.
+
+Reporting mechanism: readiness-condition-reporter as a standalone DaemonSet
+
+### `security-agent-readiness/`
+
+Demonstrates two different implementations for reporting the readiness of a security agent:
+
+- **`nrr-variant/`** uses `readiness-condition-reporter` as a sidecar to publish the condition via Falco's HTTP health endpoint.
+- **`npd-variant/`** uses a Node Problem Detector (NPD) custom plugin to evaluate Falco health and publish the condition directly on the node.
+
+These variants demonstrate that the reporting mechanism can change without requiring changes to NRC.
+
+Reporting mechanisms: readiness-condition-reporter (sidecar), Node Problem Detector (NPD)
+
+### `static-pod/`
+
+Demonstrates deploying NRC itself as a static pod on control-plane nodes. This is suited for clusters where the controller needs to be available during early bootstrap, before the API server is fully operational, or where high availability of the controller across control-plane nodes is required.
+
+### `constrained-impersonation/`
+
+Demonstrates the same CNI readiness pattern as `cni-readiness/`, using the constrained node impersonation feature of `readiness-condition-reporter`. Each reporter pod impersonates its own node's identity when writing conditions, so that a compromised reporter can only affect the node it runs on.
+
+## Reporting Mechanisms
+
+Node conditions can be reported to NRC in several ways. The examples in this
+directory demonstrate the following mechanisms:
+
+| Mechanism | Description | Examples |
+|---|---|---|
+| `readiness-condition-reporter` (DaemonSet) | A standalone DaemonSet checks an HTTP endpoint and writes the condition | `cni-readiness/`, `constrained-impersonation/` |
+| `readiness-condition-reporter` (sidecar) | The reporter runs as a sidecar inside the component's own pod | `security-agent-readiness/nrr-variant/` |
+| Node Problem Detector (NPD) | An NPD custom plugin script runs on the node and writes the condition | `security-agent-readiness/npd-variant/` |

--- a/examples/cni-readiness/README.md
+++ b/examples/cni-readiness/README.md
@@ -1,6 +1,8 @@
 # CNI Readiness Example (Calico)
 
-This example demonstrates how to use the Node Readiness Controller to ensure nodes are only marked ready for workloads after the CNI (Calico) has fully initialized.
+This example demonstrates using `readiness-condition-reporter` to monitor the Calico CNI health endpoint and publish the result as a Kubernetes node condition. Node Readiness Controller (NRC) watches the reported node condition and removes the startup taint once the configured NodeReadinessRule is satisfied.
+
+NRC does not communicate directly with Calico or the reporter. It simply watches `node.status.conditions` and evaluates the configured readiness rule.
 
 ### How it works:
 1. Nodes join with a `readiness.k8s.io/NetworkReady=pending:NoSchedule` taint.
@@ -10,3 +12,13 @@ This example demonstrates how to use the Node Readiness Controller to ensure nod
 3. The `NodeReadinessRule` (`network-readiness-rule.yaml`) instructs the controller to remove the startup taint once the `projectcalico.org/CalicoReady` condition becomes `True`.
 4. The reporter is deployed with `hostNetwork: true` to reach Calico's local health endpoint.
 5. The reporter needs a dedicated ServiceAccount (`cni-reporter`) with permissions to patch node status.
+
+## Files
+
+| File | Description |
+|---|---|
+| `cni-reporter-ds.yaml` | `readiness-condition-reporter` DaemonSet that checks Calico's health endpoint and writes the node condition |
+| `network-readiness-rule.yaml` | `NodeReadinessRule` that instructs NRC to manage the `readiness.k8s.io/NetworkReady` taint based on the `projectcalico.org/CalicoReady` condition |
+| `network-readiness-dryrun-rule.yaml` | A dry-run variant of the rule for observing NRC behaviour without applying taints |
+| `calico-rbac-node-status-patch-role.yaml` | RBAC permissions allowing the reporter's `ServiceAccount` to patch node status |
+| `apply-calico.sh` | Script to deploy Calico with the reporter injected as a sidecar |

--- a/examples/security-agent-readiness/README.md
+++ b/examples/security-agent-readiness/README.md
@@ -1,0 +1,31 @@
+# Security Agent Readiness
+
+This example demonstrates two independent approaches for reporting the readiness of a security agent (Falco) to Node Readiness Controller (NRC).
+
+In both approaches, the reporting component is responsible for determining the health of Falco and publishing the result as a Kubernetes node condition. NRC does not perform the health check itself. Instead, it watches the reported node condition and evaluates it using a `NodeReadinessRule` to manage readiness taints.
+
+The two variants differ only in how the node condition is produced.
+
+## `nrr-variant/`
+
+Uses `readiness-condition-reporter` as a sidecar to publish a node condition representing Falco readiness.
+
+The reporter checks Falco's HTTP health endpoint (`localhost:8765/healthz`) and publishes the result as `falco.org/FalcoReady`. The `NodeReadinessRule` removes the startup taint when `falco.org/FalcoReady` is `True`.
+
+This approach is well suited when the component exposes an HTTP health endpoint that can be checked from within the same pod.
+
+## `npd-variant/`
+
+Uses Node Problem Detector (NPD) with a custom plugin that evaluates Falco health and publishes a node condition.
+
+The NPD plugin checks whether Falco's port (`8765`) is reachable on the node and publishes the result as `falco.org/FalcoNotReady`. This is a problem-oriented condition, following the same convention as built-in Kubernetes node conditions such as `MemoryPressure` and `DiskPressure`, where `True` means a problem exists and `False` means the component is healthy. The `NodeReadinessRule` removes the startup taint when `falco.org/FalcoNotReady` is `False`.
+
+This approach is well suited when health is best determined by running checks directly on the node, such as inspecting local ports, processes, or files, without requiring an HTTP endpoint.
+
+## Shared files
+
+| File | Description |
+|---|---|
+| `kind-cluster-config.yaml` | Kind cluster configuration for local testing. Worker nodes join with the `readiness.k8s.io/security-agent-ready=pending:NoSchedule` startup taint pre-applied. |
+| `setup-falco.sh` | Script to install Falco on the cluster |
+| `add-falco-toleration.sh` | Script to add a toleration to Falco so it can run on tainted nodes |

--- a/examples/static-pod/README.md
+++ b/examples/static-pod/README.md
@@ -1,0 +1,35 @@
+# Static Pod Deployment
+
+This example demonstrates deploying Node Readiness Controller (NRC) itself as a static pod on control-plane nodes.
+
+## Why deploy NRC as a static pod?
+
+In most clusters, NRC is deployed as a standard Kubernetes `Deployment`. For clusters that require NRC to be available during early node bootstrap, before the API server is fully operational or that need the controller to be distributed across control-plane nodes for high availability, deploying NRC as a static pod on each control-plane node is an alternative.
+
+## How it works
+
+1. The NRC pod manifest (`node-readiness-controller.yaml`) is placed in `/etc/kubernetes/manifests/` on each control-plane node.
+2. Kubelet on each control-plane node starts NRC directly from the manifest, without involving the scheduler.
+3. An init container copies the node's kubeconfig to a shared volume and sets its permissions, making it accessible to the non-root NRC process.
+4. NRC runs with `hostNetwork: true` and `priorityClassName: system-node-critical`, consistent with other control-plane static pods.
+
+## Files
+
+| File | Description |
+|---|---|
+| `node-readiness-controller.yaml` | NRC pod manifest for static pod deployment. Place this file in `/etc/kubernetes/manifests/` on each control-plane node. |
+| `kind-static-pod.yaml` | Kind cluster configuration for local testing. Creates a three-control-plane cluster with `node-readiness-controller.yaml` pre-mounted at the static pod path on each control-plane node, and two worker nodes with a `readiness.k8s.io/NetworkReady=pending:NoSchedule` startup taint. |
+
+## Local testing
+
+```bash
+kind create cluster --config kind-static-pod.yaml
+```
+
+After the cluster starts, verify NRC is running as a static pod on the control-plane nodes:
+
+```bash
+kubectl get pods -n kube-system | grep node-readiness-controller
+```
+
+You should see one mirror pod per control-plane node, each with a `-<nodename>` suffix.


### PR DESCRIPTION
Add READMEs to examples directory

This PR adds README files to the `examples/` directory to make it clear for users how node conditions can be reported to NRC, and what options are available.

NRC does not restrict which component reports a condition and anything that writes to `node.status.conditions` works. The existing examples already demonstrate multiple reporting mechanisms, but this was not surfaced clearly to users browsing the examples.

It addresses feedback that it was unclear how conditions can be reported to NRC and that the examples should show different options explicitly. With these READMEs, a user landing on the examples directory can immediately see the available reporting mechanisms and pick the example that fits their use case.