### PR TITLE
docs: add reporter configuration ref and document HEARTBEAT_PERIOD behaviour

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -42,4 +42,5 @@
 
 # Reference
 
+- [Reporter Configuration](./reference/reporter-configuration.md)
 - [API Specification](./reference/api-spec.md)

--- a/docs/book/src/operations/security.md
+++ b/docs/book/src/operations/security.md
@@ -70,3 +70,7 @@ env:
 ```
 
 When `IMPERSONATE_NODE` is not set, the reporter uses its ServiceAccount identity directly (the pre-v1.35 behavior).
+
+`IMPERSONATE_NODE` is one of several environment variables the reporter
+supports, see [Reporter Configuration](../reference/reporter-configuration.md)
+for the complete list.

--- a/docs/book/src/operations/security.md
+++ b/docs/book/src/operations/security.md
@@ -71,6 +71,4 @@ env:
 
 When `IMPERSONATE_NODE` is not set, the reporter uses its ServiceAccount identity directly (the pre-v1.35 behavior).
 
-`IMPERSONATE_NODE` is one of several environment variables the reporter
-supports, see [Reporter Configuration](../reference/reporter-configuration.md)
-for the complete list.
+See [Reporter Configuration](../reference/reporter-configuration.md) for more configuration details.

--- a/docs/book/src/reference/reporter-configuration.md
+++ b/docs/book/src/reference/reporter-configuration.md
@@ -1,0 +1,42 @@
+# Reporter Configuration
+
+The `readiness-condition-reporter` is configured entirely through environment
+variables on its container. This page lists all supported variables. For a
+walkthrough of deploying the reporter, see the [CNI Readiness](../examples/cni-readiness.md)
+and [Security Agent](../examples/security-agent-readiness.md) examples.
+
+## Environment Variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `NODE_NAME` | The name of the Node this reporter instance updates. Typically set via the Downward API (`fieldRef: spec.nodeName`) rather than a literal value. | (required) |
+| `CHECK_ENDPOINT` | The local HTTP endpoint the reporter polls to determine health, e.g. `http://localhost:9099/readiness`. | (required) |
+| `CONDITION_TYPE` | The Node condition type the reporter writes, e.g. `projectcalico.org/CalicoReady`. | (required) |
+| `CHECK_INTERVAL` | How often the reporter polls `CHECK_ENDPOINT`. | `30s` |
+| `HEARTBEAT_PERIOD` | The maximum time the reporter can go without writing to the Node's condition, even when the observed health status hasn't changed. See [Reducing unnecessary node status writes](../user-guide/concepts.md#reducing-unnecessary-node-status-writes) for details. Accepts a Go duration string (`30s`, `2m`, `1h`). Invalid values are logged and fall back to the default. | `5m` |
+| `IMPERSONATE_NODE` | When set to `"true"`, the reporter sends `Impersonate-User: system:node:<nodeName>` headers on every request, enabling the constrained impersonation authorization flow. See [Security](../operations/security.md#reporter-configuration) for details. | unset (uses the reporter's own ServiceAccount identity) |
+
+> [!NOTE]
+> `NODE_NAME`, `CHECK_ENDPOINT`, and `CONDITION_TYPE` together define *what*
+> the reporter checks and *where* it writes the result. `CHECK_INTERVAL` and
+> `HEARTBEAT_PERIOD` control *how often* it checks and *how often* it is
+> guaranteed to write, respectively i.e. these are two different clocks and not
+> the same setting.
+
+## Example
+
+```yaml
+env:
+  - name: NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: CHECK_ENDPOINT
+    value: "http://localhost:9099/readiness"
+  - name: CONDITION_TYPE
+    value: "projectcalico.org/CalicoReady"
+  - name: CHECK_INTERVAL
+    value: "30s"
+  - name: HEARTBEAT_PERIOD
+    value: "5m"
+```

--- a/docs/book/src/reference/reporter-configuration.md
+++ b/docs/book/src/reference/reporter-configuration.md
@@ -1,7 +1,7 @@
 # Reporter Configuration
 
 The `readiness-condition-reporter` is one of the ways Node Readiness Controller
-supports reporting node conditions from the node itself.
+supports reporting node conditions from the node.
 
 This page lists configuration variables for deploying the
 `readiness-condition-reporter`. These can be configured through environment
@@ -12,19 +12,12 @@ and [Security Agent](../examples/security-agent-readiness.md) for examples.
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `NODE_NAME` | The name of the Node this reporter instance updates. Typically set via the Downward API (`fieldRef: spec.nodeName`) rather than a literal value. | (required) |
-| `CHECK_ENDPOINT` | The local HTTP endpoint the reporter polls to determine health, e.g. `http://localhost:9099/readiness`. | (required) |
+| `NODE_NAME` | The host name of the underlying Node. The reporter uses it to identify the Node object in the API server for the readiness updates. Typically set via the Downward API (`fieldRef: spec.nodeName`). | (required) |
+| `CHECK_ENDPOINT` | The HTTP endpoint the reporter polls to determine component health, e.g. `http://localhost:9099/healthz`. | (required) |
 | `CONDITION_TYPE` | The Node Readiness condition written by the reporter, e.g. `projectcalico.org/CalicoReady`. | (required) |
 | `CHECK_INTERVAL` | How often the reporter polls `CHECK_ENDPOINT`. | `30s` |
 | `HEARTBEAT_PERIOD` | The maximum time the reporter can go without writing to the Node's condition if component health hasn't changed. See [Optimizing node status writes](../user-guide/concepts.md#optimizing-node-status-writes). Accepts Go duration strings like `30s`, `2m`, `1h`. Invalid values are logged and fall back to the default. | `5m` |
-| `IMPERSONATE_NODE` | When set to `"true"`, the reporter sends `Impersonate-User: system:node:<nodeName>` headers on every request, enabling the constrained impersonation authorization flow. Requires Kubernetes **v1.35+** for [KEP-5284](https://github.com/kubernetes/enhancements/issues/5284) (Constrained Impersonation) to actually be enforced by the API server. See [Security](../operations/security.md#reporter-configuration) for details. | unset (uses the reporter's own ServiceAccount identity) |
-
-> [!NOTE]
-> `NODE_NAME`, `CHECK_ENDPOINT`, and `CONDITION_TYPE` together define *what*
-> the reporter checks and *where* it writes the result. `CHECK_INTERVAL` and
-> `HEARTBEAT_PERIOD` control *how often* it checks and *how often* it is
-> guaranteed to write, respectively i.e. these are two different clocks and not
-> the same setting.
+| `IMPERSONATE_NODE` | When set to `"true"`, the reporter sends `Impersonate-User: system:node:<nodeName>` headers on every request, enabling the constrained impersonation authorization flow. Requires Kubernetes **v1.35+** for [Constrained Impersonation](https://kubernetes.io/docs/reference/access-authn-authz/user-impersonation/#constrained-impersonation) feature. See [Security](../operations/security.md#reporter-configuration) for details. | unset (uses the reporter's own ServiceAccount identity) |
 
 ## Example
 

--- a/docs/book/src/reference/reporter-configuration.md
+++ b/docs/book/src/reference/reporter-configuration.md
@@ -1,9 +1,12 @@
 # Reporter Configuration
 
-The `readiness-condition-reporter` is configured entirely through environment
-variables on its container. This page lists all supported variables. For a
-walkthrough of deploying the reporter, see the [CNI Readiness](../examples/cni-readiness.md)
-and [Security Agent](../examples/security-agent-readiness.md) examples.
+The `readiness-condition-reporter` is one of the ways Node Readiness Controller
+supports reporting node conditions from the node itself.
+
+This page lists configuration variables for deploying the
+`readiness-condition-reporter`. These can be configured through environment
+variables on its container. See the [CNI Readiness](../examples/cni-readiness.md)
+and [Security Agent](../examples/security-agent-readiness.md) for examples.
 
 ## Environment Variables
 
@@ -11,10 +14,10 @@ and [Security Agent](../examples/security-agent-readiness.md) examples.
 | --- | --- | --- |
 | `NODE_NAME` | The name of the Node this reporter instance updates. Typically set via the Downward API (`fieldRef: spec.nodeName`) rather than a literal value. | (required) |
 | `CHECK_ENDPOINT` | The local HTTP endpoint the reporter polls to determine health, e.g. `http://localhost:9099/readiness`. | (required) |
-| `CONDITION_TYPE` | The Node condition type the reporter writes, e.g. `projectcalico.org/CalicoReady`. | (required) |
+| `CONDITION_TYPE` | The Node Readiness condition written by the reporter, e.g. `projectcalico.org/CalicoReady`. | (required) |
 | `CHECK_INTERVAL` | How often the reporter polls `CHECK_ENDPOINT`. | `30s` |
-| `HEARTBEAT_PERIOD` | The maximum time the reporter can go without writing to the Node's condition, even when the observed health status hasn't changed. See [Reducing unnecessary node status writes](../user-guide/concepts.md#reducing-unnecessary-node-status-writes) for details. Accepts a Go duration string (`30s`, `2m`, `1h`). Invalid values are logged and fall back to the default. | `5m` |
-| `IMPERSONATE_NODE` | When set to `"true"`, the reporter sends `Impersonate-User: system:node:<nodeName>` headers on every request, enabling the constrained impersonation authorization flow. See [Security](../operations/security.md#reporter-configuration) for details. | unset (uses the reporter's own ServiceAccount identity) |
+| `HEARTBEAT_PERIOD` | The maximum time the reporter can go without writing to the Node's condition if component health hasn't changed. See [Optimizing node status writes](../user-guide/concepts.md#optimizing-node-status-writes). Accepts Go duration strings like `30s`, `2m`, `1h`. Invalid values are logged and fall back to the default. | `5m` |
+| `IMPERSONATE_NODE` | When set to `"true"`, the reporter sends `Impersonate-User: system:node:<nodeName>` headers on every request, enabling the constrained impersonation authorization flow. Requires Kubernetes **v1.35+** for [KEP-5284](https://github.com/kubernetes/enhancements/issues/5284) (Constrained Impersonation) to actually be enforced by the API server. See [Security](../operations/security.md#reporter-configuration) for details. | unset (uses the reporter's own ServiceAccount identity) |
 
 > [!NOTE]
 > `NODE_NAME`, `CHECK_ENDPOINT`, and `CONDITION_TYPE` together define *what*

--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -103,8 +103,8 @@ To help you integrate custom checks where NPD might not be suitable, the project
 
 #### Optimizing node status writes
 
-On every check interval, the reporter compares the observed component health
-against the condition already stored on the Node (`Status`,
+On every `CHECK_INTERVAL`, the reporter compares the health result it just
+observed against the condition already stored on the Node (`Status`,
 `Reason`, and `Message`). If the condition matches these and differs only in
 `lastHeartbeatTime`, the reporter skips updating the readiness condition.
 

--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -101,6 +101,33 @@ To help you integrate custom checks where NPD might not be suitable, the project
 *   **Simplicity**: Good for simple "is this HTTP endpoint up?" checks without configuring external scripts.
 *   **Direct Coupling**: Useful when you want the readiness reporting lifecycle of the component to strictly match the pod's lifecycle.
 
+### Reducing unnecessary node status writes
+
+On every check interval, the reporter compares the health result it just
+observed against the condition already stored on the Node (`Status`,
+`Reason`, and `Message`). If all three match what's already there, the
+reporter skips the write entirely.
+
+This matters at scale: writing a Node's status forces the API server to
+persist the entire Node object to `etcd`, even if only one condition field
+would have changed. Skipping no-op writes avoids that cost across large
+fleets of nodes reporting on a short interval.
+
+To make sure a reporter with nothing new to add doesn't look stalled, it
+still writes at least once every `HEARTBEAT_PERIOD` (default `5m`),
+refreshing the condition's `lastHeartbeatTime` even when nothing changed.
+If the health status *does* change, the reporter writes immediately,
+regardless of this timer.
+
+> [!NOTE]
+> This only reduces *writes*. The reporter still reads the Node object on
+> every check interval to compare state, so this does not reduce the
+> number of requests sent to the API server, only the number of updates
+> persisted to `etcd`.
+
+See [Reporter Configuration](../reference/reporter-configuration.md) for the
+full list of environment variables, including `HEARTBEAT_PERIOD`.
+
 ## Dry Run Mode
 
 To reduce the operational risks while deploying new readiness rules in production, the controller includes a `dryRun` capability to first analyze the impact before actual deployment.

--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -24,29 +24,6 @@ Typical taint keys look like:
 
 The segment after `readiness.k8s.io/` should describe the dependency or subsystem whose readiness is being guarded (for example, a CNI plugin, storage backend, or security agent). Treat this domain as reserved for the controller and closely related components, and avoid reusing it for unrelated taints.
 
-### Default Condition Status (`defaultStatus`)
-
-When defining readiness conditions, you can configure an optional `defaultStatus` field (one of `True`, `False`, or `Unknown`) under `spec.conditions[]`. This field determines how a condition is evaluated when it is completely absent from the Node's status.
-
-If `defaultStatus` is omitted, the controller assumes a fallback status of `Unknown`.
-
-#### Use Case: Problem Gating (Default-Allow)
-By default, the controller operates in a "default-deny" fashion. If a guarded condition is missing from a new node, it resolves to `Unknown`, which typically does not satisfy `requiredStatus: True` or `requiredStatus: False`, causing the node to be tainted.
-
-However, for problem-detection conditions (like those reported by Node Problem Detector), you want a "default-allow" behavior: the node should start as healthy, and only be tainted if the problem condition explicitly triggers (e.g., `MaintenanceRequired=True`). 
-
-By setting `requiredStatus: False` and `defaultStatus: False`, an absent `MaintenanceRequired` condition evaluates to `False`. It matches the required status, allowing the node to bootstrap without being blocked by race conditions or initialization delays.
-
-#### Important Implication: Enforcement Modes
-The choice of `defaultStatus` has critical interaction with the rule's `enforcementMode`:
-
-> [!IMPORTANT]
-> **`defaultStatus` is not supported with `bootstrap-only` rules.**
->
-> `defaultStatus` is useful when a condition may never appear on a node in its healthy state, effectively treating its absence as a known-good signal. However, `bootstrap-only` mode exists precisely to *wait* for conditions to be explicitly reported before completing the bootstrap gate.
->
- > Because these two features serve opposing purposes, using them together can lead to unintended behavior, such as completing the bootstrap phase before a condition is actually verified. To prevent  this, the admission webhook explicitly rejects this combination.
-
 ## Enforcement Modes
 
 The controller supports two distinct modes of enforcement, configured via `spec.enforcementMode`, to handle different operational needs.
@@ -72,6 +49,29 @@ In this mode, the controller enforces readiness only during the initial node sta
     *   **After completion**: The controller ignores this rule for the node, even if the conditions fail later.
 *   **Use Case**: One-time initialization steps.
     *   *Example*: Pre-pulling heavy container images, initializing a local cache, or performing hardware provisioning that only needs to happen once per boot.
+
+### Default Condition Status (`defaultStatus`)
+
+When defining readiness conditions, you can configure an optional `defaultStatus` field (one of `True`, `False`, or `Unknown`) under `spec.conditions[]`. This field determines how a condition is evaluated when it is completely absent from the Node's status.
+
+If `defaultStatus` is omitted, the controller assumes a fallback status of `Unknown`.
+
+#### Use Case: Problem Gating (Default-Allow)
+By default, the controller operates in a "default-deny" fashion. If a guarded condition is missing from a new node, it resolves to `Unknown`, which typically does not satisfy `requiredStatus: True` or `requiredStatus: False`, causing the node to be tainted.
+
+However, for problem-detection conditions (like those reported by Node Problem Detector), you want a "default-allow" behavior: the node should start as healthy, and only be tainted if the problem condition explicitly triggers (e.g., `MaintenanceRequired=True`). 
+
+By setting `requiredStatus: False` and `defaultStatus: False`, an absent `MaintenanceRequired` condition evaluates to `False`. It matches the required status, allowing the node to bootstrap without being blocked by race conditions or initialization delays.
+
+#### Important Implication: Enforcement Modes
+The choice of `defaultStatus` has critical interaction with the rule's `enforcementMode`:
+
+> [!IMPORTANT]
+> **`defaultStatus` is not supported with `bootstrap-only` rules.**
+>
+> `defaultStatus` is useful when a condition may never appear on a node in its healthy state, effectively treating its absence as a known-good signal. However, `bootstrap-only` mode exists precisely to *wait* for conditions to be explicitly reported before completing the bootstrap gate.
+>
+ > Because these two features serve opposing purposes, using them together can lead to unintended behavior, such as completing the bootstrap phase before a condition is actually verified. To prevent  this, the admission webhook explicitly rejects this combination.
 
 ## Readiness Condition Reporting
 
@@ -101,32 +101,27 @@ To help you integrate custom checks where NPD might not be suitable, the project
 *   **Simplicity**: Good for simple "is this HTTP endpoint up?" checks without configuring external scripts.
 *   **Direct Coupling**: Useful when you want the readiness reporting lifecycle of the component to strictly match the pod's lifecycle.
 
-### Reducing unnecessary node status writes
+#### Optimizing node status writes
 
-On every check interval, the reporter compares the health result it just
-observed against the condition already stored on the Node (`Status`,
-`Reason`, and `Message`). If all three match what's already there, the
-reporter skips the write entirely.
+On every check interval, the reporter compares the observed component health
+against the condition already stored on the Node (`Status`,
+`Reason`, and `Message`). If the condition matches these and differs only in
+`lastHeartbeatTime`, the reporter skips updating the readiness condition.
 
-This matters at scale: writing a Node's status forces the API server to
-persist the entire Node object to `etcd`, even if only one condition field
-would have changed. Skipping no-op writes avoids that cost across large
-fleets of nodes reporting on a short interval.
+This is preferred in large scale clusters. Skipping no-op writes helps
+scale by reducing the condition update load for the API server.
 
-To make sure a reporter with nothing new to add doesn't look stalled, it
-still writes at least once every `HEARTBEAT_PERIOD` (default `5m`),
-refreshing the condition's `lastHeartbeatTime` even when nothing changed.
-If the health status *does* change, the reporter writes immediately,
-regardless of this timer.
+To ensure reliability, the reporter forces a refresh of the condition every
+`HEARTBEAT_PERIOD`, which is default to 5 minutes.
 
 > [!NOTE]
 > This only reduces *writes*. The reporter still reads the Node object on
 > every check interval to compare state, so this does not reduce the
-> number of requests sent to the API server, only the number of updates
+> number of read requests sent to the API server, only the number of updates
 > persisted to `etcd`.
 
-See [Reporter Configuration](../reference/reporter-configuration.md) for the
-full list of environment variables, including `HEARTBEAT_PERIOD`.
+See [Reporter Configuration](../reference/reporter-configuration.md) for
+all supported configuration.
 
 ## Dry Run Mode
 


### PR DESCRIPTION
This PR adds documentation for the reporter write-skipping HEARTBEAT_PERIOD behaviour introduced in PR #263 

This PR also adds a single reference page listing all `readiness-condition-reporter` env variables (previously they were only documented inside individual examples).

## Changes

- **New:** `reference/reporter-configuration.md` added a reference table for all reporter environment variables (`NODE_NAME`, `CHECK_ENDPOINT`, `CONDITION_TYPE`, `CHECK_INTERVAL`, `HEARTBEAT_PERIOD`, `IMPERSONATE_NODE`)
- **Updated:** `user-guide/concepts.md` added explaination why the reporter skips writes when the node condition is unchanged and how `HEARTBEAT_PERIOD` guarantees a periodic write regardless
- **Updated:** `operations/security.md` added a link `IMPERSONATE_NODE` to the new full reference page
- **Updated:** `SUMMARY.md` registered the new reference page under `# Reference`

## Testing

Ran the book locally and verified the new/changed links and tables.