### PR TITLE
docs: add Problem-gate (NPD) example using defaultStatus

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -14,6 +14,7 @@
 - [CNI Installation](./examples/cni-readiness.md)
 <!-- - [Storage Drivers](./examples/storage-readiness.md) -->
 - [Security Agent](./examples/security-agent-readiness.md)
+- [Problem-Gate (Default-Allow)](./examples/problem-gate-readiness.md)
 <!-- - [Device Drivers](./examples/dra-readiness.md) -->
 - [Constrained Impersonation](./examples/constrained-impersonation.md)
 

--- a/docs/book/src/examples/problem-gate-readiness.md
+++ b/docs/book/src/examples/problem-gate-readiness.md
@@ -13,7 +13,7 @@ The Node Readiness Controller supports two primary architectural patterns for ma
 
 2. **Problem-Gating (Default-Allow)**:
    - Used for problem detectors (such as Node Problem Detector, GPU fault monitors, or custom hardware health checkers) that report unhealthy node conditions (e.g., `MaintenanceRequired=True` or `HardwareDegraded=True`).
-   - During initial node bootstrap, the problem detector pod or DaemonSet may take time to start up, meaning the problem condition is physically **absent** from the Node's status.
+   - Many problem detectors are designed to only publish a condition when an actual problem is detected; otherwise, the condition remains completely **absent** from the Node's status. Furthermore, during initial bootstrap, the detector DaemonSet itself may take time to start.
    - Using a **default-allow** configuration (`defaultStatus: "False"` with `requiredStatus: "False"`), NRC treats the missing condition as healthy (`False`), allowing the node to be untainted immediately.
    - If the problem detector later detects an issue and reports `MaintenanceRequired=True`, NRC's **continuous enforcement** re-applies the taint to isolate the node.
 
@@ -94,13 +94,4 @@ status:
 
 When a node joins, NRC immediately untaints it. If a monitoring tool later patches the node status to `MaintenanceRequired=True`, NRC will automatically re-taint the node to prevent scheduling.
 
----
 
-## Enforcement Mode Considerations
-
-> [!WARNING]
-> `defaultStatus` is **not supported** with `bootstrap-only` enforcement mode.
->
-> `bootstrap-only` rules wait for conditions to be explicitly reported before completing the bootstrap phase. Pairing `bootstrap-only` with a satisfying `defaultStatus` would cause NRC to immediately untaint the node and mark bootstrap as complete before the condition is ever verified, permanently bypassing evaluation.
->
-> The admission webhook will explicitly reject any `NodeReadinessRule` that uses `defaultStatus` with `enforcementMode: bootstrap-only`. Always use **`continuous`** enforcement mode for problem-gating rules.

--- a/docs/book/src/examples/problem-gate-readiness.md
+++ b/docs/book/src/examples/problem-gate-readiness.md
@@ -1,0 +1,106 @@
+# Problem-Gate (Default-Allow)
+
+This guide demonstrates how to configure the Node Readiness Controller (NRC) to implement a **problem gate** using a **default-allow** pattern.
+
+## Background: Readiness Gating vs. Problem Gating
+
+The Node Readiness Controller supports two primary architectural patterns for managing node readiness and health:
+
+1. **Readiness-Gating (Default-Block)**:
+   - Used for critical infrastructure dependencies (such as CNI plugins, storage drivers, or security agents).
+   - The node is assumed **not ready** until the dependency explicitly reports `True` (e.g., `projectcalico.org/CalicoReady=True`).
+   - If the condition is absent during node bootstrap, the controller evaluates it as `Unknown`, which does not satisfy the requirement, keeping the startup taint in place.
+
+2. **Problem-Gating (Default-Allow)**:
+   - Used for problem detectors (such as Node Problem Detector, GPU fault monitors, or custom hardware health checkers) that report unhealthy node conditions (e.g., `MaintenanceRequired=True` or `HardwareDegraded=True`).
+   - During initial node bootstrap, the problem detector pod or DaemonSet may take time to start up, meaning the problem condition is physically **absent** from the Node's status.
+   - Using a **default-allow** configuration (`defaultStatus: "False"` with `requiredStatus: "False"`), NRC treats the missing condition as healthy (`False`), allowing the node to be untainted immediately.
+   - If the problem detector later detects an issue and reports `MaintenanceRequired=True`, NRC's **continuous enforcement** re-applies the taint to isolate the node.
+
+---
+
+## The Solution: `defaultStatus`
+
+By setting `defaultStatus: "False"` alongside `requiredStatus: "False"`, you tell NRC:
+> *"Assume the node does not have this problem unless a problem detector explicitly reports otherwise."*
+
+- **During Boot (Condition Absent)**: NRC resolves the missing condition to `False`, satisfying `requiredStatus: "False"`, and untaints the node immediately.
+- **After Boot (Problem Detected)**: If the problem detector publishes `MaintenanceRequired=True`, the condition is no longer absent and evaluates to `True`. This breaks the rule expectation (`requiredStatus: "False"`), causing NRC to re-apply the taint.
+
+---
+
+## Step-by-Step Guide
+
+> [!NOTE]
+> You can find the example manifest in [`examples/problem-gate-readiness`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/problem-gate-readiness).
+
+### 1. Bootstrap Nodes with a Startup Taint
+
+Configure your nodes to join the cluster with a startup taint. For example:
+
+```
+readiness.k8s.io/problem-gate=pending:NoSchedule
+```
+
+### 2. Define the NodeReadinessRule
+
+Create a `NodeReadinessRule` targeting the custom problem condition (e.g., `MaintenanceRequired`).
+
+```yaml
+# problem-gate-rule.yaml
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: problem-gate-rule
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux
+  conditions:
+    - type: MaintenanceRequired
+      requiredStatus: "False"
+      defaultStatus: "False"  # Default-allow: treat absent condition as False (healthy)
+  taint:
+    key: readiness.k8s.io/problem-gate
+    effect: NoSchedule
+  enforcementMode: continuous
+```
+
+### 3. Apply and Verify
+
+**Apply the rule:**
+```bash
+kubectl apply -f problem-gate-rule.yaml
+```
+
+**Verify rule evaluation:**
+Check the rule status to confirm how NRC evaluates nodes with absent conditions:
+```bash
+kubectl get nodereadinessrule problem-gate-rule -o yaml
+```
+
+Output excerpt:
+```yaml
+status:
+  nodeEvaluations:
+    - nodeName: node-1
+      satisfied: true
+      conditionResults:
+        - type: MaintenanceRequired
+          currentStatus: Unknown      # Condition is absent from Node status
+          requiredStatus: "False"
+          defaultStatus: "False"      # Default status applied during evaluation
+```
+
+When a node joins, NRC immediately untaints it. If a monitoring tool later patches the node status to `MaintenanceRequired=True`, NRC will automatically re-taint the node to prevent scheduling.
+
+---
+
+## Enforcement Mode Considerations
+
+> [!WARNING]
+> `defaultStatus` is **not supported** with `bootstrap-only` enforcement mode.
+>
+> `bootstrap-only` rules wait for conditions to be explicitly reported before completing the bootstrap phase. Pairing `bootstrap-only` with a satisfying `defaultStatus` would cause NRC to immediately untaint the node and mark bootstrap as complete before the condition is ever verified, permanently bypassing evaluation.
+>
+> The admission webhook will explicitly reject any `NodeReadinessRule` that uses `defaultStatus` with `enforcementMode: bootstrap-only`. Always use **`continuous`** enforcement mode for problem-gating rules.

--- a/docs/book/src/examples/problem-gate-readiness.md
+++ b/docs/book/src/examples/problem-gate-readiness.md
@@ -31,9 +31,6 @@ By setting `defaultStatus: "False"` alongside `requiredStatus: "False"`, you tel
 
 ## Step-by-Step Guide
 
-> [!NOTE]
-> You can find the example manifest in [`examples/problem-gate-readiness`](https://github.com/kubernetes-sigs/node-readiness-controller/tree/main/examples/problem-gate-readiness).
-
 ### 1. Bootstrap Nodes with a Startup Taint
 
 Configure your nodes to join the cluster with a startup taint. For example:
@@ -92,6 +89,6 @@ status:
           defaultStatus: "False"      # Default status applied during evaluation
 ```
 
-When a node joins, NRC immediately untaints it. If a monitoring tool later patches the node status to `MaintenanceRequired=True`, NRC will automatically re-taint the node to prevent scheduling.
+When a node joins, NRC immediately untaints it. If a maintenance controller later patches the node status to `MaintenanceRequired=True`, NRC will automatically re-taint the node to prevent scheduling.
 
 

--- a/examples/problem-gate-readiness/README.md
+++ b/examples/problem-gate-readiness/README.md
@@ -1,0 +1,17 @@
+# Problem-Gate (Default-Allow) Example
+
+This example demonstrates how to configure a `NodeReadinessRule` for problem-gating (default-allow) using `defaultStatus: "False"` and `requiredStatus: "False"`.
+
+## Quick Start
+
+1. Apply the problem gate rule:
+   ```bash
+   kubectl apply -f problem-gate-rule.yaml
+   ```
+
+2. Verify rule status and node evaluation:
+   ```bash
+   kubectl get nodereadinessrule problem-gate-rule -o yaml
+   ```
+
+For detailed documentation, see the [Problem-Gate Guide](../../docs/book/src/examples/problem-gate-readiness.md).

--- a/examples/problem-gate-readiness/problem-gate-rule.yaml
+++ b/examples/problem-gate-readiness/problem-gate-rule.yaml
@@ -1,0 +1,16 @@
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: problem-gate-rule
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux
+  conditions:
+    - type: MaintenanceRequired
+      requiredStatus: "False"
+      defaultStatus: "False"
+  taint:
+    key: readiness.k8s.io/problem-gate
+    effect: NoSchedule
+  enforcementMode: continuous


### PR DESCRIPTION
Fixes #289

## Summary

This PR adds a new example guide `docs/book/src/examples/problem-gate-npd.md` showing how to use the `defaultStatus` feature to set up a default-allow "problem-gate" (useful for integrating with controllers like Node Problem Detector).

## Content Added

1. **The Problem**: Node conditions (e.g. `KernelDeadlock`) are absent during the initial bootstrap of the node, which defaults to `Unknown` and stays blocked if the rule requires `False`.
2. **The Solution**: Use `defaultStatus: False` to allow the node to be immediately untainted on boot.
3. **Step-by-Step**: Shows a sample `NodeReadinessRule` and instructions for verifying the state.
4. **Warnings**: Highlights that `defaultStatus` with satisfying values should **not** be used in `bootstrap-only` rules since it permanently bypasses the evaluation.

Also updates `SUMMARY.md` to link to the new example in the Examples section.