### PR TITLE
fix: compare node labels in both directions in update predicate

### DIFF
--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -105,13 +105,7 @@ func taintsEqual(a, b []corev1.Taint) bool {
 	return true
 }
 
-// labelsEqual checks if two label maps are equal.
-//
-// maps.Equal compares both keys and values in both directions. A hand-rolled
-// length check plus a one-directional `b[k] != v` comparison is not sufficient:
-// a missing key yields the zero value "", so removing an empty valued label and
-// adding a different empty valued one in the same update would compare equal and
-// the Node event would be dropped by the update predicate.
+// labelsEqual checks if two label maps hold the same keys with the same values.
 func labelsEqual(a, b map[string]string) bool {
 	return maps.Equal(a, b)
 }

--- a/internal/controller/helper.go
+++ b/internal/controller/helper.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"encoding/json"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -105,16 +106,12 @@ func taintsEqual(a, b []corev1.Taint) bool {
 }
 
 // labelsEqual checks if two label maps are equal.
+//
+// maps.Equal compares both keys and values in both directions. A hand-rolled
+// length check plus a one-directional `b[k] != v` comparison is not sufficient:
+// a missing key yields the zero value "", so removing an empty valued label and
+// adding a different empty valued one in the same update would compare equal and
+// the Node event would be dropped by the update predicate.
 func labelsEqual(a, b map[string]string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for k, v := range a {
-		if b[k] != v {
-			return false
-		}
-	}
-
-	return true
+	return maps.Equal(a, b)
 }

--- a/internal/controller/helper_unit_test.go
+++ b/internal/controller/helper_unit_test.go
@@ -57,6 +57,76 @@ func TestLegacyBootstrapAnnotationKey(t *testing.T) {
 	g.Expect(key).To(Equal("readiness.k8s.io/bootstrap-completed-my-rule"))
 }
 
+func TestLabelsEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        map[string]string
+		b        map[string]string
+		expected bool
+	}{
+		{
+			name:     "identical labels",
+			a:        map[string]string{"env": "prod"},
+			b:        map[string]string{"env": "prod"},
+			expected: true,
+		},
+		{
+			name:     "different value for the same key",
+			a:        map[string]string{"env": "prod"},
+			b:        map[string]string{"env": "staging"},
+			expected: false,
+		},
+		{
+			name:     "extra key",
+			a:        map[string]string{"env": "prod"},
+			b:        map[string]string{"env": "prod", "tier": "frontend"},
+			expected: false,
+		},
+		{
+			// A missing key reads back as the zero value "", so an empty valued
+			// label that is swapped for a different empty valued one must still
+			// be reported as a change.
+			name:     "empty valued role label swapped for another",
+			a:        map[string]string{"node-role.kubernetes.io/worker": ""},
+			b:        map[string]string{"node-role.kubernetes.io/infra": ""},
+			expected: false,
+		},
+		{
+			name:     "disjoint empty valued keys alongside a shared label",
+			a:        map[string]string{"a": "", "shared": "x"},
+			b:        map[string]string{"b": "", "shared": "x"},
+			expected: false,
+		},
+		{
+			name:     "empty valued label kept unchanged",
+			a:        map[string]string{"node-role.kubernetes.io/worker": ""},
+			b:        map[string]string{"node-role.kubernetes.io/worker": ""},
+			expected: true,
+		},
+		{
+			name:     "both nil",
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			name:     "nil compared to empty valued label",
+			a:        nil,
+			b:        map[string]string{"node-role.kubernetes.io/worker": ""},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(labelsEqual(tt.a, tt.b)).To(Equal(tt.expected))
+			// The comparison must be symmetric.
+			g.Expect(labelsEqual(tt.b, tt.a)).To(Equal(tt.expected))
+		})
+	}
+}
+
 func TestGetApplicableRulesForNode_DeepCopy(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/controller/helper_unit_test.go
+++ b/internal/controller/helper_unit_test.go
@@ -83,9 +83,8 @@ func TestLabelsEqual(t *testing.T) {
 			expected: false,
 		},
 		{
-			// A missing key reads back as the zero value "", so an empty valued
-			// label that is swapped for a different empty valued one must still
-			// be reported as a change.
+			// Role labels conventionally carry an empty value, so a swap between
+			// two of them differs only by key.
 			name:     "empty valued role label swapped for another",
 			a:        map[string]string{"node-role.kubernetes.io/worker": ""},
 			b:        map[string]string{"node-role.kubernetes.io/infra": ""},


### PR DESCRIPTION
## Description

`labelsEqual` combined a length check with a one-directional comparison:

```go
for k, v := range a {
	if b[k] != v {
		return false
	}
}
```

A key that is missing from `b` reads back as the zero value `""`, so when `v` is also `""` the difference is not detected. Because the lengths still match, removing an empty valued label and adding a different empty valued one in the same update compares equal. The `NodeReconciler` update predicate then computes `labelsChanged == false` and, if conditions and taints are also unchanged, drops the event before `Reconcile` runs.

Empty valued labels are the norm on Nodes rather than an edge case. The `node-role.kubernetes.io/<role>` convention always uses an empty value, and this repository's own tests and examples select on `node-role.kubernetes.io/worker: ""`. A Node that starts matching a rule's `nodeSelector` through such a relabel is therefore never evaluated against that rule, so its readiness taint is never applied. The node does not recover quickly either, because `conditionsEqual` deliberately ignores heartbeat updates, so nothing re-enqueues the Node until a real condition or taint change happens.

The fix uses `maps.Equal`, which compares keys and values in both directions and cannot regress in the same way. I kept the `labelsEqual` helper rather than inlining the call so the predicate still reads consistently next to `conditionsEqual` and `taintsEqual`, and so the regression test has a stable target. Happy to inline it if reviewers prefer.

Worth noting that `conditionsEqual` and `taintsEqual`, in the same file, both already check key existence with `value, exists := aMap[key]`. `labelsEqual` was the only one of the three missing that check.

## Related Issue

Fixes #346

## Type of Change

/kind bug

## Testing

Added `TestLabelsEqual` to `internal/controller/helper_unit_test.go`, a table driven test that also asserts the comparison is symmetric. The two empty value cases fail on `main` and pass with this change:

```
--- FAIL: TestLabelsEqualEmptyValueSwap (0.00s)
    Expected
        <bool>: true
    to be false
```

Full run after the change, using envtest with Kubernetes 1.36.2 binaries:

```
--- PASS: TestLabelsEqual (0.00s)
    --- PASS: TestLabelsEqual/identical_labels
    --- PASS: TestLabelsEqual/different_value_for_the_same_key
    --- PASS: TestLabelsEqual/extra_key
    --- PASS: TestLabelsEqual/empty_valued_role_label_swapped_for_another
    --- PASS: TestLabelsEqual/disjoint_empty_valued_keys_alongside_a_shared_label
    --- PASS: TestLabelsEqual/empty_valued_label_kept_unchanged
    --- PASS: TestLabelsEqual/both_nil
    --- PASS: TestLabelsEqual/nil_compared_to_empty_valued_label
ok  	sigs.k8s.io/node-readiness-controller/internal/controller
```

The existing controller suite is unaffected: 62 of 62 specs pass, and `internal/webhook` plus `cmd/readiness-condition-reporter` pass as well.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Fixed the node update predicate dropping label changes when a removed label had an empty value, which could leave a node without the readiness taint of a rule it had just started matching.
```
