### PR TITLE
chore: improve logging and error reporting across controllers, webhoooks , and the condition reporter

### DIFF
--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -167,6 +167,10 @@ func runCheck(ctx context.Context, httpClient *http.Client, clientset kubernetes
 		}
 	}
 
+	if !health.Healthy {
+		klog.InfoS("Health check unhealthy", "endpoint", checkEndpoint, "reason", health.Reason, "message", health.Message)
+	}
+
 	if err := updateNodeCondition(ctx, clientset, nodeName, conditionType, health, heartbeatPeriod); err != nil {
 		klog.ErrorS(err, "Failed to update node condition", "node", nodeName, "condition", conditionType)
 	}
@@ -319,6 +323,9 @@ func updateNodeCondition(ctx context.Context, client kubernetes.Interface, nodeN
 		}
 
 		_, err = client.CoreV1().Nodes().UpdateStatus(ctx, node, metav1.UpdateOptions{})
+		if err == nil {
+			klog.InfoS("Successfully updated node condition status", "node", nodeName, "condition", conditionType, "status", status, "reason", health.Reason)
+		}
 		return err
 	})
 }

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -349,6 +349,7 @@ func (r *RuleReadinessController) removeTaintBySpec(ctx context.Context, node *c
 func (r *RuleReadinessController) isBootstrapCompleted(ctx context.Context, nodeName string, ruleName string, ruleUID types.UID) bool {
 	node := &corev1.Node{}
 	if err := r.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "Failed to get node to check bootstrap completion status", "node", nodeName, "rule", ruleName)
 		return false
 	}
 	_, existsNew := node.Annotations[bootstrapAnnotationKey(ruleUID)]

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -523,7 +523,7 @@ func (r *RuleReadinessController) ruleAppliesTo(ctx context.Context, rule *readi
 
 	selector, err := metav1.LabelSelectorAsSelector(&rule.Spec.NodeSelector)
 	if err != nil {
-		log.Error(err, "Invalid node selector for rule", "rule", rule.Name)
+		log.V(4).Info("Skipping rule due to invalid node selector", "rule", rule.Name, "error", err.Error())
 		return false
 	}
 
@@ -533,6 +533,11 @@ func (r *RuleReadinessController) ruleAppliesTo(ctx context.Context, rule *readi
 // updateRuleCache updates the rule cache.
 func (r *RuleReadinessController) updateRuleCache(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule) {
 	log := ctrl.LoggerFrom(ctx)
+
+	if _, err := metav1.LabelSelectorAsSelector(&rule.Spec.NodeSelector); err != nil {
+		log.Error(err, "Rule has invalid node selector", "rule", rule.Name)
+	}
+
 	r.ruleCacheMutex.Lock()
 	defer r.ruleCacheMutex.Unlock()
 

--- a/internal/webhook/nodereadinessgaterule_webhook.go
+++ b/internal/webhook/nodereadinessgaterule_webhook.go
@@ -140,6 +140,7 @@ func (w *NodeReadinessRuleWebhook) nodeSelectorsOverlap(selector1, selector2 met
 	sel2, err2 := metav1.LabelSelectorAsSelector(&selector2)
 
 	if err1 != nil || err2 != nil {
+		ctrl.Log.Error(fmt.Errorf("failed to parse selectors"), "Assuming selectors overlap for safety", "err1", err1, "err2", err2)
 		// If we can't parse selectors, assume they overlap for safety
 		return true
 	}


### PR DESCRIPTION
## Description

This PR improves observability in the node-readiness-controller by adding logging for several failure paths that were previously silent, while avoiding excessive log noise in hot code paths.

### Changes

- Log unhealthy health check results and successful node condition updates in the readiness condition reporter.
- Log label selector parsing errors in the validating webhook instead of silently treating them as overlapping.
- Log Kubernetes API errors in `isBootstrapCompleted` to make bootstrap-related failures easier to diagnose.
- Validate node selectors when caching rules and log invalid selectors once.
- Downgrade selector parsing logs in `ruleAppliesTo` to a verbose log level to avoid flooding logs during reconciliation.

## Type of Change

/kind cleanup

## Checklist

- [x] `make test` 
- [ ] `make lint` 

## Does this PR introduce a user-facing change?


Improved logging for node readiness health checks, selector validation, and controller error paths to make debugging and operational troubleshooting easier.
