### PR TITLE
add --pprof-bind-address flag to NRC controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,6 +64,7 @@ var (
 	metricsCertDir           string
 	leaderElectionNamespace  string
 	enableNodeStateMetrics   bool
+	pprofAddr                string
 	kubeAPIQPS               float64
 	kubeAPIBurst             int
 	nodeConcurrentReconciles int
@@ -87,6 +88,7 @@ func main() {
 	flag.StringVar(&metricsCertDir, "metrics-cert-dir", "",
 		"The directory where the certificates for metrics are located.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "", "The address the pprof endpoint binds to. Leave empty to disable.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -136,6 +138,7 @@ func main() {
 		Scheme:                  scheme,
 		Metrics:                 metricsServerOptions,
 		HealthProbeBindAddress:  probeAddr,
+		PprofBindAddress:        pprofAddr,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "ba65f13e.readiness.node.x-k8s.io",
 		LeaderElectionNamespace: leaderElectionNamespace,


### PR DESCRIPTION
With the new flag, we can expose the NRC controller's pprof HTTP endpoints, and capture heap and CPU profiles from the running NRC instance during our scale test harness.

controller-runtime project provides this with [PprofBindAddress](https://github.com/kubernetes-sigs/controller-runtime/blob/efff3590e02a2a27059a57a9535e87d829c3cc77/pkg/manager/manager.go#L248-L253) (so, we don't need to setup custom server)

Many  projects in the kubernetes ecosystem are using it - https://cs.k8s.io/?q=PprofBindAddress&i=nope&literal=nope&files=&excludeFiles=&repos=

---

A tiny tutorial on how to use it - https://book.kubebuilder.io/reference/pprof-tutorial.html, cc: @vitorfloriano

It will be useful for diagnosing memory growth and CPU hotspots during scale tests.


## Type of Change

/kind feature


## Testing
<!-- How was this tested? -->

## Checklist
- [x] `make test` passes
- [x] `make lint` passes


