### PR TITLE
cleanup(reporter): address review follow-ups on unchanged-condition skip

### DIFF
--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"slices"
 	"syscall"
 	"time"
 
@@ -303,51 +304,46 @@ func updateNodeCondition(ctx context.Context, client kubernetes.Interface, nodeN
 			status = corev1.ConditionTrue
 		}
 
-		// Find the condition we report on, carrying its transition time over for
-		// as long as the status is unchanged.
-		var transitionTime metav1.Time
-		idx := -1
-		for i, condition := range node.Status.Conditions {
-			if string(condition.Type) == conditionType {
-				idx = i
-				if condition.Status == status {
-					transitionTime = condition.LastTransitionTime
+		// Find the condition we report on, if it already exists.
+		idx := slices.IndexFunc(node.Status.Conditions, func(c corev1.NodeCondition) bool {
+			return string(c.Type) == conditionType
+		})
 
-					// Nothing has changed about the condition, so skip the update
-					// to avoid unnecessary etcd write amplification.
-					// Write still forced once LastHeartbeatTime is stale,
-					// this is to signal that the reporter is alive
-					if condition.Reason == health.Reason &&
-						condition.Message == health.Message &&
-						time.Since(condition.LastHeartbeatTime.Time) < heartbeatPeriod {
-						klog.V(4).InfoS("Condition state unchanged, skipping node status update", "node", nodeName, "condition", conditionType)
-						reporterConditionWritesTotal.WithLabelValues("skipped").Inc()
-						return nil
-					}
-				}
-				break
-			}
-		}
-
-		if transitionTime.IsZero() {
-			transitionTime = now
-		}
-
-		// Create condition
-		condition := corev1.NodeCondition{
+		// Create a new condition
+		newCondition := corev1.NodeCondition{
 			Type:               corev1.NodeConditionType(conditionType),
 			Status:             status,
 			LastHeartbeatTime:  now,
-			LastTransitionTime: transitionTime,
+			LastTransitionTime: now,
 			Reason:             health.Reason,
 			Message:            health.Message,
 		}
 
 		// Update node status
 		if idx >= 0 {
-			node.Status.Conditions[idx] = condition
+			existingCondition := node.Status.Conditions[idx]
+
+			// Nothing has changed about the condition and heartbeat is fresh
+			// skip write to avoid unnecessary etcd churn, force write if heartbeat is stale
+			if existingCondition.Status == status &&
+				existingCondition.Reason == health.Reason &&
+				existingCondition.Message == health.Message &&
+				time.Since(existingCondition.LastHeartbeatTime.Time) < heartbeatPeriod {
+				klog.V(4).InfoS("Condition state unchanged, skipping node status update", "node", nodeName, "condition", conditionType)
+				reporterConditionWritesTotal.WithLabelValues("skipped").Inc()
+				return nil
+			}
+
+			// Status is unchanged (even though something else, like Message, updated) —
+			// preserve the original transition time.
+			// A zero value means no transition was recorded, fallback to now
+			if existingCondition.Status == status && !existingCondition.LastTransitionTime.IsZero() {
+				newCondition.LastTransitionTime = existingCondition.LastTransitionTime
+			}
+
+			node.Status.Conditions[idx] = newCondition
 		} else {
-			node.Status.Conditions = append(node.Status.Conditions, condition)
+			node.Status.Conditions = append(node.Status.Conditions, newCondition)
 		}
 
 		_, err = client.CoreV1().Nodes().UpdateStatus(ctx, node, metav1.UpdateOptions{})

--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -309,7 +309,6 @@ func updateNodeCondition(ctx context.Context, client kubernetes.Interface, nodeN
 			return string(c.Type) == conditionType
 		})
 
-		// Create a new condition
 		newCondition := corev1.NodeCondition{
 			Type:               corev1.NodeConditionType(conditionType),
 			Status:             status,
@@ -319,7 +318,6 @@ func updateNodeCondition(ctx context.Context, client kubernetes.Interface, nodeN
 			Message:            health.Message,
 		}
 
-		// Update node status
 		if idx >= 0 {
 			existingCondition := node.Status.Conditions[idx]
 
@@ -336,8 +334,7 @@ func updateNodeCondition(ctx context.Context, client kubernetes.Interface, nodeN
 
 			// Status is unchanged (even though something else, like Message, updated) —
 			// preserve the original transition time.
-			// A zero value means no transition was recorded, fallback to now
-			if existingCondition.Status == status && !existingCondition.LastTransitionTime.IsZero() {
+			if existingCondition.Status == status {
 				newCondition.LastTransitionTime = existingCondition.LastTransitionTime
 			}
 

--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -303,54 +303,44 @@ func updateNodeCondition(ctx context.Context, client kubernetes.Interface, nodeN
 			status = corev1.ConditionTrue
 		}
 
-		// Find existing condition to preserve transition time if status hasn't changed
-		var transitionTime metav1.Time
+		// Find the existing condition of this type: it drives both the write
+		// skip below and the transition time carried over onto the new condition.
 		var existingCondition *corev1.NodeCondition
-
 		for _, condition := range node.Status.Conditions {
 			if string(condition.Type) == conditionType {
 				condCopy := condition
 				existingCondition = &condCopy
-				if condition.Status == status {
-					transitionTime = condition.LastTransitionTime
-				}
 				break
 			}
 		}
 
 		// If the semantic state is completely unchanged, bypass the API write
 		// to prevent etcd write amplification and control plane flooding.
-		needsUpdate := true
-		if existingCondition != nil && existingCondition.Status == status && existingCondition.Reason == health.Reason && existingCondition.Message == health.Message {
-			needsUpdate = false
-			/*
-				NOTE: Skipping the write stops refreshing the LastHeartbeatTime on every tick.
-				To mitigate this, force an update every 5 minutes even if the state is unchanged.
-			*/
-			if time.Since(existingCondition.LastHeartbeatTime.Time) >= heartbeatPeriod {
-				needsUpdate = true
-			}
-		}
-
-		if !needsUpdate {
-			// state has not changed for specified period, skip the write
+		// Skipping the write also stops refreshing LastHeartbeatTime, which is the
+		// only signal that the reporter is still alive, so a write is still forced
+		// once the condition has gone untouched for heartbeatPeriod.
+		if existingCondition != nil &&
+			existingCondition.Status == status &&
+			existingCondition.Reason == health.Reason &&
+			existingCondition.Message == health.Message &&
+			time.Since(existingCondition.LastHeartbeatTime.Time) < heartbeatPeriod {
 			klog.V(4).InfoS("Condition state unchanged, skipping node status update", "node", nodeName, "condition", conditionType)
 			reporterConditionWritesTotal.WithLabelValues("skipped").Inc()
 			return nil
 		}
 
-		if transitionTime.IsZero() {
-			transitionTime = now
-		}
-
-		// Create condition
+		// Create condition, preserving the transition time if the status itself
+		// hasn't changed; a status flip starts a new transition.
 		condition := corev1.NodeCondition{
 			Type:               corev1.NodeConditionType(conditionType),
 			Status:             status,
 			LastHeartbeatTime:  now,
-			LastTransitionTime: transitionTime,
+			LastTransitionTime: now,
 			Reason:             health.Reason,
 			Message:            health.Message,
+		}
+		if existingCondition != nil && existingCondition.Status == status && !existingCondition.LastTransitionTime.IsZero() {
+			condition.LastTransitionTime = existingCondition.LastTransitionTime
 		}
 
 		// Update node status

--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -303,57 +303,50 @@ func updateNodeCondition(ctx context.Context, client kubernetes.Interface, nodeN
 			status = corev1.ConditionTrue
 		}
 
-		// Find the existing condition of this type: it drives both the write
-		// skip below and the transition time carried over onto the new condition.
-		var existingCondition *corev1.NodeCondition
-		for _, condition := range node.Status.Conditions {
+		// Find the condition we report on, carrying its transition time over for
+		// as long as the status is unchanged.
+		var transitionTime metav1.Time
+		idx := -1
+		for i, condition := range node.Status.Conditions {
 			if string(condition.Type) == conditionType {
-				condCopy := condition
-				existingCondition = &condCopy
+				idx = i
+				if condition.Status == status {
+					transitionTime = condition.LastTransitionTime
+
+					// Nothing has changed about the condition, so skip the update
+					// to avoid unnecessary etcd write amplification.
+					// Write still forced once LastHeartbeatTime is stale,
+					// this is to signal that the reporter is alive
+					if condition.Reason == health.Reason &&
+						condition.Message == health.Message &&
+						time.Since(condition.LastHeartbeatTime.Time) < heartbeatPeriod {
+						klog.V(4).InfoS("Condition state unchanged, skipping node status update", "node", nodeName, "condition", conditionType)
+						reporterConditionWritesTotal.WithLabelValues("skipped").Inc()
+						return nil
+					}
+				}
 				break
 			}
 		}
 
-		// If the semantic state is completely unchanged, bypass the API write
-		// to prevent etcd write amplification and control plane flooding.
-		// Skipping the write also stops refreshing LastHeartbeatTime, which is the
-		// only signal that the reporter is still alive, so a write is still forced
-		// once the condition has gone untouched for heartbeatPeriod.
-		if existingCondition != nil &&
-			existingCondition.Status == status &&
-			existingCondition.Reason == health.Reason &&
-			existingCondition.Message == health.Message &&
-			time.Since(existingCondition.LastHeartbeatTime.Time) < heartbeatPeriod {
-			klog.V(4).InfoS("Condition state unchanged, skipping node status update", "node", nodeName, "condition", conditionType)
-			reporterConditionWritesTotal.WithLabelValues("skipped").Inc()
-			return nil
+		if transitionTime.IsZero() {
+			transitionTime = now
 		}
 
-		// Create condition, preserving the transition time if the status itself
-		// hasn't changed; a status flip starts a new transition.
+		// Create condition
 		condition := corev1.NodeCondition{
 			Type:               corev1.NodeConditionType(conditionType),
 			Status:             status,
 			LastHeartbeatTime:  now,
-			LastTransitionTime: now,
+			LastTransitionTime: transitionTime,
 			Reason:             health.Reason,
 			Message:            health.Message,
 		}
-		if existingCondition != nil && existingCondition.Status == status && !existingCondition.LastTransitionTime.IsZero() {
-			condition.LastTransitionTime = existingCondition.LastTransitionTime
-		}
 
 		// Update node status
-		found := false
-		for i, c := range node.Status.Conditions {
-			if string(c.Type) == conditionType {
-				node.Status.Conditions[i] = condition
-				found = true
-				break
-			}
-		}
-
-		if !found {
+		if idx >= 0 {
+			node.Status.Conditions[idx] = condition
+		} else {
 			node.Status.Conditions = append(node.Status.Conditions, condition)
 		}
 

--- a/cmd/readiness-condition-reporter/main_test.go
+++ b/cmd/readiness-condition-reporter/main_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -333,13 +334,14 @@ func TestUpdateNodeCondition(t *testing.T) {
 	staleTime := time.Now().Add(-6 * time.Minute)
 
 	tests := []struct {
-		name             string
-		existingNode     *corev1.Node
-		health           *HealthResponse
-		heartbeatPeriod  time.Duration
-		wantStatus       corev1.ConditionStatus
-		wantReason       string
-		wantUpdateCalled bool
+		name                    string
+		existingNode            *corev1.Node
+		health                  *HealthResponse
+		heartbeatPeriod         time.Duration
+		wantStatus              corev1.ConditionStatus
+		wantReason              string
+		wantUpdateCount         int
+		wantTransitionPreserved bool
 	}{
 		{
 			name: "New Condition Healthy",
@@ -351,10 +353,11 @@ func TestUpdateNodeCondition(t *testing.T) {
 				Reason:  "EndpointOK",
 				Message: "All good",
 			},
-			heartbeatPeriod:  5 * time.Minute,
-			wantStatus:       corev1.ConditionTrue,
-			wantReason:       "EndpointOK",
-			wantUpdateCalled: true,
+			heartbeatPeriod:         5 * time.Minute,
+			wantStatus:              corev1.ConditionTrue,
+			wantReason:              "EndpointOK",
+			wantUpdateCount:         1,
+			wantTransitionPreserved: false,
 		},
 		{
 			// A state change bypasses the heartbeat gate, so the update is written
@@ -376,10 +379,11 @@ func TestUpdateNodeCondition(t *testing.T) {
 				Reason:  "HealthCheckFailed",
 				Message: "Something failed",
 			},
-			heartbeatPeriod:  5 * time.Minute,
-			wantStatus:       corev1.ConditionFalse,
-			wantReason:       "HealthCheckFailed",
-			wantUpdateCalled: true,
+			heartbeatPeriod:         5 * time.Minute,
+			wantStatus:              corev1.ConditionFalse,
+			wantReason:              "HealthCheckFailed",
+			wantUpdateCount:         1,
+			wantTransitionPreserved: false,
 		},
 		{
 			name: "State unchanged: Fresh heartbeat (skip write)",
@@ -403,10 +407,11 @@ func TestUpdateNodeCondition(t *testing.T) {
 				Reason:  "EndpointOk",
 				Message: "All good",
 			},
-			heartbeatPeriod:  5 * time.Minute,
-			wantStatus:       corev1.ConditionTrue,
-			wantReason:       "EndpointOk",
-			wantUpdateCalled: false,
+			heartbeatPeriod:         5 * time.Minute,
+			wantStatus:              corev1.ConditionTrue,
+			wantReason:              "EndpointOk",
+			wantUpdateCount:         0,
+			wantTransitionPreserved: true,
 		},
 		{
 			name: "State unchanged: Stale heartbeat (force write)",
@@ -430,10 +435,11 @@ func TestUpdateNodeCondition(t *testing.T) {
 				Reason:  "EndpointOk",
 				Message: "All good",
 			},
-			heartbeatPeriod:  5 * time.Minute,
-			wantStatus:       corev1.ConditionTrue,
-			wantReason:       "EndpointOk",
-			wantUpdateCalled: true,
+			heartbeatPeriod:         5 * time.Minute,
+			wantStatus:              corev1.ConditionTrue,
+			wantReason:              "EndpointOk",
+			wantUpdateCount:         1,
+			wantTransitionPreserved: true,
 		},
 	}
 
@@ -441,14 +447,24 @@ func TestUpdateNodeCondition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(tt.existingNode)
 
-			updateCalled := func() bool {
+			countUpdates := func() int {
+				count := 0
 				for _, a := range client.Actions() {
 					if a.GetVerb() == "update" && a.GetSubresource() == "status" && a.GetResource().Resource == "nodes" {
-						return true
+						count++
 					}
 				}
-				return false
+				return count
 			}
+
+			var previousTransition metav1.Time
+			for _, cond := range tt.existingNode.Status.Conditions {
+				if string(cond.Type) == conditionType {
+					previousTransition = cond.LastTransitionTime
+					break
+				}
+			}
+			testStart := metav1.NewTime(time.Now())
 
 			err := updateNodeCondition(context.Background(), client, nodeName, conditionType, tt.health, tt.heartbeatPeriod)
 			if err != nil {
@@ -456,8 +472,8 @@ func TestUpdateNodeCondition(t *testing.T) {
 			}
 
 			// Assert whether the status write reached the API server
-			if got := updateCalled(); got != tt.wantUpdateCalled {
-				t.Errorf("UpdateStatus called = %v, want %v", got, tt.wantUpdateCalled)
+			if got := countUpdates(); got != tt.wantUpdateCount {
+				t.Errorf("UpdateStatus called = %v, want %v", got, tt.wantUpdateCount)
 			}
 
 			updatedNode, err := client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
@@ -482,6 +498,14 @@ func TestUpdateNodeCondition(t *testing.T) {
 			}
 			if foundCondition.Reason != tt.wantReason {
 				t.Errorf("Condition reason = %v, want %v", foundCondition.Reason, tt.wantReason)
+			}
+
+			if tt.wantTransitionPreserved {
+				if !foundCondition.LastTransitionTime.Equal(&previousTransition) {
+					t.Errorf("LastTransitionTime = %v, want it preserved as %v", foundCondition.LastTransitionTime, previousTransition)
+				}
+			} else if foundCondition.LastTransitionTime.Before(&testStart) {
+				t.Errorf("LastTransitionTime = %v, want a new transition at or after %v", foundCondition.LastTransitionTime, testStart)
 			}
 		})
 	}
@@ -529,5 +553,30 @@ func TestParseDurationWithDefault(t *testing.T) {
 				t.Errorf("parseDurationWithDefault(%q) = %v, expected %v", tt.input, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestUpdateNodeConditionNodeNotFound(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	health := &HealthResponse{
+		Healthy: true,
+		Reason:  "EndpointOK",
+		Message: "All good",
+	}
+
+	err := updateNodeCondition(context.Background(), client, "missing-node", "TestCondition", health, 5*time.Minute)
+	if err == nil {
+		t.Fatal("updateNodeCondition() error = nil, want a NotFound error")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("updateNodeCondition() error = %v, want a NotFound error", err)
+	}
+
+	// The lookup failure must abort before any attempt to write the status.
+	for _, a := range client.Actions() {
+		if a.GetVerb() == "update" {
+			t.Error("UpdateStatus was called after the node lookup failed")
+		}
 	}
 }

--- a/cmd/readiness-condition-reporter/main_test.go
+++ b/cmd/readiness-condition-reporter/main_test.go
@@ -485,7 +485,7 @@ func TestUpdateNodeCondition(t *testing.T) {
 				}
 			}
 			if previousTransition.IsZero() {
-				previousTransition = metav1.NewTime(time.Now())
+				previousTransition = metav1.NewTime(staleTime)
 			}
 
 			err := updateNodeCondition(context.Background(), client, nodeName, conditionType, tt.health, tt.heartbeatPeriod)

--- a/cmd/readiness-condition-reporter/main_test.go
+++ b/cmd/readiness-condition-reporter/main_test.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/node-readiness-controller/internal/info"
@@ -353,6 +352,7 @@ func TestUpdateNodeCondition(t *testing.T) {
 		wantReason              string
 		wantUpdateCount         int
 		wantTransitionPreserved bool
+		wantNotFoundErr         bool
 	}{
 		{
 			name: "New Condition Healthy",
@@ -462,15 +462,21 @@ func TestUpdateNodeCondition(t *testing.T) {
 			},
 			heartbeatPeriod: 5 * time.Minute,
 			wantUpdateCount: 0,
+			wantNotFoundErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var objs []runtime.Object
+			var client *fake.Clientset
+			if tt.existingNode != nil {
+				client = fake.NewClientset(tt.existingNode)
+			} else {
+				client = fake.NewClientset()
+			}
+
 			var previousTransition metav1.Time
 			if tt.existingNode != nil {
-				objs = append(objs, tt.existingNode)
 				for _, cond := range tt.existingNode.Status.Conditions {
 					if string(cond.Type) == conditionType {
 						previousTransition = cond.LastTransitionTime
@@ -478,25 +484,25 @@ func TestUpdateNodeCondition(t *testing.T) {
 					}
 				}
 			}
-			client := fake.NewSimpleClientset(objs...)
-
 			if previousTransition.IsZero() {
 				previousTransition = metav1.NewTime(time.Now())
 			}
 
 			err := updateNodeCondition(context.Background(), client, nodeName, conditionType, tt.health, tt.heartbeatPeriod)
-			if tt.existingNode == nil {
-				if !apierrors.IsNotFound(err) {
-					t.Fatalf("updateNodeCondition() error = %v, want a NotFound error", err)
-				}
-				if got := countUpdateCalls(client); got != tt.wantUpdateCount {
-					t.Errorf("UpdateStatus called = %v, want %v", got, tt.wantUpdateCount)
-				}
-				return
-			}
-
 			if err != nil {
+				if tt.wantNotFoundErr {
+					if !apierrors.IsNotFound(err) {
+						t.Fatalf("updateNodeCondition() error = %v, want a NotFound error", err)
+					}
+					if got := countUpdateCalls(client); got != tt.wantUpdateCount {
+						t.Errorf("UpdateStatus called = %v, want %v", got, tt.wantUpdateCount)
+					}
+					return
+				}
 				t.Fatalf("updateNodeCondition() error = %v", err)
+			}
+			if tt.wantNotFoundErr {
+				t.Fatal("updateNodeCondition() succeeded, want a NotFound error")
 			}
 
 			// Assert whether the status write reached the API server

--- a/cmd/readiness-condition-reporter/main_test.go
+++ b/cmd/readiness-condition-reporter/main_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"sigs.k8s.io/node-readiness-controller/internal/info"
@@ -333,6 +334,16 @@ func TestUpdateNodeCondition(t *testing.T) {
 	conditionType := "TestCondition"
 	staleTime := time.Now().Add(-6 * time.Minute)
 
+	countUpdateCalls := func(client *fake.Clientset) int {
+		calls := 0
+		for _, a := range client.Actions() {
+			if a.GetVerb() == "update" && a.GetSubresource() == "status" && a.GetResource().Resource == "nodes" {
+				calls++
+			}
+		}
+		return calls
+	}
+
 	tests := []struct {
 		name                    string
 		existingNode            *corev1.Node
@@ -441,38 +452,55 @@ func TestUpdateNodeCondition(t *testing.T) {
 			wantUpdateCount:         1,
 			wantTransitionPreserved: true,
 		},
+		{
+			name:         "Node not found",
+			existingNode: nil,
+			health: &HealthResponse{
+				Healthy: true,
+				Reason:  "EndpointOK",
+				Message: "All good",
+			},
+			heartbeatPeriod: 5 * time.Minute,
+			wantUpdateCount: 0,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := fake.NewSimpleClientset(tt.existingNode)
-
-			countUpdates := func() int {
-				count := 0
-				for _, a := range client.Actions() {
-					if a.GetVerb() == "update" && a.GetSubresource() == "status" && a.GetResource().Resource == "nodes" {
-						count++
+			var objs []runtime.Object
+			var previousTransition metav1.Time
+			if tt.existingNode != nil {
+				objs = append(objs, tt.existingNode)
+				for _, cond := range tt.existingNode.Status.Conditions {
+					if string(cond.Type) == conditionType {
+						previousTransition = cond.LastTransitionTime
+						break
 					}
 				}
-				return count
 			}
+			client := fake.NewSimpleClientset(objs...)
 
-			var previousTransition metav1.Time
-			for _, cond := range tt.existingNode.Status.Conditions {
-				if string(cond.Type) == conditionType {
-					previousTransition = cond.LastTransitionTime
-					break
-				}
+			if previousTransition.IsZero() {
+				previousTransition = metav1.NewTime(time.Now())
 			}
-			testStart := metav1.NewTime(time.Now())
 
 			err := updateNodeCondition(context.Background(), client, nodeName, conditionType, tt.health, tt.heartbeatPeriod)
+			if tt.existingNode == nil {
+				if !apierrors.IsNotFound(err) {
+					t.Fatalf("updateNodeCondition() error = %v, want a NotFound error", err)
+				}
+				if got := countUpdateCalls(client); got != tt.wantUpdateCount {
+					t.Errorf("UpdateStatus called = %v, want %v", got, tt.wantUpdateCount)
+				}
+				return
+			}
+
 			if err != nil {
-				t.Errorf("updateNodeCondition() error = %v", err)
+				t.Fatalf("updateNodeCondition() error = %v", err)
 			}
 
 			// Assert whether the status write reached the API server
-			if got := countUpdates(); got != tt.wantUpdateCount {
+			if got := countUpdateCalls(client); got != tt.wantUpdateCount {
 				t.Errorf("UpdateStatus called = %v, want %v", got, tt.wantUpdateCount)
 			}
 
@@ -504,8 +532,8 @@ func TestUpdateNodeCondition(t *testing.T) {
 				if !foundCondition.LastTransitionTime.Equal(&previousTransition) {
 					t.Errorf("LastTransitionTime = %v, want it preserved as %v", foundCondition.LastTransitionTime, previousTransition)
 				}
-			} else if foundCondition.LastTransitionTime.Before(&testStart) {
-				t.Errorf("LastTransitionTime = %v, want a new transition at or after %v", foundCondition.LastTransitionTime, testStart)
+			} else if !foundCondition.LastTransitionTime.After(previousTransition.Time) {
+				t.Errorf("LastTransitionTime = %v, want a new transition at or after %v", foundCondition.LastTransitionTime, previousTransition.Time)
 			}
 		})
 	}
@@ -553,30 +581,5 @@ func TestParseDurationWithDefault(t *testing.T) {
 				t.Errorf("parseDurationWithDefault(%q) = %v, expected %v", tt.input, result, tt.expected)
 			}
 		})
-	}
-}
-
-func TestUpdateNodeConditionNodeNotFound(t *testing.T) {
-	client := fake.NewSimpleClientset()
-
-	health := &HealthResponse{
-		Healthy: true,
-		Reason:  "EndpointOK",
-		Message: "All good",
-	}
-
-	err := updateNodeCondition(context.Background(), client, "missing-node", "TestCondition", health, 5*time.Minute)
-	if err == nil {
-		t.Fatal("updateNodeCondition() error = nil, want a NotFound error")
-	}
-	if !apierrors.IsNotFound(err) {
-		t.Errorf("updateNodeCondition() error = %v, want a NotFound error", err)
-	}
-
-	// The lookup failure must abort before any attempt to write the status.
-	for _, a := range client.Actions() {
-		if a.GetVerb() == "update" {
-			t.Error("UpdateStatus was called after the node lookup failed")
-		}
 	}
 }

--- a/cmd/readiness-condition-reporter/main_test.go
+++ b/cmd/readiness-condition-reporter/main_test.go
@@ -357,7 +357,9 @@ func TestUpdateNodeCondition(t *testing.T) {
 			wantUpdateCalled: true,
 		},
 		{
-			name: "State change triggers immediate write",
+			// A state change bypasses the heartbeat gate, so the update is written
+			// immediately rather than waiting for the next heartbeat.
+			name: "update condition on state change",
 			existingNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
 				Status: corev1.NodeStatus{
@@ -439,14 +441,13 @@ func TestUpdateNodeCondition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(tt.existingNode)
 
-			countUpdates := func() int {
-				n := 0
+			updateCalled := func() bool {
 				for _, a := range client.Actions() {
 					if a.GetVerb() == "update" && a.GetSubresource() == "status" && a.GetResource().Resource == "nodes" {
-						n++
+						return true
 					}
 				}
-				return n
+				return false
 			}
 
 			err := updateNodeCondition(context.Background(), client, nodeName, conditionType, tt.health, tt.heartbeatPeriod)
@@ -454,12 +455,9 @@ func TestUpdateNodeCondition(t *testing.T) {
 				t.Errorf("updateNodeCondition() error = %v", err)
 			}
 
-			// Assert API call frequency
-			updateCount := countUpdates()
-			if tt.wantUpdateCalled && updateCount == 0 {
-				t.Errorf("Expected UpdateStatus to be called, but it was skipped")
-			} else if !tt.wantUpdateCalled && updateCount > 0 {
-				t.Errorf("Expected UpdateStatus to be skipped, but it was called %d times", updateCount)
+			// Assert whether the status write reached the API server
+			if got := updateCalled(); got != tt.wantUpdateCalled {
+				t.Errorf("UpdateStatus called = %v, want %v", got, tt.wantUpdateCalled)
 			}
 
 			updatedNode, err := client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})

--- a/cmd/readiness-condition-reporter/main_test.go
+++ b/cmd/readiness-condition-reporter/main_test.go
@@ -344,15 +344,15 @@ func TestUpdateNodeCondition(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                    string
-		existingNode            *corev1.Node
-		health                  *HealthResponse
-		heartbeatPeriod         time.Duration
-		wantStatus              corev1.ConditionStatus
-		wantReason              string
-		wantUpdateCount         int
-		wantTransitionPreserved bool
-		wantNotFoundErr         bool
+		name                        string
+		existingNode                *corev1.Node
+		health                      *HealthResponse
+		heartbeatPeriod             time.Duration
+		wantStatus                  corev1.ConditionStatus
+		wantReason                  string
+		wantUpdateCount             int
+		wantTransitionTimePreserved bool
+		wantNotFoundErr             bool
 	}{
 		{
 			name: "New Condition Healthy",
@@ -364,11 +364,11 @@ func TestUpdateNodeCondition(t *testing.T) {
 				Reason:  "EndpointOK",
 				Message: "All good",
 			},
-			heartbeatPeriod:         5 * time.Minute,
-			wantStatus:              corev1.ConditionTrue,
-			wantReason:              "EndpointOK",
-			wantUpdateCount:         1,
-			wantTransitionPreserved: false,
+			heartbeatPeriod:             5 * time.Minute,
+			wantStatus:                  corev1.ConditionTrue,
+			wantReason:                  "EndpointOK",
+			wantUpdateCount:             1,
+			wantTransitionTimePreserved: false,
 		},
 		{
 			// A state change bypasses the heartbeat gate, so the update is written
@@ -390,11 +390,11 @@ func TestUpdateNodeCondition(t *testing.T) {
 				Reason:  "HealthCheckFailed",
 				Message: "Something failed",
 			},
-			heartbeatPeriod:         5 * time.Minute,
-			wantStatus:              corev1.ConditionFalse,
-			wantReason:              "HealthCheckFailed",
-			wantUpdateCount:         1,
-			wantTransitionPreserved: false,
+			heartbeatPeriod:             5 * time.Minute,
+			wantStatus:                  corev1.ConditionFalse,
+			wantReason:                  "HealthCheckFailed",
+			wantUpdateCount:             1,
+			wantTransitionTimePreserved: false,
 		},
 		{
 			name: "State unchanged: Fresh heartbeat (skip write)",
@@ -418,11 +418,11 @@ func TestUpdateNodeCondition(t *testing.T) {
 				Reason:  "EndpointOk",
 				Message: "All good",
 			},
-			heartbeatPeriod:         5 * time.Minute,
-			wantStatus:              corev1.ConditionTrue,
-			wantReason:              "EndpointOk",
-			wantUpdateCount:         0,
-			wantTransitionPreserved: true,
+			heartbeatPeriod:             5 * time.Minute,
+			wantStatus:                  corev1.ConditionTrue,
+			wantReason:                  "EndpointOk",
+			wantUpdateCount:             0,
+			wantTransitionTimePreserved: true,
 		},
 		{
 			name: "State unchanged: Stale heartbeat (force write)",
@@ -446,11 +446,11 @@ func TestUpdateNodeCondition(t *testing.T) {
 				Reason:  "EndpointOk",
 				Message: "All good",
 			},
-			heartbeatPeriod:         5 * time.Minute,
-			wantStatus:              corev1.ConditionTrue,
-			wantReason:              "EndpointOk",
-			wantUpdateCount:         1,
-			wantTransitionPreserved: true,
+			heartbeatPeriod:             5 * time.Minute,
+			wantStatus:                  corev1.ConditionTrue,
+			wantReason:                  "EndpointOk",
+			wantUpdateCount:             1,
+			wantTransitionTimePreserved: true,
 		},
 		{
 			name:         "Node not found",
@@ -534,7 +534,7 @@ func TestUpdateNodeCondition(t *testing.T) {
 				t.Errorf("Condition reason = %v, want %v", foundCondition.Reason, tt.wantReason)
 			}
 
-			if tt.wantTransitionPreserved {
+			if tt.wantTransitionTimePreserved {
 				if !foundCondition.LastTransitionTime.Equal(&previousTransition) {
 					t.Errorf("LastTransitionTime = %v, want it preserved as %v", foundCondition.LastTransitionTime, previousTransition)
 				}


### PR DESCRIPTION
## Description
Follow-up to #263, addressing the review comments left open when it merged.

- Fold the idempotency check into a single early return after the condition search, dropping the `needsUpdate` flag and the separate `transitionTime` variable, the split logic was hard to follow.
- Replace the block comment with line comments (block comments are a Go anti-pattern), and refer to `heartbeatPeriod` rather than a hardcoded "5 minutes", since the period is configurable.
- Rename test case `State change triggers immediate write` to `update condition on state change` — the immediate write is the outcome, not the cause, and is now noted in a comment.
- Return a bool instead of an update count from the test helper, collapsing the assertion to one comparison.

No behaviour change.

## Related Issue
None

## Type of Change

/kind cleanup

## Testing
This change is a refactor only.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```