### PR TITLE
feat: support querying rules by field-selectors

### DIFF
--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -321,9 +321,12 @@ type DryRunResults struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=nrr
 // +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.enforcementMode`,description="The enforcement mode of the rule: bootstrap-only or continuous."
+// +kubebuilder:selectablefield:JSONPath=`.spec.enforcementMode`
 // +kubebuilder:printcolumn:name="Taint",type=string,JSONPath=`.spec.taint.key`,description="The readiness taint applied by this rule."
+// +kubebuilder:selectablefield:JSONPath=`.spec.taint.key`
 // +kubebuilder:printcolumn:name="Effect",type=string,JSONPath=`.spec.taint.effect`,description="The taint effect: NoSchedule, PreferNoSchedule or NoExecute."
 // +kubebuilder:printcolumn:name="DryRun",type=boolean,JSONPath=`.spec.dryRun`,description="Whether the rule is in dry-run mode and only previews taint changes."
+// +kubebuilder:selectablefield:JSONPath=`.spec.dryRun`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of this resource"
 
 // NodeReadinessRule is the Schema for the NodeReadinessRules API.

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -453,6 +453,10 @@ spec:
         required:
         - spec
         type: object
+    selectableFields:
+    - jsonPath: .spec.enforcementMode
+    - jsonPath: .spec.taint.key
+    - jsonPath: .spec.dryRun
     served: true
     storage: true
     subresources:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -676,6 +676,107 @@ spec:
 			exec.Command("kubectl", "delete", "node", nodeName).Run()
 			exec.Command("kubectl", "delete", "nodereadinessrule", "event-test-rule").Run()
 		})
+
+		It("should support FieldSelectors for enforcementMode and taint key", func() {
+			By("applying test rules with different modes and taint keys")
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(`
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: selector-test-bootstrap
+spec:
+  conditions:
+    - type: SelectorTest
+      requiredStatus: "True"
+  taint:
+    key: readiness.k8s.io/test-bootstrap
+    effect: NoSchedule
+  enforcementMode: "bootstrap-only"
+  nodeSelector:
+    matchLabels:
+      e2e-test: "selector"
+---
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: selector-test-continuous
+spec:
+  conditions:
+    - type: SelectorTest
+      requiredStatus: "True"
+  taint:
+    key: readiness.k8s.io/test-continuous
+    effect: NoSchedule
+  enforcementMode: "continuous"
+  nodeSelector:
+    matchLabels:
+      e2e-test: "selector"
+`)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("querying rules by enforcementMode=bootstrap-only")
+			Eventually(func() bool {
+				cmd := exec.Command("kubectl", "get", "nrr", "--field-selector", "spec.enforcementMode=bootstrap-only", "-o", "jsonpath={.items[*].metadata.name}")
+				output, err := utils.Run(cmd)
+				if err != nil {
+					return false
+				}
+				return strings.Contains(output, "selector-test-bootstrap") && !strings.Contains(output, "selector-test-continuous")
+			}, 30*time.Second, 2*time.Second).Should(BeTrue())
+
+			By("querying rules by taint key")
+			Eventually(func() bool {
+				cmd := exec.Command("kubectl", "get", "nrr", "--field-selector", "spec.taint.key=readiness.k8s.io/test-continuous", "-o", "jsonpath={.items[*].metadata.name}")
+				output, err := utils.Run(cmd)
+				if err != nil {
+					return false
+				}
+				return strings.Contains(output, "selector-test-continuous") && !strings.Contains(output, "selector-test-bootstrap")
+			}, 30*time.Second, 2*time.Second).Should(BeTrue())
+
+			By("cleaning up test resources")
+			exec.Command("kubectl", "delete", "nodereadinessrule", "selector-test-bootstrap", "selector-test-continuous").Run()
+		})
+
+		It("should support FieldSelectors for dryRun", func() {
+			By("applying test rules for dryRun")
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(`
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: selector-test-dryrun
+spec:
+  conditions:
+    - type: SelectorTest
+      requiredStatus: "True"
+  taint:
+    key: readiness.k8s.io/test-dryrun
+    effect: NoSchedule
+  enforcementMode: "bootstrap-only"
+  dryRun: true
+  nodeSelector:
+    matchLabels:
+      e2e-test: "selector"
+`)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("querying rules by dryRun=true")
+			Eventually(func() bool {
+				cmd := exec.Command("kubectl", "get", "nrr", "--field-selector", "spec.dryRun=true", "-o", "jsonpath={.items[*].metadata.name}")
+				output, err := utils.Run(cmd)
+				if err != nil {
+					return false
+				}
+				return strings.Contains(output, "selector-test-dryrun")
+			}, 30*time.Second, 2*time.Second).Should(BeTrue())
+
+			By("cleaning up test resources")
+			exec.Command("kubectl", "delete", "nodereadinessrule", "selector-test-dryrun").Run()
+		})
 	})
 })
 


### PR DESCRIPTION
## Description
Feature to support querying node-readiness-rules by enforcement-mode, taint-key or dry-run 

## Related Issue
Fixes #311 

## Type of Change

/kind feature

## Testing

```
▮ajaysundar@ajaysundar-cloudtop:~/workspace/src/k8s.io/node-readiness-controller$ kubectl get nrr
NAME                MODE             TAINT                                EFFECT       DRYRUN   AGE
test-bootstrap      bootstrap-only   readiness.k8s.io/test-bootstrap      NoSchedule            4m30s
test-bootstrap-2    bootstrap-only   readiness.k8s.io/test-bootstrap-2    NoSchedule            89s
test-continuous     continuous       readiness.k8s.io/test-continuous     NoSchedule            4m29s
test-continuous-2   continuous       readiness.k8s.io/test-continuous-2   NoSchedule            89s
▮ajaysundar@ajaysundar-cloudtop:~/workspace/src/k8s.io/node-readiness-controller$
▮ajaysundar@ajaysundar-cloudtop:~/workspace/src/k8s.io/node-readiness-controller$ kubectl get nrr --field-selector spec.enforcementMode="bootstrap-only"
NAME               MODE             TAINT                               EFFECT       DRYRUN   AGE
test-bootstrap     bootstrap-only   readiness.k8s.io/test-bootstrap     NoSchedule            5m1s
test-bootstrap-2   bootstrap-only   readiness.k8s.io/test-bootstrap-2   NoSchedule            2m
▮ajaysundar@ajaysundar-cloudtop:~/workspace/src/k8s.io/node-readiness-controller$
▮ajaysundar@ajaysundar-cloudtop:~/workspace/src/k8s.io/node-readiness-controller$ kubectl get nrr --field-selector spec.enforcementMode="continuous"
NAME                MODE         TAINT                                EFFECT       DRYRUN   AGE
test-continuous     continuous   readiness.k8s.io/test-continuous     NoSchedule            5m7s
test-continuous-2   continuous   readiness.k8s.io/test-continuous-2   NoSchedule            2m7s
▮ajaysundar@ajaysundar-cloudtop:~/workspace/src/k8s.io/node-readiness-controller$ kubectl get nrr --field-selector spec.taint.key="readiness.k8s.io/test-bootstrap"
NAME             MODE             TAINT                             EFFECT       DRYRUN   AGE
test-bootstrap   bootstrap-only   readiness.k8s.io/test-bootstrap   NoSchedule            5m38s
▮ajaysundar@ajaysundar-cloudtop:~/workspace/src/k8s.io/node-readiness-controller$
```

added e2e tests.

## Checklist
- [X] `make test` passes
- [X] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
feature: support server-side filtering for NodeReadinessRules using field selectors
```
