### PR TITLE
feat: anyOf readiness condition requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ With this controller you can:
 
 ### Key Features
 
-- **Multi-condition Rules**: Define rules that require ALL specified conditions to be satisfied
+- **Multi-condition Rules**: Define rules with flexible condition policies (`allOf` or `anyOf`) to require ALL or ANY specified conditions to be satisfied
 - **Flexible Enforcement**: Support for bootstrap-only and continuous enforcement modes
 - **Conflict Prevention**: Validation webhook prevents conflicting taint configurations
 - **Dry Run Mode**: Preview rule impact before applying changes

--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -57,14 +57,14 @@ const (
 	TaintStatusAbsent TaintStatus = "Absent"
 )
 
+// Note for Developers: conditionPolicy immutability validation is placed at the
+// NodeReadinessRuleSpec level instead of conditionPolicy because conditionPolicy is optional.
+// When transitioning between omitted and explicit "allOf", field-level transition rules are
+// bypassed since CEL only evaluates them when both self and oldSelf are present. Evaluating at
+// the struct level allows using has() to normalize absent values.
+
 // NodeReadinessRuleSpec defines the desired state of NodeReadinessRule.
 //
-// We put the conditionPolicy immutability validation at `NodeReadinessRuleSpec` level instead of
-// putting it on `conditionPolicy`. This is required because conditionPolicy is optional field. If a
-// user transitions from an omitted field to an explicit "allOf" or vice-versa, field-level
-// transition rules are not evaluated, since validations are only performed only when both self and
-// oldSelf are present. By evaluating it at the struct level, we can safely use the `has()` macro to
-// normalize absent values and force evaluation under any condition.
 // +kubebuilder:validation:XValidation:rule="(!has(oldSelf.conditionPolicy) ? 'allOf' : oldSelf.conditionPolicy) == (!has(self.conditionPolicy) ? 'allOf' : self.conditionPolicy)",message="conditionPolicy is immutable"
 type NodeReadinessRuleSpec struct {
 	// conditions contains a list of the Node conditions that defines the specific

--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -33,6 +33,18 @@ const (
 	EnforcementModeContinuous EnforcementMode = "continuous"
 )
 
+// ConditionPolicy defines how the list of conditions is aggregated when evaluating a rule.
+// +kubebuilder:validation:Enum=allOf;anyOf
+type ConditionPolicy string
+
+const (
+	// ConditionPolicyAllOf requires ALL conditions to match their requiredStatus (default).
+	ConditionPolicyAllOf ConditionPolicy = "allOf"
+
+	// ConditionPolicyAnyOf requires at least ONE condition to match its requiredStatus.
+	ConditionPolicyAnyOf ConditionPolicy = "anyOf"
+)
+
 // TaintStatus specifies status of the Taint on Node.
 // +kubebuilder:validation:Enum=Present;Absent
 type TaintStatus string
@@ -46,6 +58,14 @@ const (
 )
 
 // NodeReadinessRuleSpec defines the desired state of NodeReadinessRule.
+//
+// We put the conditionPolicy immutability validation at `NodeReadinessRuleSpec` level instead of
+// putting it on `conditionPolicy`. This is required because conditionPolicy is optional field. If a
+// user transitions from an omitted field to an explicit "allOf" or vice-versa, field-level
+// transition rules are not evaluated, since validations are only performed only when both self and
+// oldSelf are present. By evaluating it at the struct level, we can safely use the `has()` macro to
+// normalize absent values and force evaluation under any condition.
+// +kubebuilder:validation:XValidation:rule="(!has(oldSelf.conditionPolicy) ? 'allOf' : oldSelf.conditionPolicy) == (!has(self.conditionPolicy) ? 'allOf' : self.conditionPolicy)",message="conditionPolicy is immutable"
 type NodeReadinessRuleSpec struct {
 	// conditions contains a list of the Node conditions that defines the specific
 	// criteria that must be met for taints to be managed on the target Node.
@@ -98,6 +118,15 @@ type NodeReadinessRuleSpec struct {
 	// +required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="nodeSelector is immutable"
 	NodeSelector metav1.LabelSelector `json:"nodeSelector,omitempty,omitzero"`
+
+	// conditionPolicy controls how the conditions list is evaluated.
+	// "allOf" (default) requires every condition to match its requiredStatus before the taint is removed.
+	// "anyOf" requires at least one condition to match its requiredStatus.
+	//
+	// anyOf cannot be used with enforcementMode: bootstrap-only.
+	//
+	// +optional
+	ConditionPolicy ConditionPolicy `json:"conditionPolicy,omitempty"` // Use GetConditionPolicy() for safe access; field may be empty even when allOf applies.
 
 	// dryRun when set to true, The controller will evaluate Node conditions and log intended taint modifications
 	// without persisting changes to the cluster. Proposed actions are reflected in the resource status.
@@ -377,6 +406,20 @@ func (c *ConditionRequirement) GetDefaultStatus() corev1.ConditionStatus {
 		return corev1.ConditionUnknown
 	}
 	return c.DefaultStatus
+}
+
+// GetConditionPolicy returns the effective condition policy, defaulting to allOf
+// when the field is not explicitly set.
+//
+// Always use this method instead of reading ConditionPolicy directly. The field
+// is intentionally left without an OpenAPI schema default (kubebuilder:default
+// is forbidden by project policy) and the Spec is immutable, so defaulting
+// must happen at read time via this accessor.
+func (spec *NodeReadinessRuleSpec) GetConditionPolicy() ConditionPolicy {
+	if spec.ConditionPolicy == "" {
+		return ConditionPolicyAllOf
+	}
+	return spec.ConditionPolicy
 }
 
 func init() {

--- a/charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
+++ b/charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
@@ -62,6 +62,17 @@ spec:
           spec:
             description: spec defines the desired state of NodeReadinessRule
             properties:
+              conditionPolicy:
+                description: |-
+                  conditionPolicy controls how the conditions list is evaluated.
+                  "allOf" (default) requires every condition to match its requiredStatus before the taint is removed.
+                  "anyOf" requires at least one condition to match its requiredStatus.
+
+                  anyOf cannot be used with enforcementMode: bootstrap-only.
+                enum:
+                - allOf
+                - anyOf
+                type: string
               conditions:
                 description: |-
                   conditions contains a list of the Node conditions that defines the specific
@@ -251,6 +262,10 @@ spec:
             - nodeSelector
             - taint
             type: object
+            x-kubernetes-validations:
+            - message: conditionPolicy is immutable
+              rule: '(!has(oldSelf.conditionPolicy) ? ''allOf'' : oldSelf.conditionPolicy)
+                == (!has(self.conditionPolicy) ? ''allOf'' : self.conditionPolicy)'
           status:
             description: status defines the observed state of NodeReadinessRule
             minProperties: 1

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -62,6 +62,17 @@ spec:
           spec:
             description: spec defines the desired state of NodeReadinessRule
             properties:
+              conditionPolicy:
+                description: |-
+                  conditionPolicy controls how the conditions list is evaluated.
+                  "allOf" (default) requires every condition to match its requiredStatus before the taint is removed.
+                  "anyOf" requires at least one condition to match its requiredStatus.
+
+                  anyOf cannot be used with enforcementMode: bootstrap-only.
+                enum:
+                - allOf
+                - anyOf
+                type: string
               conditions:
                 description: |-
                   conditions contains a list of the Node conditions that defines the specific
@@ -251,6 +262,10 @@ spec:
             - nodeSelector
             - taint
             type: object
+            x-kubernetes-validations:
+            - message: conditionPolicy is immutable
+              rule: '(!has(oldSelf.conditionPolicy) ? ''allOf'' : oldSelf.conditionPolicy)
+                == (!has(self.conditionPolicy) ? ''allOf'' : self.conditionPolicy)'
           status:
             description: status defines the observed state of NodeReadinessRule
             minProperties: 1

--- a/docs/book/src/reference/api-spec.md
+++ b/docs/book/src/reference/api-spec.md
@@ -27,10 +27,10 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _string_ | type corresponds to the Node condition type being evaluated. |  | MaxLength: 316 <br />MinLength: 1 <br />Required: \{\} <br /> |
-| `currentStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | currentStatus is the actual status value observed on the Node, one of True, False, Unknown. |  | Enum: [True False Unknown] <br />Required: \{\} <br /> |
-| `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is the status value defined in the rule that must be matched, one of True, False, Unknown. |  | Enum: [True False Unknown] <br />Required: \{\} <br /> |
-| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the status a condition is evaluated to if the condition<br />is not found in a node. Reflects the defaultStatus configured in the rule<br />spec. |  | Enum: [True False Unknown] <br />Optional: \{\} <br /> |
+| `type` _string_ | type corresponds to the Node condition type being evaluated. |  | MaxLength: 316 <br />MinLength: 1 <br /> |
+| `currentStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | currentStatus is the actual status value observed on the Node, one of True, False, Unknown. |  | Enum: [True False Unknown] <br /> |
+| `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is the status value defined in the rule that must be matched, one of True, False, Unknown. |  | Enum: [True False Unknown] <br /> |
+| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the status a condition is evaluated to if the condition<br />is not found in a node. Reflects the defaultStatus configured in the rule<br />spec. |  | Enum: [True False Unknown] <br /> |
 
 
 #### ConditionPolicy
@@ -66,9 +66,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _string_ | type of Node condition<br />Following kubebuilder validation is referred from https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition |  | MaxLength: 316 <br />MinLength: 1 <br />Required: \{\} <br /> |
-| `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is status of the condition, one of True, False, Unknown. |  | Enum: [True False Unknown] <br />Required: \{\} <br /> |
-| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the status a condition is evaluated to if the condition<br />is not found in a node.<br />Accepted values are True, False, Unknown. It is optional.<br />When omitted, the effective default is Unknown, applied transparently by<br />the controller at evaluation time.<br />Note: This field must not be set when enforcementMode is bootstrap-only. |  | Enum: [True False Unknown] <br />Optional: \{\} <br /> |
+| `type` _string_ | type of Node condition<br />Following kubebuilder validation is referred from https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition |  | MaxLength: 316 <br />MinLength: 1 <br /> |
+| `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is status of the condition, one of True, False, Unknown. |  | Enum: [True False Unknown] <br /> |
+| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the status a condition is evaluated to if the condition<br />is not found in a node.<br />Accepted values are True, False, Unknown. It is optional.<br />When omitted, the effective default is Unknown, applied transparently by<br />the controller at evaluation time.<br />Note: This field must not be set when enforcementMode is bootstrap-only. |  | Enum: [True False Unknown] <br /> |
 
 
 #### DryRunResults
@@ -85,11 +85,11 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `affectedNodes` _integer_ | affectedNodes is the total count of Nodes that match the rule's criteria. |  | Minimum: 0 <br />Optional: \{\} <br /> |
-| `taintsToAdd` _integer_ | taintsToAdd is the number of Nodes that currently lack the specified taint and would have it applied. |  | Minimum: 0 <br />Optional: \{\} <br /> |
-| `taintsToRemove` _integer_ | taintsToRemove is the number of Nodes that currently possess the<br />taint but no longer meet the criteria, leading to its removal. |  | Minimum: 0 <br />Optional: \{\} <br /> |
-| `riskyOperations` _integer_ | riskyOperations represents the count of Nodes where required conditions<br />are missing entirely, potentially indicating an ambiguous node state. |  | Minimum: 0 <br />Optional: \{\} <br /> |
-| `summary` _string_ | summary provides a human-readable overview of the dry run evaluation,<br />highlighting key findings or warnings. |  | MaxLength: 4096 <br />MinLength: 1 <br />Required: \{\} <br /> |
+| `affectedNodes` _integer_ | affectedNodes is the total count of Nodes that match the rule's criteria. |  | Minimum: 0 <br /> |
+| `taintsToAdd` _integer_ | taintsToAdd is the number of Nodes that currently lack the specified taint and would have it applied. |  | Minimum: 0 <br /> |
+| `taintsToRemove` _integer_ | taintsToRemove is the number of Nodes that currently possess the<br />taint but no longer meet the criteria, leading to its removal. |  | Minimum: 0 <br /> |
+| `riskyOperations` _integer_ | riskyOperations represents the count of Nodes where required conditions<br />are missing entirely, potentially indicating an ambiguous node state. |  | Minimum: 0 <br /> |
+| `summary` _string_ | summary provides a human-readable overview of the dry run evaluation,<br />highlighting key findings or warnings. |  | MaxLength: 4096 <br />MinLength: 1 <br /> |
 
 
 #### EnforcementMode
@@ -123,10 +123,10 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `nodeName` _string_ | nodeName is the name of the evaluated Node. |  | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$` <br />Required: \{\} <br /> |
-| `conditionResults` _[ConditionEvaluationResult](#conditionevaluationresult) array_ | conditionResults provides a detailed breakdown of each condition evaluation<br />for this Node. This allows for granular auditing of which specific<br />criteria passed or failed during the rule assessment. |  | MaxItems: 5000 <br />Required: \{\} <br /> |
-| `taintStatus` _[TaintStatus](#taintstatus)_ | taintStatus represents the taint status on the Node, one of Present, Absent. |  | Enum: [Present Absent] <br />Required: \{\} <br /> |
-| `lastEvaluationTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | lastEvaluationTime is the timestamp when the controller last assessed this Node. |  | Required: \{\} <br /> |
+| `nodeName` _string_ | nodeName is the name of the evaluated Node. |  | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$` <br /> |
+| `conditionResults` _[ConditionEvaluationResult](#conditionevaluationresult) array_ | conditionResults provides a detailed breakdown of each condition evaluation<br />for this Node. This allows for granular auditing of which specific<br />criteria passed or failed during the rule assessment. |  | MaxItems: 5000 <br /> |
+| `taintStatus` _[TaintStatus](#taintstatus)_ | taintStatus represents the taint status on the Node, one of Present, Absent. |  | Enum: [Present Absent] <br /> |
+| `lastEvaluationTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | lastEvaluationTime is the timestamp when the controller last assessed this Node. |  |  |
 
 
 #### NodeFailure
@@ -142,10 +142,10 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `nodeName` _string_ | nodeName is the name of the failed Node.<br />Following kubebuilder validation is referred from<br />https://github.com/kubernetes/apimachinery/blob/84d740c9e27f3ccc94c8bc4d13f1b17f60f7080b/pkg/util/validation/validation.go#L198 |  | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$` <br />Required: \{\} <br /> |
-| `reason` _string_ | reason provides a brief explanation of the evaluation result. |  | MaxLength: 256 <br />MinLength: 1 <br />Optional: \{\} <br /> |
-| `message` _string_ | message is a human-readable message indicating details about the evaluation. |  | MaxLength: 10240 <br />MinLength: 1 <br />Optional: \{\} <br /> |
-| `lastEvaluationTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | lastEvaluationTime is the timestamp of the last rule check failed for this Node. |  | Required: \{\} <br /> |
+| `nodeName` _string_ | nodeName is the name of the failed Node.<br />Following kubebuilder validation is referred from<br />https://github.com/kubernetes/apimachinery/blob/84d740c9e27f3ccc94c8bc4d13f1b17f60f7080b/pkg/util/validation/validation.go#L198 |  | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$` <br /> |
+| `reason` _string_ | reason provides a brief explanation of the evaluation result. |  | MaxLength: 256 <br />MinLength: 1 <br /> |
+| `message` _string_ | message is a human-readable message indicating details about the evaluation. |  | MaxLength: 10240 <br />MinLength: 1 <br /> |
+| `lastEvaluationTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | lastEvaluationTime is the timestamp of the last rule check failed for this Node. |  |  |
 
 
 #### NodeReadinessRule
@@ -162,9 +162,9 @@ NodeReadinessRule is the Schema for the NodeReadinessRules API.
 | --- | --- | --- | --- |
 | `apiVersion` _string_ | `readiness.node.x-k8s.io/v1alpha1` | | |
 | `kind` _string_ | `NodeReadinessRule` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
-| `spec` _[NodeReadinessRuleSpec](#nodereadinessrulespec)_ | spec defines the desired state of NodeReadinessRule |  | Required: \{\} <br /> |
-| `status` _[NodeReadinessRuleStatus](#nodereadinessrulestatus)_ | status defines the observed state of NodeReadinessRule |  | MinProperties: 1 <br />Optional: \{\} <br /> |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[NodeReadinessRuleSpec](#nodereadinessrulespec)_ | spec defines the desired state of NodeReadinessRule |  |  |
+| `status` _[NodeReadinessRuleStatus](#nodereadinessrulestatus)_ | status defines the observed state of NodeReadinessRule |  | MinProperties: 1 <br /> |
 
 
 #### NodeReadinessRuleSpec
@@ -173,13 +173,6 @@ NodeReadinessRule is the Schema for the NodeReadinessRules API.
 
 NodeReadinessRuleSpec defines the desired state of NodeReadinessRule.
 
-We put the conditionPolicy immutability validation at `NodeReadinessRuleSpec` level instead of
-putting it on `conditionPolicy`. This is required because conditionPolicy is optional field. If a
-user transitions from an omitted field to an explicit "allOf" or vice-versa, field-level
-transition rules are not evaluated, since validations are only performed only when both self and
-oldSelf are present. By evaluating it at the struct level, we can safely use the `has()` macro to
-normalize absent values and force evaluation under any condition.
-
 
 
 _Appears in:_
@@ -187,12 +180,12 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `conditions` _[ConditionRequirement](#conditionrequirement) array_ | conditions contains a list of the Node conditions that defines the specific<br />criteria that must be met for taints to be managed on the target Node.<br />The presence or status of these conditions directly triggers the application or removal of Node taints. |  | MaxItems: 32 <br />MinItems: 1 <br />Required: \{\} <br /> |
-| `enforcementMode` _[EnforcementMode](#enforcementmode)_ | enforcementMode specifies how the controller maintains the desired state.<br />enforcementMode is one of bootstrap-only, continuous.<br />"bootstrap-only" applies the configuration once during initial setup.<br />"continuous" ensures the state is monitored and corrected throughout the resource lifecycle. |  | Enum: [bootstrap-only continuous] <br />Required: \{\} <br /> |
-| `taint` _[Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#taint-v1-core)_ | taint defines the specific Taint (Key, Value, and Effect) to be managed<br />on Nodes that meet the defined condition criteria.<br />The taint key must follow Kubernetes qualified name format: prefix/name<br />where prefix is 'readiness.k8s.io' (DNS subdomain) and name is a qualified<br />name (max 63 chars, alphanumeric, '-', '_', '.', must start and end with alphanumeric).<br />ref: git.k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/validate/content/kube.go#L24-L72<br />Supported effects: NoSchedule, PreferNoSchedule, NoExecute.<br />Caution: NoExecute evicts existing pods and can cause significant disruption<br />when combined with continuous enforcement mode. Prefer NoSchedule for most use cases. |  | Required: \{\} <br /> |
-| `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta)_ | nodeSelector limits the scope of this rule to a specific subset of Nodes. |  | Required: \{\} <br /> |
-| `conditionPolicy` _[ConditionPolicy](#conditionpolicy)_ | conditionPolicy controls how the conditions list is evaluated.<br />"allOf" (default) requires every condition to match its requiredStatus before the taint is removed.<br />"anyOf" requires at least one condition to match its requiredStatus.<br />anyOf cannot be used with enforcementMode: bootstrap-only. |  | Enum: [allOf anyOf] <br />Optional: \{\} <br /> |
-| `dryRun` _boolean_ | dryRun when set to true, The controller will evaluate Node conditions and log intended taint modifications<br />without persisting changes to the cluster. Proposed actions are reflected in the resource status. |  | Optional: \{\} <br /> |
+| `conditions` _[ConditionRequirement](#conditionrequirement) array_ | conditions contains a list of the Node conditions that defines the specific<br />criteria that must be met for taints to be managed on the target Node.<br />The presence or status of these conditions directly triggers the application or removal of Node taints. |  | MaxItems: 32 <br />MinItems: 1 <br /> |
+| `enforcementMode` _[EnforcementMode](#enforcementmode)_ | enforcementMode specifies how the controller maintains the desired state.<br />enforcementMode is one of bootstrap-only, continuous.<br />"bootstrap-only" applies the configuration once during initial setup.<br />"continuous" ensures the state is monitored and corrected throughout the resource lifecycle. |  | Enum: [bootstrap-only continuous] <br /> |
+| `taint` _[Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#taint-v1-core)_ | taint defines the specific Taint (Key, Value, and Effect) to be managed<br />on Nodes that meet the defined condition criteria.<br />The taint key must follow Kubernetes qualified name format: prefix/name<br />where prefix is 'readiness.k8s.io' (DNS subdomain) and name is a qualified<br />name (max 63 chars, alphanumeric, '-', '_', '.', must start and end with alphanumeric).<br />ref: git.k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/validate/content/kube.go#L24-L72<br />Supported effects: NoSchedule, PreferNoSchedule, NoExecute.<br />Caution: NoExecute evicts existing pods and can cause significant disruption<br />when combined with continuous enforcement mode. Prefer NoSchedule for most use cases. |  |  |
+| `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta)_ | nodeSelector limits the scope of this rule to a specific subset of Nodes. |  |  |
+| `conditionPolicy` _[ConditionPolicy](#conditionpolicy)_ | conditionPolicy controls how the conditions list is evaluated.<br />"allOf" (default) requires every condition to match its requiredStatus before the taint is removed.<br />"anyOf" requires at least one condition to match its requiredStatus.<br />anyOf cannot be used with enforcementMode: bootstrap-only. |  | Enum: [allOf anyOf] <br /> |
+| `dryRun` _boolean_ | dryRun when set to true, The controller will evaluate Node conditions and log intended taint modifications<br />without persisting changes to the cluster. Proposed actions are reflected in the resource status. |  |  |
 
 
 #### NodeReadinessRuleStatus
@@ -209,11 +202,11 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `observedGeneration` _integer_ | observedGeneration reflects the generation of the most recently observed NodeReadinessRule by the controller. |  | Minimum: 1 <br />Optional: \{\} <br /> |
-| `appliedNodes` _string array_ | appliedNodes lists the names of Nodes where the taint has been successfully managed.<br />This provides a quick reference to the scope of impact for this rule. |  | MaxItems: 5000 <br />items:MaxLength: 253 <br />Optional: \{\} <br /> |
-| `failedNodes` _[NodeFailure](#nodefailure) array_ | failedNodes lists the Nodes where the rule evaluation encountered an error.<br />This is used for troubleshooting configuration issues, such as invalid selectors during node lookup. |  | MaxItems: 5000 <br />Optional: \{\} <br /> |
-| `nodeEvaluations` _[NodeEvaluation](#nodeevaluation) array_ | nodeEvaluations provides detailed insight into the rule's assessment for individual Nodes.<br />This is primarily used for auditing and debugging why specific Nodes were or<br />were not targeted by the rule. |  | MaxItems: 5000 <br />Optional: \{\} <br /> |
-| `dryRunResults` _[DryRunResults](#dryrunresults)_ | dryRunResults captures the outcome of the rule evaluation when DryRun is enabled.<br />This field provides visibility into the actions the controller would have taken,<br />allowing users to preview taint changes before they are committed. |  | MinProperties: 1 <br />Optional: \{\} <br /> |
+| `observedGeneration` _integer_ | observedGeneration reflects the generation of the most recently observed NodeReadinessRule by the controller. |  | Minimum: 1 <br /> |
+| `appliedNodes` _string array_ | appliedNodes lists the names of Nodes where the taint has been successfully managed.<br />This provides a quick reference to the scope of impact for this rule. |  | MaxItems: 5000 <br />items:MaxLength: 253 <br /> |
+| `failedNodes` _[NodeFailure](#nodefailure) array_ | failedNodes lists the Nodes where the rule evaluation encountered an error.<br />This is used for troubleshooting configuration issues, such as invalid selectors during node lookup. |  | MaxItems: 5000 <br /> |
+| `nodeEvaluations` _[NodeEvaluation](#nodeevaluation) array_ | nodeEvaluations provides detailed insight into the rule's assessment for individual Nodes.<br />This is primarily used for auditing and debugging why specific Nodes were or<br />were not targeted by the rule. |  | MaxItems: 5000 <br /> |
+| `dryRunResults` _[DryRunResults](#dryrunresults)_ | dryRunResults captures the outcome of the rule evaluation when DryRun is enabled.<br />This field provides visibility into the actions the controller would have taken,<br />allowing users to preview taint changes before they are committed. |  | MinProperties: 1 <br /> |
 
 
 #### TaintStatus

--- a/docs/book/src/reference/api-spec.md
+++ b/docs/book/src/reference/api-spec.md
@@ -27,10 +27,28 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _string_ | type corresponds to the Node condition type being evaluated. |  | MaxLength: 316 <br />MinLength: 1 <br /> |
-| `currentStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | currentStatus is the actual status value observed on the Node, one of True, False, Unknown. |  | Enum: [True False Unknown] <br /> |
-| `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is the status value defined in the rule that must be matched, one of True, False, Unknown. |  | Enum: [True False Unknown] <br /> |
-| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the fallback status value configured in the rule spec, which is used for evaluation if the condition is not present on the Node. |  | Enum: [True False Unknown] <br /> |
+| `type` _string_ | type corresponds to the Node condition type being evaluated. |  | MaxLength: 316 <br />MinLength: 1 <br />Required: \{\} <br /> |
+| `currentStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | currentStatus is the actual status value observed on the Node, one of True, False, Unknown. |  | Enum: [True False Unknown] <br />Required: \{\} <br /> |
+| `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is the status value defined in the rule that must be matched, one of True, False, Unknown. |  | Enum: [True False Unknown] <br />Required: \{\} <br /> |
+| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the status a condition is evaluated to if the condition<br />is not found in a node. Reflects the defaultStatus configured in the rule<br />spec. |  | Enum: [True False Unknown] <br />Optional: \{\} <br /> |
+
+
+#### ConditionPolicy
+
+_Underlying type:_ _string_
+
+ConditionPolicy defines how the list of conditions is aggregated when evaluating a rule.
+
+_Validation:_
+- Enum: [allOf anyOf]
+
+_Appears in:_
+- [NodeReadinessRuleSpec](#nodereadinessrulespec)
+
+| Field | Description |
+| --- | --- |
+| `allOf` | ConditionPolicyAllOf requires ALL conditions to match their requiredStatus (default).<br /> |
+| `anyOf` | ConditionPolicyAnyOf requires at least ONE condition to match its requiredStatus.<br /> |
 
 
 #### ConditionRequirement
@@ -38,7 +56,8 @@ _Appears in:_
 
 
 ConditionRequirement defines a specific Node condition and the status value
-required to trigger the controller's action.
+required to trigger the controller's action. It also contains an optional
+default status value.
 
 
 
@@ -47,9 +66,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `type` _string_ | type of Node condition<br />Following kubebuilder validation is referred from https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition |  | MaxLength: 316 <br />MinLength: 1 <br /> |
-| `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is status of the condition, one of True, False, Unknown. |  | Enum: [True False Unknown] <br /> |
-| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the fallback status assumed when the condition is completely missing from the Node's status. <br /><br />Note: This field must not be set when enforcementMode is bootstrap-only. | Unknown | Enum: [True False Unknown] <br /> |
+| `type` _string_ | type of Node condition<br />Following kubebuilder validation is referred from https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition |  | MaxLength: 316 <br />MinLength: 1 <br />Required: \{\} <br /> |
+| `requiredStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | requiredStatus is status of the condition, one of True, False, Unknown. |  | Enum: [True False Unknown] <br />Required: \{\} <br /> |
+| `defaultStatus` _[ConditionStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#conditionstatus-v1-core)_ | defaultStatus is the status a condition is evaluated to if the condition<br />is not found in a node.<br />Accepted values are True, False, Unknown. It is optional.<br />When omitted, the effective default is Unknown, applied transparently by<br />the controller at evaluation time.<br />Note: This field must not be set when enforcementMode is bootstrap-only. |  | Enum: [True False Unknown] <br />Optional: \{\} <br /> |
 
 
 #### DryRunResults
@@ -66,11 +85,11 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `affectedNodes` _integer_ | affectedNodes is the total count of Nodes that match the rule's criteria. |  | Minimum: 0 <br /> |
-| `taintsToAdd` _integer_ | taintsToAdd is the number of Nodes that currently lack the specified taint and would have it applied. |  | Minimum: 0 <br /> |
-| `taintsToRemove` _integer_ | taintsToRemove is the number of Nodes that currently possess the<br />taint but no longer meet the criteria, leading to its removal. |  | Minimum: 0 <br /> |
-| `riskyOperations` _integer_ | riskyOperations represents the count of Nodes where required conditions<br />are missing entirely, potentially indicating an ambiguous node state. |  | Minimum: 0 <br /> |
-| `summary` _string_ | summary provides a human-readable overview of the dry run evaluation,<br />highlighting key findings or warnings. |  | MaxLength: 4096 <br />MinLength: 1 <br /> |
+| `affectedNodes` _integer_ | affectedNodes is the total count of Nodes that match the rule's criteria. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `taintsToAdd` _integer_ | taintsToAdd is the number of Nodes that currently lack the specified taint and would have it applied. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `taintsToRemove` _integer_ | taintsToRemove is the number of Nodes that currently possess the<br />taint but no longer meet the criteria, leading to its removal. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `riskyOperations` _integer_ | riskyOperations represents the count of Nodes where required conditions<br />are missing entirely, potentially indicating an ambiguous node state. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `summary` _string_ | summary provides a human-readable overview of the dry run evaluation,<br />highlighting key findings or warnings. |  | MaxLength: 4096 <br />MinLength: 1 <br />Required: \{\} <br /> |
 
 
 #### EnforcementMode
@@ -104,10 +123,10 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `nodeName` _string_ | nodeName is the name of the evaluated Node. |  | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$` <br /> |
-| `conditionResults` _[ConditionEvaluationResult](#conditionevaluationresult) array_ | conditionResults provides a detailed breakdown of each condition evaluation<br />for this Node. This allows for granular auditing of which specific<br />criteria passed or failed during the rule assessment. |  | MaxItems: 5000 <br /> |
-| `taintStatus` _[TaintStatus](#taintstatus)_ | taintStatus represents the taint status on the Node, one of Present, Absent. |  | Enum: [Present Absent] <br /> |
-| `lastEvaluationTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | lastEvaluationTime is the timestamp when the controller last assessed this Node. |  |  |
+| `nodeName` _string_ | nodeName is the name of the evaluated Node. |  | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$` <br />Required: \{\} <br /> |
+| `conditionResults` _[ConditionEvaluationResult](#conditionevaluationresult) array_ | conditionResults provides a detailed breakdown of each condition evaluation<br />for this Node. This allows for granular auditing of which specific<br />criteria passed or failed during the rule assessment. |  | MaxItems: 5000 <br />Required: \{\} <br /> |
+| `taintStatus` _[TaintStatus](#taintstatus)_ | taintStatus represents the taint status on the Node, one of Present, Absent. |  | Enum: [Present Absent] <br />Required: \{\} <br /> |
+| `lastEvaluationTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | lastEvaluationTime is the timestamp when the controller last assessed this Node. |  | Required: \{\} <br /> |
 
 
 #### NodeFailure
@@ -123,10 +142,10 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `nodeName` _string_ | nodeName is the name of the failed Node.<br />Following kubebuilder validation is referred from<br />https://github.com/kubernetes/apimachinery/blob/84d740c9e27f3ccc94c8bc4d13f1b17f60f7080b/pkg/util/validation/validation.go#L198 |  | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$` <br /> |
-| `reason` _string_ | reason provides a brief explanation of the evaluation result. |  | MaxLength: 256 <br />MinLength: 1 <br /> |
-| `message` _string_ | message is a human-readable message indicating details about the evaluation. |  | MaxLength: 10240 <br />MinLength: 1 <br /> |
-| `lastEvaluationTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | lastEvaluationTime is the timestamp of the last rule check failed for this Node. |  |  |
+| `nodeName` _string_ | nodeName is the name of the failed Node.<br />Following kubebuilder validation is referred from<br />https://github.com/kubernetes/apimachinery/blob/84d740c9e27f3ccc94c8bc4d13f1b17f60f7080b/pkg/util/validation/validation.go#L198 |  | MaxLength: 253 <br />MinLength: 1 <br />Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$` <br />Required: \{\} <br /> |
+| `reason` _string_ | reason provides a brief explanation of the evaluation result. |  | MaxLength: 256 <br />MinLength: 1 <br />Optional: \{\} <br /> |
+| `message` _string_ | message is a human-readable message indicating details about the evaluation. |  | MaxLength: 10240 <br />MinLength: 1 <br />Optional: \{\} <br /> |
+| `lastEvaluationTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta)_ | lastEvaluationTime is the timestamp of the last rule check failed for this Node. |  | Required: \{\} <br /> |
 
 
 #### NodeReadinessRule
@@ -143,9 +162,9 @@ NodeReadinessRule is the Schema for the NodeReadinessRules API.
 | --- | --- | --- | --- |
 | `apiVersion` _string_ | `readiness.node.x-k8s.io/v1alpha1` | | |
 | `kind` _string_ | `NodeReadinessRule` | | |
-| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
-| `spec` _[NodeReadinessRuleSpec](#nodereadinessrulespec)_ | spec defines the desired state of NodeReadinessRule |  |  |
-| `status` _[NodeReadinessRuleStatus](#nodereadinessrulestatus)_ | status defines the observed state of NodeReadinessRule |  | MinProperties: 1 <br /> |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  | Optional: \{\} <br /> |
+| `spec` _[NodeReadinessRuleSpec](#nodereadinessrulespec)_ | spec defines the desired state of NodeReadinessRule |  | Required: \{\} <br /> |
+| `status` _[NodeReadinessRuleStatus](#nodereadinessrulestatus)_ | status defines the observed state of NodeReadinessRule |  | MinProperties: 1 <br />Optional: \{\} <br /> |
 
 
 #### NodeReadinessRuleSpec
@@ -154,6 +173,13 @@ NodeReadinessRule is the Schema for the NodeReadinessRules API.
 
 NodeReadinessRuleSpec defines the desired state of NodeReadinessRule.
 
+We put the conditionPolicy immutability validation at `NodeReadinessRuleSpec` level instead of
+putting it on `conditionPolicy`. This is required because conditionPolicy is optional field. If a
+user transitions from an omitted field to an explicit "allOf" or vice-versa, field-level
+transition rules are not evaluated, since validations are only performed only when both self and
+oldSelf are present. By evaluating it at the struct level, we can safely use the `has()` macro to
+normalize absent values and force evaluation under any condition.
+
 
 
 _Appears in:_
@@ -161,11 +187,12 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `conditions` _[ConditionRequirement](#conditionrequirement) array_ | conditions contains a list of the Node conditions that defines the specific<br />criteria that must be met for taints to be managed on the target Node.<br />The presence or status of these conditions directly triggers the application or removal of Node taints. |  | MaxItems: 32 <br />MinItems: 1 <br /> |
-| `enforcementMode` _[EnforcementMode](#enforcementmode)_ | enforcementMode specifies how the controller maintains the desired state.<br />enforcementMode is one of bootstrap-only, continuous.<br />"bootstrap-only" applies the configuration once during initial setup.<br />"continuous" ensures the state is monitored and corrected throughout the resource lifecycle. |  | Enum: [bootstrap-only continuous] <br /> |
-| `taint` _[Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#taint-v1-core)_ | taint defines the specific Taint (Key, Value, and Effect) to be managed<br />on Nodes that meet the defined condition criteria. |  |  |
-| `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta)_ | nodeSelector limits the scope of this rule to a specific subset of Nodes. |  |  |
-| `dryRun` _boolean_ | dryRun when set to true, The controller will evaluate Node conditions and log intended taint modifications<br />without persisting changes to the cluster. Proposed actions are reflected in the resource status. |  |  |
+| `conditions` _[ConditionRequirement](#conditionrequirement) array_ | conditions contains a list of the Node conditions that defines the specific<br />criteria that must be met for taints to be managed on the target Node.<br />The presence or status of these conditions directly triggers the application or removal of Node taints. |  | MaxItems: 32 <br />MinItems: 1 <br />Required: \{\} <br /> |
+| `enforcementMode` _[EnforcementMode](#enforcementmode)_ | enforcementMode specifies how the controller maintains the desired state.<br />enforcementMode is one of bootstrap-only, continuous.<br />"bootstrap-only" applies the configuration once during initial setup.<br />"continuous" ensures the state is monitored and corrected throughout the resource lifecycle. |  | Enum: [bootstrap-only continuous] <br />Required: \{\} <br /> |
+| `taint` _[Taint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#taint-v1-core)_ | taint defines the specific Taint (Key, Value, and Effect) to be managed<br />on Nodes that meet the defined condition criteria.<br />The taint key must follow Kubernetes qualified name format: prefix/name<br />where prefix is 'readiness.k8s.io' (DNS subdomain) and name is a qualified<br />name (max 63 chars, alphanumeric, '-', '_', '.', must start and end with alphanumeric).<br />ref: git.k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/validate/content/kube.go#L24-L72<br />Supported effects: NoSchedule, PreferNoSchedule, NoExecute.<br />Caution: NoExecute evicts existing pods and can cause significant disruption<br />when combined with continuous enforcement mode. Prefer NoSchedule for most use cases. |  | Required: \{\} <br /> |
+| `nodeSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta)_ | nodeSelector limits the scope of this rule to a specific subset of Nodes. |  | Required: \{\} <br /> |
+| `conditionPolicy` _[ConditionPolicy](#conditionpolicy)_ | conditionPolicy controls how the conditions list is evaluated.<br />"allOf" (default) requires every condition to match its requiredStatus before the taint is removed.<br />"anyOf" requires at least one condition to match its requiredStatus.<br />anyOf cannot be used with enforcementMode: bootstrap-only. |  | Enum: [allOf anyOf] <br />Optional: \{\} <br /> |
+| `dryRun` _boolean_ | dryRun when set to true, The controller will evaluate Node conditions and log intended taint modifications<br />without persisting changes to the cluster. Proposed actions are reflected in the resource status. |  | Optional: \{\} <br /> |
 
 
 #### NodeReadinessRuleStatus
@@ -182,11 +209,11 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `observedGeneration` _integer_ | observedGeneration reflects the generation of the most recently observed NodeReadinessRule by the controller. |  | Minimum: 1 <br /> |
-| `appliedNodes` _string array_ | appliedNodes lists the names of Nodes where the taint has been successfully managed.<br />This provides a quick reference to the scope of impact for this rule. |  | MaxItems: 5000 <br />items:MaxLength: 253 <br /> |
-| `failedNodes` _[NodeFailure](#nodefailure) array_ | failedNodes lists the Nodes where the rule evaluation encountered an error.<br />This is used for troubleshooting configuration issues, such as invalid selectors during node lookup. |  | MaxItems: 5000 <br /> |
-| `nodeEvaluations` _[NodeEvaluation](#nodeevaluation) array_ | nodeEvaluations provides detailed insight into the rule's assessment for individual Nodes.<br />This is primarily used for auditing and debugging why specific Nodes were or<br />were not targeted by the rule. |  | MaxItems: 5000 <br /> |
-| `dryRunResults` _[DryRunResults](#dryrunresults)_ | dryRunResults captures the outcome of the rule evaluation when DryRun is enabled.<br />This field provides visibility into the actions the controller would have taken,<br />allowing users to preview taint changes before they are committed. |  | MinProperties: 1 <br /> |
+| `observedGeneration` _integer_ | observedGeneration reflects the generation of the most recently observed NodeReadinessRule by the controller. |  | Minimum: 1 <br />Optional: \{\} <br /> |
+| `appliedNodes` _string array_ | appliedNodes lists the names of Nodes where the taint has been successfully managed.<br />This provides a quick reference to the scope of impact for this rule. |  | MaxItems: 5000 <br />items:MaxLength: 253 <br />Optional: \{\} <br /> |
+| `failedNodes` _[NodeFailure](#nodefailure) array_ | failedNodes lists the Nodes where the rule evaluation encountered an error.<br />This is used for troubleshooting configuration issues, such as invalid selectors during node lookup. |  | MaxItems: 5000 <br />Optional: \{\} <br /> |
+| `nodeEvaluations` _[NodeEvaluation](#nodeevaluation) array_ | nodeEvaluations provides detailed insight into the rule's assessment for individual Nodes.<br />This is primarily used for auditing and debugging why specific Nodes were or<br />were not targeted by the rule. |  | MaxItems: 5000 <br />Optional: \{\} <br /> |
+| `dryRunResults` _[DryRunResults](#dryrunresults)_ | dryRunResults captures the outcome of the rule evaluation when DryRun is enabled.<br />This field provides visibility into the actions the controller would have taken,<br />allowing users to preview taint changes before they are committed. |  | MinProperties: 1 <br />Optional: \{\} <br /> |
 
 
 #### TaintStatus

--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -24,6 +24,19 @@ Typical taint keys look like:
 
 The segment after `readiness.k8s.io/` should describe the dependency or subsystem whose readiness is being guarded (for example, a CNI plugin, storage backend, or security agent). Treat this domain as reserved for the controller and closely related components, and avoid reusing it for unrelated taints.
 
+### Condition Evaluation Policy (`conditionPolicy`)
+
+When a rule specifies multiple conditions, the `conditionPolicy` determines how they are evaluated collectively to decide if the node should be tainted:
+
+- **`allOf` (Default)**: Every single condition listed in the rule must match its `requiredStatus`. If even one condition fails, the node is tainted. This is the standard behavior for ensuring all critical dependencies are healthy.
+- **`anyOf`**: At least ONE condition must match its `requiredStatus`. If no conditions match, the node is tainted. This is particularly useful for hardware that may be satisfied by multiple drivers, or systems with active/passive fallbacks.
+
+> [!IMPORTANT]
+> **`anyOf` is not supported with `bootstrap-only` rules.**
+>
+> `bootstrap-only` mode exists to verify that specific components have finished initializing. Using `anyOf` with `bootstrap-only` could lead to the node bootstrapping prematurely if just one component is ready, completely ignoring the initialization status of the others. The admission webhook enforces this restriction.
+
+
 ## Enforcement Modes
 
 The controller supports two distinct modes of enforcement, configured via `spec.enforcementMode`, to handle different operational needs.

--- a/docs/book/src/user-guide/getting-started.md
+++ b/docs/book/src/user-guide/getting-started.md
@@ -55,7 +55,14 @@ The `conditions` list defines the criteria. The controller watches the Node's st
 *   `requiredStatus`: The status required (`True`, `False`, or `Unknown`).
 *   `defaultStatus`: (Optional) The status to assume if the condition is completely missing from the Node's status. (`True`, `False`, or `Unknown`, defaults to `Unknown` if not provided). Must not be set in `bootstrap-only` mode. (See [Concepts](./concepts.md#default-condition-status-defaultstatus) for usage implications).
 
-### 3. Choose an Enforcement Mode
+### 3. Choose a Condition Policy (Optional)
+The `conditionPolicy` determines how the list of conditions is evaluated.
+*   **`allOf` (Default)**: Require every condition to match its required status.
+*   **`anyOf`**: Require at least one condition to match its required status. Must not be used in `bootstrap-only` mode.
+
+> For more details on `conditionPolicy`, see [Concepts](./concepts.md#condition-evaluation-policy-conditionpolicy).
+
+### 4. Choose an Enforcement Mode
 The `enforcementMode` determines how the controller manages the taint lifecycle.
 
 *   **`bootstrap-only`**: Use this for one-time initialization tasks (e.g., installing a kernel module or driver). Once the conditions are met once, the taint is removed and never reapplied.
@@ -63,7 +70,7 @@ The `enforcementMode` determines how the controller manages the taint lifecycle.
 
 > For more details on these modes, see [Concepts](./concepts.md#enforcement-modes).
 
-### 4. Configure the Taint
+### 5. Configure the Taint
 Define the taint that will block scheduling.
 *   **Key**: Must start with `readiness.k8s.io/` prefix.
 *   **Effect**:

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -248,6 +248,7 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 }
 
 // getConditionStatus gets the status of a condition on a node.
+// If the condition is not present, defaultStatus is returned with found=false.
 func (r *RuleReadinessController) getConditionStatus(
 	node *corev1.Node,
 	conditionType string,

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -323,9 +323,11 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 	defer timer.ObserveDuration()
 	log := ctrl.LoggerFrom(ctx)
 
-	// Evaluate all conditions (ALL logic)
-	allConditionsSatisfied := true
+	// Evaluate all conditions, accumulating the policy result alongside per-condition results.
 	conditionResults := make([]readinessv1alpha1.ConditionEvaluationResult, 0, len(rule.Spec.Conditions))
+	conditionPolicy := rule.Spec.GetConditionPolicy()
+	allSatisfied := true
+	anySatisfied := false
 
 	for _, condReq := range rule.Spec.Conditions {
 		effectiveStatus, conditionFound := r.getConditionStatus(
@@ -335,16 +337,18 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 		)
 		satisfied := effectiveStatus == condReq.RequiredStatus
 
+		if !satisfied {
+			allSatisfied = false
+			metrics.ConditionEvaluationFailures.WithLabelValues(rule.Name, condReq.Type).Inc()
+		} else {
+			anySatisfied = true
+		}
+
 		// observedStatus is the condition status of a node without applying the default
 		// fallback in case the condition is not found.
 		observedStatus := effectiveStatus
 		if !conditionFound {
 			observedStatus = corev1.ConditionUnknown
-		}
-
-		if !satisfied {
-			allConditionsSatisfied = false
-			metrics.ConditionEvaluationFailures.WithLabelValues(rule.Name, condReq.Type).Inc()
 		}
 
 		conditionResults = append(conditionResults, readinessv1alpha1.ConditionEvaluationResult{
@@ -360,12 +364,15 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 			"satisfied", satisfied)
 	}
 
-	// Determine taint action
-	shouldRemoveTaint := allConditionsSatisfied
+	// Determine taint action: allOf requires every condition satisfied; anyOf requires at least one.
+	shouldRemoveTaint := allSatisfied
+	if conditionPolicy == readinessv1alpha1.ConditionPolicyAnyOf {
+		shouldRemoveTaint = anySatisfied
+	}
 	currentlyHasTaint := r.hasTaintBySpec(node, rule.Spec.Taint)
 
 	log.Info("Evaluation result", "node", node.Name, "rule", rule.Name,
-		"allConditionsSatisfied", allConditionsSatisfied, "hasTaint", currentlyHasTaint)
+		"conditionPolicy", rule.Spec.GetConditionPolicy(), "conditionsSatisfied", shouldRemoveTaint, "hasTaint", currentlyHasTaint)
 
 	isFirstEvaluation := r.getPreviousNodeEvaluation(rule, node.Name) == nil
 
@@ -607,9 +614,11 @@ func (r *RuleReadinessController) processDryRun(ctx context.Context, rule *readi
 
 		affectedNodes++
 
-		// Simulate rule evaluation
-		allConditionsSatisfied := true
+		// Simulate rule evaluation using the rule's conditionPolicy
+		conditionPolicy := rule.Spec.GetConditionPolicy()
 		missingConditions := 0
+		allSatisfied := true
+		anySatisfied := false
 
 		for _, condReq := range rule.Spec.Conditions {
 			currentStatus, conditionFound := r.getConditionStatus(
@@ -621,11 +630,16 @@ func (r *RuleReadinessController) processDryRun(ctx context.Context, rule *readi
 				missingConditions++
 			}
 			if currentStatus != condReq.RequiredStatus {
-				allConditionsSatisfied = false
+				allSatisfied = false
+			} else {
+				anySatisfied = true
 			}
 		}
 
-		shouldRemoveTaint := allConditionsSatisfied
+		shouldRemoveTaint := allSatisfied
+		if conditionPolicy == readinessv1alpha1.ConditionPolicyAnyOf {
+			shouldRemoveTaint = anySatisfied
+		}
 		currentlyHasTaint := r.hasTaintBySpec(&node, rule.Spec.Taint)
 
 		if shouldRemoveTaint && currentlyHasTaint {

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -1918,6 +1918,15 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("enforcementMode is immutable"))
 		})
+
+		It("should reject attempts to change conditionPolicy", func() {
+			updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "immutability-test-rule"}, updatedRule)).To(Succeed())
+			updatedRule.Spec.ConditionPolicy = nodereadinessiov1alpha1.ConditionPolicyAnyOf
+			err := k8sClient.Update(ctx, updatedRule)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("conditionPolicy is immutable"))
+		})
 	})
 
 	Context("when existing rule is updated", func() {
@@ -2303,6 +2312,112 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				failedNames = append(failedNames, f.NodeName)
 			}
 			Expect(failedNames).NotTo(ContainElement("stale-recovery-node"))
+		})
+	})
+
+	Context("ConditionPolicy", func() {
+		var (
+			anyOfNode *corev1.Node
+			rule      *nodereadinessiov1alpha1.NodeReadinessRule
+		)
+
+		BeforeEach(func() {
+			anyOfNode = &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "anyof-test-node",
+					Labels: map[string]string{"anyof-test": "true"},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{Key: "readiness.k8s.io/condition-policy", Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: "gpu.example.com/HardwareDriverReady", Status: corev1.ConditionTrue},
+						{Type: "gpu.example.com/SoftwareFallbackReady", Status: corev1.ConditionFalse},
+					},
+				},
+			}
+
+			rule = &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "anyof-rule-removes-taint"},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					ConditionPolicy: nodereadinessiov1alpha1.ConditionPolicyAnyOf,
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{Type: "gpu.example.com/HardwareDriverReady", RequiredStatus: corev1.ConditionTrue},
+						{Type: "gpu.example.com/SoftwareFallbackReady", RequiredStatus: corev1.ConditionTrue},
+					},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/condition-policy", Effect: corev1.TaintEffectNoSchedule},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"anyof-test": "true"}},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+		})
+
+		It("anyOf: removes taint when at least one condition is satisfied", func() {
+			readinessController.updateRuleCache(ctx, rule)
+
+			Expect(k8sClient.Create(ctx, anyOfNode)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, anyOfNode)).To(Succeed()) }()
+			Expect(readinessController.evaluateRuleForNode(ctx, rule, anyOfNode)).To(Succeed())
+
+			// Taint should have been removed because HardwareDriverReady=True satisfies anyOf
+			Expect(readinessController.hasTaintBySpec(anyOfNode, rule.Spec.Taint)).To(BeFalse())
+
+			// conditionResults in status should reflect actual observed values
+			eval := readinessController.getPreviousNodeEvaluation(rule, anyOfNode.Name)
+			Expect(eval).NotTo(BeNil())
+			Expect(eval.ConditionResults).To(HaveLen(2))
+		})
+
+		It("anyOf: adds taint when no conditions are satisfied", func() {
+			rule.Name = "anyof-rule-adds-taint"
+			// Node has no taint; controller should add one
+			anyOfNode.Spec.Taints = nil
+			anyOfNode.Status.Conditions[0].Status = corev1.ConditionFalse
+
+			readinessController.updateRuleCache(ctx, rule)
+
+			Expect(k8sClient.Create(ctx, anyOfNode)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, anyOfNode)).To(Succeed()) }()
+			Expect(readinessController.evaluateRuleForNode(ctx, rule, anyOfNode)).To(Succeed())
+
+			// Taint should have been added because neither condition is satisfied
+			Expect(readinessController.hasTaintBySpec(anyOfNode, rule.Spec.Taint)).To(BeTrue())
+		})
+
+		It("allOf (explicit): adds taint when not all conditions are satisfied", func() {
+			rule.Name = "allof-explicit-rule"
+			rule.Spec.ConditionPolicy = nodereadinessiov1alpha1.ConditionPolicyAllOf
+
+			// Node has no taint; controller should add one
+			anyOfNode.Spec.Taints = nil
+
+			readinessController.updateRuleCache(ctx, rule)
+
+			Expect(k8sClient.Create(ctx, anyOfNode)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, anyOfNode)).To(Succeed()) }()
+			Expect(readinessController.evaluateRuleForNode(ctx, rule, anyOfNode)).To(Succeed())
+
+			// Taint should have been added because SoftwareFallbackReady is still False
+			Expect(readinessController.hasTaintBySpec(anyOfNode, rule.Spec.Taint)).To(BeTrue())
+		})
+		It("allOf (explicit): removes taint when all conditions are satisfied", func() {
+			rule.Name = "allof-explicit-removes-taint"
+			rule.Spec.ConditionPolicy = nodereadinessiov1alpha1.ConditionPolicyAllOf
+
+			// Set both conditions to True to satisfy allOf
+			anyOfNode.Status.Conditions[1].Status = corev1.ConditionTrue
+
+			readinessController.updateRuleCache(ctx, rule)
+
+			Expect(k8sClient.Create(ctx, anyOfNode)).To(Succeed())
+			defer func() { Expect(k8sClient.Delete(ctx, anyOfNode)).To(Succeed()) }()
+			Expect(readinessController.evaluateRuleForNode(ctx, rule, anyOfNode)).To(Succeed())
+
+			// Taint should be removed because all conditions are satisfied
+			Expect(readinessController.hasTaintBySpec(anyOfNode, rule.Spec.Taint)).To(BeFalse())
 		})
 	})
 })

--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -71,8 +71,8 @@ func (w *NodeReadinessRuleWebhook) validateSpec(
 		allErrs = append(allErrs, field.Required(field.NewPath("spec", "nodeSelector"), "nodeSelector must not be empty"))
 	}
 
-	// skip below checks for update because both `enforcementMode` and `conditions`
-	// are immutable as constrained by CEL XValidation rules
+	// skip below checks for update because `enforcementMode`, `conditions`,
+	// and `conditionPolicy` are immutable as constrained by CEL XValidation rules.
 	if isUpdate {
 		return allErrs
 	}
@@ -88,6 +88,16 @@ func (w *NodeReadinessRuleWebhook) validateSpec(
 			}
 		}
 	}
+
+	// validate anyOf conditionPolicy is not combined with bootstrap-only mode.
+	if spec.ConditionPolicy == readinessv1alpha1.ConditionPolicyAnyOf &&
+		spec.EnforcementMode == readinessv1alpha1.EnforcementModeBootstrapOnly {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "conditionPolicy"),
+			"anyOf conditionPolicy is not supported with bootstrap-only enforcementMode",
+		))
+	}
+
 	return allErrs
 }
 

--- a/internal/webhook/nodereadinessgaterule_webhook_test.go
+++ b/internal/webhook/nodereadinessgaterule_webhook_test.go
@@ -173,9 +173,40 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 			})
 		})
 
-		It("should accumulate errors across nodeSelector and multiple defaultStatus violations", func() {
+		Context("conditionPolicy with bootstrap-only", func() {
+			var spec readinessv1alpha1.NodeReadinessRuleSpec
+
+			BeforeEach(func() {
+				spec = readinessv1alpha1.NodeReadinessRuleSpec{
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+					ConditionPolicy: readinessv1alpha1.ConditionPolicyAnyOf,
+					EnforcementMode: readinessv1alpha1.EnforcementModeBootstrapOnly,
+				}
+			})
+
+			It("should skip conditionPolicy check on update (early return)", func() {
+				allErrs := webhook.validateSpec(spec, true)
+				Expect(allErrs).To(BeEmpty())
+			})
+
+			It("should allow anyOf conditionPolicy for continuous enforcement", func() {
+				spec.EnforcementMode = readinessv1alpha1.EnforcementModeContinuous
+				allErrs := webhook.validateSpec(spec, false)
+				Expect(allErrs).To(BeEmpty())
+			})
+
+			It("should forbid anyOf conditionPolicy with bootstrap-only enforcement", func() {
+				allErrs := webhook.validateSpec(spec, false)
+				Expect(allErrs).To(HaveLen(1))
+				Expect(allErrs[0].Field).To(Equal("spec.conditionPolicy"))
+				Expect(allErrs[0].Type).To(Equal(field.ErrorTypeForbidden))
+			})
+		})
+
+		It("should accumulate errors across nodeSelector, defaultStatus, and conditionPolicy violations", func() {
 			spec := readinessv1alpha1.NodeReadinessRuleSpec{
-				NodeSelector: metav1.LabelSelector{}, // empty → ErrorTypeRequired
+				NodeSelector:    metav1.LabelSelector{},                 // empty → ErrorTypeRequired
+				ConditionPolicy: readinessv1alpha1.ConditionPolicyAnyOf, // anyOf + bootstrap-only → ErrorTypeForbidden
 				Conditions: []readinessv1alpha1.ConditionRequirement{
 					{
 						Type:           "Ready",
@@ -191,10 +222,11 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 			}
 
 			allErrs := webhook.validateSpec(spec, false)
-			Expect(allErrs).To(HaveLen(3))
+			Expect(allErrs).To(HaveLen(4))
 			Expect(allErrs[0].Field).To(Equal("spec.nodeSelector"))
 			Expect(allErrs[1].Field).To(Equal("spec.conditions[0].defaultStatus"))
 			Expect(allErrs[2].Field).To(Equal("spec.conditions[1].defaultStatus"))
+			Expect(allErrs[3].Field).To(Equal("spec.conditionPolicy"))
 		})
 
 		It("should pass validation for valid spec", func() {
@@ -888,6 +920,32 @@ var _ = Describe("NodeReadinessRule Validation Webhook", func() {
 			allErrs = webhook.validateNodeReadinessRule(ctx, bootstrapDefaultStatusRule, false)
 			Expect(allErrs).To(HaveLen(1))
 			Expect(allErrs[0].Field).To(Equal("spec.conditions[0].defaultStatus"))
+			Expect(allErrs[0].Type).To(Equal(field.ErrorTypeForbidden))
+
+			// Test anyOf conditionPolicy used with bootstrap-only enforcement
+			bootstrapAnyOfPolicyRule := &readinessv1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "bootstrap-anyof-comprehensive"},
+				Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+					Conditions: []readinessv1alpha1.ConditionRequirement{
+						{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+					},
+					ConditionPolicy: readinessv1alpha1.ConditionPolicyAnyOf,
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+					Taint: corev1.Taint{
+						Key:    "readiness.k8s.io/test-key-2",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					EnforcementMode: readinessv1alpha1.EnforcementModeBootstrapOnly,
+				},
+			}
+
+			allErrs = webhook.validateNodeReadinessRule(ctx, bootstrapAnyOfPolicyRule, false)
+			Expect(allErrs).To(HaveLen(1))
+			Expect(allErrs[0].Field).To(Equal("spec.conditionPolicy"))
 			Expect(allErrs[0].Type).To(Equal(field.ErrorTypeForbidden))
 		})
 	})


### PR DESCRIPTION
- Add ConditionPolicy type (allOf/anyOf) to NodeReadinessRuleSpec
- Implement IsConditionsSatisfied() with allOf/anyOf evaluation logic
- Update controller to use conditionPolicy when evaluating conditions
- Add webhook validation to reject conditionPolicy with bootstrap-only mode
- Expand controller test coverage for conditionPolicy scenarios
- Update CRD schema to include conditionPolicy field

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


## Description
Introduces a conditionPolicy field (allOf | anyOf) to NodeReadinessRuleSpec that controls how the list of node conditions is aggregated when evaluating a rule.

- allOf (default): every condition must match its requiredStatus before the taint is removed — preserves existing behavior.
- anyOf: at least one condition matching its requiredStatus is sufficient to remove the taint.

## Related Issue #313 


## Type of Change
/kind feature /kind api-change



## Testing
- Added 4 new controller integration tests covering anyOf taint removal, anyOf taint addition, explicit allOf behavior, and missing-condition resolution under anyOf.
- Existing test suite continues to pass (default allOf path unchanged).

## Checklist
- [X] `make test` passes
- [X] `make lint` passes

## Does this PR introduce a user-facing change?

Added `conditionPolicy` field to `NodeReadinessRuleSpec` (enum: `allOf` | `anyOf`).
`allOf` (default) preserves existing behavior; `anyOf` removes the taint when at least one condition is satisfied.
`anyOf` cannot be combined with `enforcementMode: bootstrap-only`.

