### PR TITLE
fix: clean up taints on rule deletion for nodes that stopped matching the selector

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -667,12 +667,34 @@ func (r *RuleReadinessController) processDryRun(ctx context.Context, rule *readi
 }
 
 // cleanupTaintsForRule removes taints managed by this rule from all applicable nodes.
+//
+// Nodes the rule previously managed are cleaned up as well, even if they no longer
+// match spec.nodeSelector. This runs on the terminal deletion path: once the
+// finalizer is removed the rule object is gone, so a taint left behind here can
+// never be reconciled away again and would strand the node.
+//
+// The previously managed set is taken from the rule's own status. That is sound
+// here precisely because this is a one shot cleanup of a rule that is going away,
+// unlike steady state reconciliation where status is not a trustworthy signal for
+// deciding the next action. It also keeps the cleanup correctly scoped: the
+// validating webhook only rejects rules sharing a taint key and effect when their
+// selectors overlap, so two rules may legitimately share a taint with disjoint
+// selectors. A node managed solely by such a sibling rule never appears in this
+// rule's status and is therefore left untouched.
 func (r *RuleReadinessController) cleanupTaintsForRule(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule, nodeList *corev1.NodeList) error {
 	log := ctrl.LoggerFrom(ctx)
 
+	managedNodes := make(map[string]bool, len(rule.Status.NodeEvaluations)+len(rule.Status.AppliedNodes))
+	for _, evaluation := range rule.Status.NodeEvaluations {
+		managedNodes[evaluation.NodeName] = true
+	}
+	for _, nodeName := range rule.Status.AppliedNodes {
+		managedNodes[nodeName] = true
+	}
+
 	var errors []string
 	for _, node := range nodeList.Items {
-		if !r.ruleAppliesTo(ctx, rule, &node) {
+		if !r.ruleAppliesTo(ctx, rule, &node) && !managedNodes[node.Name] {
 			continue
 		}
 

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -1617,6 +1617,89 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				return err != nil && client.IgnoreNotFound(err) == nil
 			}, time.Second*10).Should(BeTrue(), "Rule should be fully deleted")
 		})
+
+		It("should remove taints from nodes that no longer match the selector", func() {
+			// Establish the node as managed by the rule so it is recorded in the
+			// rule status, which is what deletion cleanup uses to find nodes that
+			// have drifted out of the selector.
+			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "cleanup-rule"}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() []nodereadinessiov1alpha1.NodeEvaluation {
+				managedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: "cleanup-rule"}, managedRule)
+				return managedRule.Status.NodeEvaluations
+			}, time.Second*10).Should(ContainElement(HaveField("NodeName", "cleanup-test-node")),
+				"Rule status should record the node it manages")
+
+			// The node is relabelled and stops matching spec.nodeSelector.
+			relabelled := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "cleanup-test-node"}, relabelled)).To(Succeed())
+			relabelled.Labels["kubernetes.io/hostname"] = "some-other-hostname"
+			Expect(k8sClient.Update(ctx, relabelled)).To(Succeed())
+
+			// The taint applied by the rule is still on the node at this point.
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "cleanup-test-node"}, relabelled)).To(Succeed())
+			Expect(relabelled.Spec.Taints).To(ContainElement(HaveField("Key", "readiness.k8s.io/cleanup-taint")),
+				"Node should still carry the rule taint before deletion")
+
+			Expect(k8sClient.Delete(ctx, rule)).To(Succeed())
+
+			_, err = ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "cleanup-rule"}})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Once the finalizer is gone the rule cannot be reconciled again, so
+			// any taint still present at this point is stranded permanently.
+			Eventually(func() bool {
+				deletedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "cleanup-rule"}, deletedRule)
+				return err != nil && client.IgnoreNotFound(err) == nil
+			}, time.Second*10).Should(BeTrue(), "Rule should be fully deleted")
+
+			Eventually(func() []corev1.Taint {
+				orphanCheck := &corev1.Node{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "cleanup-test-node"}, orphanCheck); err != nil {
+					return nil
+				}
+				return orphanCheck.Spec.Taints
+			}, time.Second*10).ShouldNot(ContainElement(HaveField("Key", "readiness.k8s.io/cleanup-taint")),
+				"Rule deletion should not leave an orphaned taint on a node that stopped matching the selector")
+		})
+
+		It("should not remove a taint from a node the rule never managed", func() {
+			// A node outside the rule selector that carries the same taint key and
+			// effect, as a rule with a disjoint selector legitimately could. Rule
+			// deletion must leave it alone.
+			siblingNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "cleanup-sibling-node",
+					Labels: map[string]string{"kubernetes.io/hostname": "cleanup-sibling-node"},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{Key: "readiness.k8s.io/cleanup-taint", Effect: corev1.TaintEffectNoSchedule, Value: "pending"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, siblingNode)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, siblingNode) }()
+
+			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "cleanup-rule"}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Delete(ctx, rule)).To(Succeed())
+			_, err = ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "cleanup-rule"}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Consistently(func() []corev1.Taint {
+				untouched := &corev1.Node{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "cleanup-sibling-node"}, untouched); err != nil {
+					return nil
+				}
+				return untouched.Spec.Taints
+			}, time.Second*2).Should(ContainElement(HaveField("Key", "readiness.k8s.io/cleanup-taint")),
+				"A node the rule never managed should keep its taint")
+		})
 	})
 
 	Context("when a node is deleted", func() {


### PR DESCRIPTION
## Description

`cleanupTaintsForRule` only considered Nodes that currently match the rule's `spec.nodeSelector`:

```go
for _, node := range nodeList.Items {
	if !r.ruleAppliesTo(ctx, rule, &node) {
		continue
	}
```

A Node that the rule had tainted, and that was later relabelled out of the selector, was skipped during cleanup. `reconcileDelete` then removed the finalizer and the rule object was deleted, leaving the taint behind with no owner. Nothing in the system references it any more, so no future reconcile can remove it and an operator has to clear it by hand. For a `NoSchedule` taint the Node stops accepting new workloads indefinitely; for `NoExecute` it also keeps evicting Pods without a toleration, on a Node that no rule governs.

Cleanup now also covers Nodes recorded in the rule's own status, through `status.nodeEvaluations` and `status.appliedNodes`.

Two design points worth calling out, since both came up while looking at the related issues:

**Why using status is acceptable here.** The review discussion on #339 concluded that leaning on `rule.Status` to decide what to act on is fragile, which is a large part of why #342 is still open. That objection is about steady state reconciliation, where the controller repeatedly consults status it wrote itself. The deletion path is different: it runs once, it is terminal, and the rule is being torn down, so the set of Nodes the rule ever managed is exactly the set that needs cleaning. There is no ongoing loop for a stale entry to feed back into.

**Why not just remove the taint everywhere.** The validating webhook rejects rules sharing a taint key and effect only when their selectors *overlap*, so two rules may legitimately share `readiness.k8s.io/x:NoSchedule` with disjoint selectors. Unconditionally stripping the key on deletion would pull the taint off Nodes owned by the surviving sibling rule. Scoping to this rule's status avoids that, because a Node managed solely by the sibling never appears in this rule's status. The second test added here locks that behaviour in.

This is deliberately scoped to the deletion path and does not attempt to resolve #342, which needs the harder "used to match, no longer does" detection during normal reconciliation. I filed this separately because the deletion case is strictly worse: while the rule still exists the taint is at least recoverable by a future fix, whereas after deletion it is permanent.

## Related Issue

Fixes #347

## Type of Change

/kind bug

## Testing

Two specs added to the existing `when a rule is deleted` context in `internal/controller/nodereadinessrule_controller_test.go`:

1. `should remove taints from nodes that no longer match the selector` reproduces the bug. The Node is managed by the rule, relabelled out of the selector, and the rule is deleted. The spec asserts the rule object is fully gone (so nothing could clean up later) and that the taint is not left behind.
2. `should not remove a taint from a node the rule never managed` guards the fix against over-removal, using a Node outside the selector that carries the same taint key and effect.

Verified the first test genuinely catches the regression by stashing the source change and re-running against unmodified `main`:

```
[FAILED] Timed out after 10.000s.
Rule deletion should not leave an orphaned taint on a node that stopped matching the selector
```

With the fix applied, the full controller suite passes: 64 of 64 specs, up from 62 before these two were added. `internal/webhook` and `cmd/readiness-condition-reporter` pass as well. Run against envtest with Kubernetes 1.36.2 binaries. `golangci-lint` v2.12.1 reports 0 issues.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Fixed rule deletion leaving a permanently orphaned taint on nodes that had stopped matching the rule's nodeSelector while the rule was still active.
```
