### PR TITLE
fix: clear stale FailedNodes entry when a node recovers

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -159,6 +159,8 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 			r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
 			errs = append(errs, err)
 			metrics.Failures.WithLabelValues(rule.Name, "EvaluationError").Inc()
+		} else {
+			r.clearNodeFailure(rule, node.Name)
 		}
 
 		// Persist the rule status
@@ -422,6 +424,17 @@ func (r *RuleReadinessController) recordNodeFailure(
 		LastEvaluationTime: metav1.Now(),
 	})
 
+	rule.Status.FailedNodes = failedNodes
+}
+
+// clearNodeFailure removes any failure record for a specific node from the rule status.
+func (r *RuleReadinessController) clearNodeFailure(rule *readinessv1alpha1.NodeReadinessRule, nodeName string) {
+	var failedNodes []readinessv1alpha1.NodeFailure
+	for _, failure := range rule.Status.FailedNodes {
+		if failure.NodeName != nodeName {
+			failedNodes = append(failedNodes, failure)
+		}
+	}
 	rule.Status.FailedNodes = failedNodes
 }
 

--- a/internal/controller/node_controller_unit_test.go
+++ b/internal/controller/node_controller_unit_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	readinessv1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
+)
+
+func TestClearNodeFailure(t *testing.T) {
+	g := NewWithT(t)
+
+	c := &RuleReadinessController{}
+
+	rule := &readinessv1alpha1.NodeReadinessRule{
+		Status: readinessv1alpha1.NodeReadinessRuleStatus{
+			FailedNodes: []readinessv1alpha1.NodeFailure{
+				{NodeName: "node-1", Reason: "EvaluationError", LastEvaluationTime: metav1.Now()},
+				{NodeName: "node-2", Reason: "EvaluationError", LastEvaluationTime: metav1.Now()},
+			},
+		},
+	}
+
+	c.clearNodeFailure(rule, "node-1")
+
+	g.Expect(rule.Status.FailedNodes).To(HaveLen(1))
+	g.Expect(rule.Status.FailedNodes[0].NodeName).To(Equal("node-2"))
+}
+
+func TestRecordThenClearNodeFailure(t *testing.T) {
+	g := NewWithT(t)
+
+	c := &RuleReadinessController{}
+
+	rule := &readinessv1alpha1.NodeReadinessRule{}
+
+	// A node fails evaluation and is recorded.
+	c.recordNodeFailure(rule, "node-1", "EvaluationError", "boom")
+	g.Expect(rule.Status.FailedNodes).To(HaveLen(1))
+
+	// The node later recovers; the failure record must be cleared.
+	c.clearNodeFailure(rule, "node-1")
+	g.Expect(rule.Status.FailedNodes).To(BeEmpty())
+}


### PR DESCRIPTION
## Description

This is a follow-up to #332, extracted per @ajaysundark's request to review #209 and evaluate the `recordFailure`/stale `FailedNodes` patch separately from the ruleCache data-race fix.

`processNodeAgainstAllRules` (the `NodeReconciler` path in `node_controller.go`) records a `NodeFailure` via `recordNodeFailure` when `evaluateRuleForNode` errors, but never clears it when the node later evaluates successfully. Since `rule` here is a deep-copied snapshot carried over from `ruleCache` (per #332), a stale failure entry from a prior reconcile keeps getting copied forward into `rule.Status.FailedNodes` on every subsequent successful evaluation, so a recovered node is stuck listed as failed indefinitely.

`nodereadinessrule_controller.go`'s `processAllNodesForRule` (the `RuleReconciler` path) already clears `FailedNodes` inline on the success branch, so it isn't affected — only the `NodeReconciler` path needed the fix.

This adds a `clearNodeFailure` helper (matching the existing `recordNodeFailure` pattern) and calls it on the success branch of `processNodeAgainstAllRules`.

## Related

Follow-up to #332, evaluated from #209.

## Type of Change

/kind bug

## Testing

- `go build ./...`
- `go vet ./...`
- `go test ./internal/controller/...`
- `golangci-lint run ./internal/controller/...`
- Added `TestClearNodeFailure` and `TestRecordThenClearNodeFailure` covering the helper directly.

## Checklist

- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Fixed a bug where a node that recovered from an evaluation error remained listed in a NodeReadinessRule's status.failedNodes indefinitely.
```
