### PR TITLE
feat: add Fleet Overview Grafana dashboard

### DIFF
--- a/config/grafana/dashboards/node-readiness-controller.json
+++ b/config/grafana/dashboards/node-readiness-controller.json
@@ -1,0 +1,208 @@
+{
+	"title": "Node Readiness Controller",
+	"uid": "node-readiness-controller",
+	"schemaVersion": 39,
+	"version": 1,
+	"editable": true,
+	"graphTooltip": 1,
+	"time": {
+		"from": "now-6h",
+		"to": "now"
+	},
+	"timezone": "browser",
+	"tags": ["node-readiness-controller"],
+	"panels": [
+		{
+			"id": 1,
+			"type": "row",
+			"title": "Fleet Overview",
+			"collapsed": false,
+			"gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+			"panels": []
+		},
+		{
+			"id": 2,
+			"type": "stat",
+			"title": "Total Managed Nodes",
+			"description": "Total nodes managed by NodeReadiness rules. If a node matches multiple rules, it is counted once for each matching rule.",
+			"gridPos": { "h": 8, "w": 6, "x": 0, "y": 1 },
+			"datasource": { "type": "prometheus", "uid": "${datasource}" },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "${datasource}" },
+					"expr": "sum(node_readiness_nodes_by_state)",
+					"legendFormat": "Total",
+					"refId": "A"
+				}
+			],
+			"fieldConfig": {
+				"defaults": {
+					"unit": "short",
+					"decimals": 0,
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [{ "color": "text", "value": null }]
+					}
+				},
+				"overrides": []
+			},
+			"options": {
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"orientation": "auto",
+				"textMode": "auto",
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto"
+			}
+		},
+		{
+			"id": 3,
+			"type": "stat",
+			"title": "Blocked Nodes",
+			"description": "Nodes that are currently unavailable for scheduling because they are still bootstrapping or not yet ready.",
+			"gridPos": { "h": 8, "w": 6, "x": 6, "y": 1 },
+			"datasource": { "type": "prometheus", "uid": "${datasource}" },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "${datasource}" },
+					"expr": "sum(node_readiness_nodes_by_state{state=~\"not_ready|bootstrapping\"})",
+					"legendFormat": "Blocked",
+					"refId": "A"
+				}
+			],
+			"fieldConfig": {
+				"defaults": {
+					"unit": "short",
+					"decimals": 0,
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{ "color": "green", "value": null },
+							{ "color": "red", "value": 1 }
+						]
+					}
+				},
+				"overrides": []
+			},
+			"options": {
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"orientation": "auto",
+				"textMode": "auto",
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto"
+			}
+		},
+		{
+			"id": 4,
+			"type": "stat",
+			"title": "Fleet Availability %",
+			"description": "The percentage of managed nodes that are ready and available to run workloads.",
+			"gridPos": { "h": 8, "w": 6, "x": 12, "y": 1 },
+			"datasource": { "type": "prometheus", "uid": "${datasource}" },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "${datasource}" },
+					"expr": "sum(node_readiness_nodes_by_state{state=\"ready\"}) / sum(node_readiness_nodes_by_state) * 100",
+					"legendFormat": "Availability",
+					"refId": "A"
+				}
+			],
+			"fieldConfig": {
+				"defaults": {
+					"unit": "percent",
+					"decimals": 1,
+					"min": 0,
+					"max": 100,
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{ "color": "red", "value": null },
+							{ "color": "yellow", "value": 80 },
+							{ "color": "green", "value": 99 }
+						]
+					}
+				},
+				"overrides": []
+			},
+			"options": {
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"orientation": "auto",
+				"textMode": "auto",
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto"
+			}
+		},
+		{
+			"id": 5,
+			"type": "stat",
+			"title": "Rules Without Nodes",
+			"description": "Rules whose node selector currently doesn't match any nodes. This may mean the selector is incorrect or the expected labels are missing.",
+			"gridPos": { "h": 8, "w": 6, "x": 18, "y": 1 },
+			"datasource": { "type": "prometheus", "uid": "${datasource}" },
+			"targets": [
+				{
+					"datasource": { "type": "prometheus", "uid": "${datasource}" },
+					"expr": "count(sum by (rule) (node_readiness_nodes_by_state) == 0) or vector(0)",
+					"legendFormat": "Rules Without Nodes",
+					"refId": "A"
+				}
+			],
+			"fieldConfig": {
+				"defaults": {
+					"unit": "short",
+					"decimals": 0,
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{ "color": "green", "value": null },
+							{ "color": "red", "value": 1 }
+						]
+					}
+				},
+				"overrides": []
+			},
+			"options": {
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"orientation": "auto",
+				"textMode": "auto",
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto"
+			}
+		}
+	],
+	"templating": {
+		"list": [
+			{
+				"name": "datasource",
+				"type": "datasource",
+				"query": "prometheus",
+				"current": {},
+				"hide": 0,
+				"refresh": 1
+			}
+		]
+	}
+}

--- a/config/grafana/kustomization.yaml
+++ b/config/grafana/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+configMapGenerator:
+- name: node-readiness-controller-dashboard
+  files:
+  - dashboards/node-readiness-controller.json
+  options:
+    disableNameSuffixHash: true
+    labels:
+      grafana_dashboard: "1"


### PR DESCRIPTION
## Description
This PR adds the Fleet Overview section, the first of five planned dashboard sections for node-readiness-controller.

The goal of this section is to provide operators with a quick overview of the fleet's current health.

### Panels in this PR
- **Total Managed Nodes** - count of nodes currently managed by the controller
- **Blocked Nodes** - Number of nodes currently unavailable, not yet ready.
- **Fleet Availability %** - Percentage of managed nodes that are currently ready to run workloads.
- **Rules Without Nodes** - Rules whose node selector currently doesn't match any nodes.

The dashboard is provisioned automatically through a Kustomize ConfigMap and loaded by Grafana, so no manual dashboard import is required.

Section 1 Documentation: [Overview + Section 1 doc](https://docs.google.com/document/d/1K13io8xVz4TW6Q9RLCXVwogqfa4RURsOph1k-KuzgoE/edit?usp=sharing)

### Metrics used
- `node_readiness_nodes_by_state` - Used by Total Managed Nodes, Blocked Nodes, and Fleet Availability.
- `node_readiness_selector_matched_nodes_total` - Used by Misconfigured Rules. Introduced in PR #286, so this panel will display data once that PR lands. 

### Screenshot

<img width="2530" height="1048" alt="image" src="https://github.com/user-attachments/assets/a16b592b-77f5-4ca2-9cc3-78dc95428d30" />

dashboard was tested using the demo environment in PR #326. Same environment will be extended as more dashboard sections are to be implemented.

### VIdeo demo

https://github.com/user-attachments/assets/dcfbc559-a877-4b24-a2ec-0baec0860b8e



### Related to Issue #459 

## Type of Change

/kind feature

## Testing

- Verified all four panels render correctly against live data in a kind + kwok test cluster
- Confirmed the setup is reproducible from a clean cluster
