### PR TITLE
docs: document rule field selectors

### DIFF
--- a/docs/book/src/user-guide/concepts.md
+++ b/docs/book/src/user-guide/concepts.md
@@ -111,3 +111,18 @@ When `spec.dryRun: true` is set on a rule:
 *   The intended actions are reported in the `status.dryRunResults` field of the `NodeReadinessRule`.
 
 This allows you to preview exactly which nodes would be affected and identifying any potential misconfigurations (like a typo in a label selector) before they impact your cluster.
+
+## Selecting Rules
+
+`NodeReadinessRule` resources support Kubernetes field selectors for `spec.enforcementMode`, `spec.taint.key`, and `spec.dryRun`. Use them with `kubectl get nrr` to list only the rules relevant to an operational task.
+
+```sh
+# List bootstrap gates
+kubectl get nrr --field-selector spec.enforcementMode=bootstrap-only
+
+# Find the rule that manages a taint
+kubectl get nrr --field-selector spec.taint.key=readiness.k8s.io/network-not-ready
+
+# Review rules that only preview taint changes
+kubectl get nrr --field-selector spec.dryRun=true
+```

--- a/docs/book/src/user-guide/getting-started.md
+++ b/docs/book/src/user-guide/getting-started.md
@@ -160,6 +160,18 @@ kubectl get nodereadinessrule my-rule -o yaml
 
 Look for `dryRunResults` in the output to see which nodes would be tainted.
 
+## Selecting Rules
+
+Use field selectors to find rules by enforcement mode, taint key, or dry-run status:
+
+```sh
+kubectl get nrr --field-selector spec.enforcementMode=continuous
+kubectl get nrr --field-selector spec.taint.key=readiness.k8s.io/nfs-unhealthy
+kubectl get nrr --field-selector spec.dryRun=true
+```
+
+See [Concepts](./concepts.md#selecting-rules) for more details.
+
 ## Reporting Node Conditions
 
 The Node Readiness Controller only 'reacts' to observed conditions on the Node object. These conditions can be set by various tools:


### PR DESCRIPTION
## Description

  Document field-selector support for NodeReadinessRule resources, including
  examples for enforcement mode, taint key, and dry-run status.

  ## Related Issue

  Related to #312
  Closes #321 

  ## Type of Change

  /kind documentation

  ## Testing

  - `make docs`
  - `make test`

  ## Checklist

  - [x] `make test` passes
  - [x] `make lint` passes

  ## Does this PR introduce a user-facing change?

  Document how to filter NodeReadinessRule resources with Kubernetes field selectors.