### PR TITLE
fix(reporter): call flag.Parse to activate klog flags

### DIFF
--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -56,6 +57,7 @@ type HealthResponse struct {
 
 func main() {
 	klog.InitFlags(nil)
+	flag.Parse()
 
 	// Get configuration from environment
 	nodeName := os.Getenv(envNodeName)


### PR DESCRIPTION
## Description
- The reporter's `main()` registers klog's flags with `klog.InitFlags(nil)` but never calls `flag.Parse()`, so the command line is never actually read.
- Added `flag.Parse()` immediately after `klog.InitFlags(nil)`, plus the `flag` import.
- Why: without parsing, `-v` has no effect, which makes the `klog.V(4)` log in `updateNodeCondition` unreachable, and misspelled flags are ignored instead of reported.
## Related Issue
None
## Type of Change

/kind bug

## Testing
Built the reporter before and after the change and ran it off-cluster (env vars set, so it reaches the in-cluster config check and exits 1).

- `--this-flag-does-not-exist=x` :- before: ignored, exit 1. After: `flag provided but not defined`, exit 2.
- `-v=4` — before: ignored, a temporary `klog.V(4)` probe at the top of `main()` never prints. After: the probe prints.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
The readiness-condition-reporter now parses command-line flags, so klog flags such as `-v` take effect. Unrecognized flags are rejected at startup instead of being silently ignored.
```