### PR TITLE
test: add demo environment for testing

### DIFF
--- a/DEMO_ENVIRONMENT_SETUP.md
+++ b/DEMO_ENVIRONMENT_SETUP.md
@@ -1,0 +1,70 @@
+# Demo Environment Setup
+
+This demo environment is used to generate metrics for the Grafana dashboard during development and testing.
+
+## Rules
+
+Three rules, defined in [hack/test-workloads/](hack/test-workloads/)
+
+### GPU Driver Readiness
+
+Simulates GPU nodes waiting for the NVIDIA driver before becoming ready.
+
+- Mode: `bootstrap-only`
+- Behavior: Intentionally matches 0 nodes to simulate a misconfigured rule (for example, an incorrect node label).
+
+---
+
+### CSI Registration
+
+Simulates nodes waiting for a CSI driver to register during startup.
+
+- Mode: `bootstrap-only`
+- Applies to **8 nodes**
+- **6 nodes** become ready after different delays.
+- **2 nodes** remain blocked to simulate a failed bootstrap.
+
+This rule provides data for:
+
+- Blocked Nodes
+- Fleet Availability
+- Bootstrap latency metrics
+
+---
+
+### Security Agent Check-in
+
+Simulates a security agent reporting node health.
+
+- Mode: continuous
+- Applies to 12 nodes
+- Behavior: One node briefly becomes unhealthy before recovering to demonstrate continuous reconciliation.
+
+---
+
+# Reproducing the Demo
+
+From a clean cluster:
+
+```bash
+kubectl delete nodereadinessrule \
+  gpu-driver-readiness-rule \
+  csi-registration-rule \
+  security-agent-checkin-rule \
+  --ignore-not-found
+
+# Once the demo cluster and Grafana are running, run:
+./hack/test-workloads/demo-stagger-conditions.sh
+```
+
+## Expected Dashboard Values
+
+
+| Panel               | Expected Value |
+| ------------------- | -------------- |
+| Total Managed Nodes | 20             |
+| Blocked Nodes       | 2              |
+| Fleet Availability  | 90%            |
+| Zero-Match Rules    | 1              |
+
+> **Note:** This is the baseline demo environment used for the Fleet Overview section. Additional scenarios may be added as later dashboard sections require them.

--- a/hack/test-workloads/demo-csi-registration-rule.yaml
+++ b/hack/test-workloads/demo-csi-registration-rule.yaml
@@ -1,0 +1,21 @@
+# Blocks node scheduling until the CSI driver has registered with kubelet.
+#
+# Applies to nodes labeled nrc-demo=csi-registration.
+# Run demo-stagger-conditions.sh to reproduce the demo behavior.
+#
+# Most nodes become ready after different delays. kwok-stuck-4 and kwok-stuck-5 intentionally remain blocked to simulate a failed bootstrap.
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: csi-registration-rule
+spec:
+  conditions:
+    - type: "storage.k8s.io/CSIRegistered"
+      requiredStatus: "True"
+  taint:
+    key: "readiness.k8s.io/csi-registration"
+    effect: "NoSchedule"
+  enforcementMode: "bootstrap-only"
+  nodeSelector:
+    matchLabels:
+      nrc-demo: csi-registration

--- a/hack/test-workloads/demo-gpu-driver-readiness-rule.yaml
+++ b/hack/test-workloads/demo-gpu-driver-readiness-rule.yaml
@@ -1,0 +1,21 @@
+# Blocks node scheduling until the GPU driver is ready.
+#
+# This rule intentionally matches no nodes to simulate a common
+# configuration mistake, such as an incorrect or missing node label.
+#
+# Used to populate the Zero-Match Rules panel.
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: gpu-driver-readiness-rule
+spec:
+  conditions:
+    - type: "gpu.nvidia.com/DriverReady"
+      requiredStatus: "True"
+  taint:
+    key: "readiness.k8s.io/gpu-driver"
+    effect: "NoSchedule"
+  enforcementMode: "bootstrap-only"
+  nodeSelector:
+    matchLabels:
+      node-pool: gpu-workloads

--- a/hack/test-workloads/demo-security-agent-checkin-rule.yaml
+++ b/hack/test-workloads/demo-security-agent-checkin-rule.yaml
@@ -1,0 +1,21 @@
+# Blocks node scheduling until the security agent reports healthy.
+#
+# Applies to nodes labeled nrc-demo=security-agent.
+#
+# Uses continuous enforcement since the security agent can become unhealthy at any time. 
+# One node briefly goes unhealthy during the demo before recovering.
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: security-agent-checkin-rule
+spec:
+  conditions:
+    - type: "security.k8s.io/AgentHealthy"
+      requiredStatus: "True"
+  taint:
+    key: "readiness.k8s.io/security-agent"
+    effect: "NoSchedule"
+  enforcementMode: "continuous"
+  nodeSelector:
+    matchLabels:
+      nrc-demo: security-agent

--- a/hack/test-workloads/demo-stagger-conditions.sh
+++ b/hack/test-workloads/demo-stagger-conditions.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Sets up the demo environment used to validate the Grafana dashboard.
+#
+# This script:
+#   - Labels the demo nodes.
+#   - Applies the demo NodeReadinessRules.
+#   - Sets the initial node conditions.
+#   - Reproduces the scenarios used by the dashboard.
+#
+# Demo scenarios:
+#   - GPU Driver Readiness: intentionally matches no nodes.
+#   - CSI Registration: nodes become ready over time, with two nodes intentionally remaining blocked.
+#   - Security Agent Check-in: one node briefly becomes unhealthy before recovering.
+#
+# Usage:
+#   ./demo-stagger-conditions.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v kubectl &> /dev/null; then
+    echo "Error: kubectl command not found. Please install it."
+    exit 1
+fi
+
+CSI_NODES=(kwok-stuck-0 kwok-stuck-1 kwok-stuck-2 kwok-stuck-3 kwok-stuck-4 kwok-stuck-5 kwok-fail-test kwok-fail-test-2)
+SECURITY_AGENT_NODES=(kwok-flap-0 kwok-flap-1 kwok-flap-2 kwok-flap-3 kwok-flap-4 kwok-flap-5 kwok-unmanaged-0 kwok-unmanaged-1 kwok-unmanaged-2 kwok-unmanaged-3 kwok-unmanaged-4 kwok-unmanaged-5)
+
+echo "==> Labeling demo nodes..."
+kubectl label node "${CSI_NODES[@]}" nrc-demo=csi-registration --overwrite
+kubectl label node "${SECURITY_AGENT_NODES[@]}" nrc-demo=security-agent --overwrite
+
+echo "==> Applying demo rules..."
+kubectl apply -f "$SCRIPT_DIR/demo-gpu-driver-readiness-rule.yaml"
+kubectl apply -f "$SCRIPT_DIR/demo-csi-registration-rule.yaml"
+kubectl apply -f "$SCRIPT_DIR/demo-security-agent-checkin-rule.yaml"
+
+echo "==> Setting initial node conditions..."
+for n in "${CSI_NODES[@]}"; do
+    "$SCRIPT_DIR/flip-node-condition.sh" "$n" "storage.k8s.io/CSIRegistered" false
+done
+for n in "${SECURITY_AGENT_NODES[@]}"; do
+    "$SCRIPT_DIR/flip-node-condition.sh" "$n" "security.k8s.io/AgentHealthy" true
+done
+
+echo "==> Simulating CSI registration..."
+"$SCRIPT_DIR/flip-node-condition.sh" kwok-fail-test "storage.k8s.io/CSIRegistered" true
+sleep 3
+"$SCRIPT_DIR/flip-node-condition.sh" kwok-stuck-0 "storage.k8s.io/CSIRegistered" true
+sleep 5
+"$SCRIPT_DIR/flip-node-condition.sh" kwok-fail-test-2 "storage.k8s.io/CSIRegistered" true
+sleep 8
+"$SCRIPT_DIR/flip-node-condition.sh" kwok-stuck-1 "storage.k8s.io/CSIRegistered" true
+sleep 13
+"$SCRIPT_DIR/flip-node-condition.sh" kwok-stuck-2 "storage.k8s.io/CSIRegistered" true
+sleep 21
+"$SCRIPT_DIR/flip-node-condition.sh" kwok-stuck-3 "storage.k8s.io/CSIRegistered" true
+
+echo "==> Simulating a temporary security agent failure..."
+"$SCRIPT_DIR/flip-node-condition.sh" kwok-flap-2 "security.k8s.io/AgentHealthy" false
+sleep 5
+"$SCRIPT_DIR/flip-node-condition.sh" kwok-flap-2 "security.k8s.io/AgentHealthy" true
+
+echo ""
+echo "Demo environment is ready."
+echo ""
+echo "Expected state:"
+echo "  • CSI Registration: 6 ready, 2 blocked"
+echo "  • Security Agent: 12 ready"
+echo "  • GPU Driver: 0 matched nodes"


### PR DESCRIPTION
## Description

This PR adds a reusable demo environment for validating the Grafana dashboards during development and testing.

It includes:
- Three demo manifests covering some readiness scenarios:
    - `gpu-driver-readiness-rule`
    - `csi-registration-rule`
    - `security-agent-checkin-rule`
- `demo-stagger-conditions.sh` to label demo nodes, apply the rules, initialize node conditions, and reproduce the demo scenarios.
- `DEMO_ENVIRONMENT_SETUP.md` describing the demo setup and expected dashboard state.

This demo environment is intended to serve as the baseline for validating the Grafana dashboards. As more dashboard sections are implemented, it can be extended with new scenarios instead of creating separate demo environments.

## Type of Change
/kind feature

## Testing
- Verified the demo environment from a clean cluster
- Expected node states and dashboard values were reproduced