### PR TITLE
fix: clean up evaluation duration metric on rule deletion

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -212,6 +212,7 @@ func (r *RuleReconciler) reconcileDelete(ctx context.Context, rule *readinessv1a
 	metrics.RuleLastReconciliationTime.DeleteLabelValues(rule.Name)
 	metrics.BootstrapCompleted.DeleteLabelValues(rule.Name)
 	metrics.BootstrapDuration.DeleteLabelValues(rule.Name)
+	metrics.EvaluationDuration.DeleteLabelValues(rule.Name)
 
 	// For multi-label metrics, use DeletePartialMatch to wipe all combinations
 	metrics.NodesByState.DeletePartialMatch(ruleLabel)


### PR DESCRIPTION
## Description
When a rule is deleted, `reconcileDelete` removes that rule's metrics so they don't pile up.
`node_readiness_evaluation_duration_seconds` is missing from that list.

It gained a `rule` label in #244. Before that it had no labels and nothing per-rule to remove,
so leaving it out was correct. Once it became per-rule it needed removing too, but the list
wasn't updated.

So the metric for a deleted rule is never dropped: the memory is never freed, and deleted rules
keep showing up,

This adds it to the existing list.
## Related Issue

None

## Type of Change

/kind bug
/kind regression

## Testing

verified with a temporary test (not included in this PR): create a rule, reconcile it,
delete it, then check what is still exported for that rule name. `RuleLastReconciliationTime`
serves as a control, since it is already in the cleanup list.

Before the fix:
before delete: evaluation_duration=1   last_reconciliation=1
after  delete: evaluation_duration=1   last_reconciliation=0

After the fix, `evaluation_duration` drops to 0 on deletion, matching the control.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Fixed a leak where node_readiness_evaluation_duration_seconds was kept for deleted
NodeReadinessRules
```