### PR TITLE
fix: isolate rule status cache per rule-reconcile workers

### DIFF
--- a/internal/controller/helper_unit_test.go
+++ b/internal/controller/helper_unit_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -27,7 +26,6 @@ import (
 
 	readinessv1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
 )
-
 
 func TestBootstrapAnnotationKey(t *testing.T) {
 	g := NewWithT(t)
@@ -78,7 +76,7 @@ func TestGetApplicableRulesForNode_DeepCopy(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	c.updateRuleCache(ctx, rule)
 
 	node := &corev1.Node{
@@ -101,4 +99,3 @@ func TestGetApplicableRulesForNode_DeepCopy(t *testing.T) {
 
 	g.Expect(cachedRule.Status.AppliedNodes).To(Equal([]string{"node-1"}))
 }
-

--- a/internal/controller/helper_unit_test.go
+++ b/internal/controller/helper_unit_test.go
@@ -17,11 +17,17 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	readinessv1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
 )
+
 
 func TestBootstrapAnnotationKey(t *testing.T) {
 	g := NewWithT(t)
@@ -52,3 +58,47 @@ func TestLegacyBootstrapAnnotationKey(t *testing.T) {
 	key := legacyBootstrapAnnotationKey("my-rule")
 	g.Expect(key).To(Equal("readiness.k8s.io/bootstrap-completed-my-rule"))
 }
+
+func TestGetApplicableRulesForNode_DeepCopy(t *testing.T) {
+	g := NewWithT(t)
+
+	c := &RuleReadinessController{
+		ruleCache: make(map[string]*readinessv1alpha1.NodeReadinessRule),
+	}
+
+	rule := &readinessv1alpha1.NodeReadinessRule{
+		ObjectMeta: metav1.ObjectMeta{Name: "rule-1"},
+		Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+			NodeSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+		},
+		Status: readinessv1alpha1.NodeReadinessRuleStatus{
+			AppliedNodes: []string{"node-1"},
+		},
+	}
+
+	ctx := context.Background()
+	c.updateRuleCache(ctx, rule)
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+
+	rules := c.getApplicableRulesForNode(ctx, node)
+	g.Expect(rules).To(HaveLen(1))
+
+	// Mutate the returned rule's status
+	rules[0].Status.AppliedNodes = append(rules[0].Status.AppliedNodes, "node-2")
+
+	// Ensure the cached rule was isolated and not mutated
+	c.ruleCacheMutex.RLock()
+	cachedRule := c.ruleCache["rule-1"]
+	c.ruleCacheMutex.RUnlock()
+
+	g.Expect(cachedRule.Status.AppliedNodes).To(Equal([]string{"node-1"}))
+}
+

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -511,7 +511,7 @@ func (r *RuleReadinessController) getApplicableRulesForNode(ctx context.Context,
 
 	for _, rule := range r.ruleCache {
 		if r.ruleAppliesTo(ctx, rule, node) {
-			applicableRules = append(applicableRules, rule)
+			applicableRules = append(applicableRules, rule.DeepCopy())
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR resolves data races and memory leaks in the controller when `--node-concurrent-reconciles` is set to > 1:

1. **Rule Cache Data Race Fix**: Updated `RuleReadinessController.getApplicableRulesForNode` to return `rule.DeepCopy()` pointers. Previously, returning pointers straight from `r.ruleCache` caused concurrent `NodeReconciler` worker threads to mutate `rule.Status.NodeEvaluations` and `rule.Status.FailedNodes` on the shared in-memory pointer without synchronization, resulting in Go data races and memory corruption under concurrent node reconciliation load.
~~2. **Prometheus Metric Leak Fix**: Added `metrics.EvaluationDuration.DeleteLabelValues(rule.Name)` to `reconcileDelete` in `nodereadinessrule_controller.go` to ensure histogram metric series are unregistered when a rule CR is deleted.~~
3. **Unit Tests**: Added `TestGetApplicableRulesForNode_DeepCopy` in `helper_unit_test.go` to verify that `getApplicableRulesForNode` returns isolated, deep-copied rule instances.

## Related Issue

Fixes #331

## Type of Change

/kind bug

## Testing

- Unit testing via `go test -v ./internal/controller/...`
- Verified deep-copy isolation unit test passes without race conditions.

## Checklist

- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```
