### PR TITLE
fix: add events.k8s.io to the Helm chart manager ClusterRole

### DIFF
--- a/charts/nrr-controller/templates/rbac.yaml
+++ b/charts/nrr-controller/templates/rbac.yaml
@@ -37,7 +37,10 @@ metadata:
   labels:
     {{- include "nrr-controller.labels" . | nindent 4 }}
 rules:
-  - apiGroups: [""]
+  # The controller records taint events through k8s.io/client-go/tools/events,
+  # which writes to events.k8s.io/v1, so both groups are required here. Keep this
+  # in sync with the generated config/rbac/role.yaml.
+  - apiGroups: ["", "events.k8s.io"]
     resources: ["events"]
     verbs: ["create", "patch"]
   - apiGroups: [""]

--- a/charts/nrr-controller/templates/rbac.yaml
+++ b/charts/nrr-controller/templates/rbac.yaml
@@ -37,9 +37,6 @@ metadata:
   labels:
     {{- include "nrr-controller.labels" . | nindent 4 }}
 rules:
-  # The controller records taint events through k8s.io/client-go/tools/events,
-  # which writes to events.k8s.io/v1, so both groups are required here. Keep this
-  # in sync with the generated config/rbac/role.yaml.
   - apiGroups: ["", "events.k8s.io"]
     resources: ["events"]
     verbs: ["create", "patch"]

--- a/charts/nrr-controller/tests/rbac_test.yaml
+++ b/charts/nrr-controller/tests/rbac_test.yaml
@@ -1,0 +1,72 @@
+suite: Test Node Readiness Controller Manager RBAC
+
+templates:
+  - "*.yaml"
+
+release:
+  name: nrr-controller
+
+tests:
+  - it: grants events on both the core and events.k8s.io groups
+    template: templates/rbac.yaml
+    documentSelector:
+      path: metadata.name
+      value: nrr-controller-manager-role
+    asserts:
+      - isKind:
+          of: ClusterRole
+      # The controller records taint events via k8s.io/client-go/tools/events,
+      # which writes to events.k8s.io/v1. Granting only the core group makes
+      # every TaintAdded, TaintRemoved and TaintAdopted write forbidden.
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["", "events.k8s.io"]
+            resources: ["events"]
+            verbs: ["create", "patch"]
+
+  - it: grants the node and rule permissions the controller needs
+    template: templates/rbac.yaml
+    documentSelector:
+      path: metadata.name
+      value: nrr-controller-manager-role
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["nodes"]
+            verbs: ["get", "list", "patch", "update", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["nodes/status"]
+            verbs: ["get"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["readiness.node.x-k8s.io"]
+            resources: ["nodereadinessrules"]
+            verbs: ["get", "list", "patch", "update", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["readiness.node.x-k8s.io"]
+            resources: ["nodereadinessrules/finalizers"]
+            verbs: ["update"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["readiness.node.x-k8s.io"]
+            resources: ["nodereadinessrules/status"]
+            verbs: ["get", "patch", "update"]
+
+  - it: omits rbac resources when rbac.create is disabled
+    template: templates/rbac.yaml
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Description

The chart's manager ClusterRole granted events on the core API group only:

```yaml
  - apiGroups: [""]
    resources: ["events"]
    verbs: ["create", "patch"]
```

That is not enough for what the controller actually does. `RuleReadinessController.EventRecorder` comes from `mgr.GetEventRecorder(...)`, which is a `k8s.io/client-go/tools/events.EventRecorder`. In controller-runtime v0.24.1 that recorder is backed by a broadcaster constructed in `pkg/manager/manager.go`:

```go
evtCl, err := eventsv1client.NewForConfigAndClient(config, httpClient)
...
return record.NewBroadcaster(), events.NewBroadcaster(&events.EventSinkImpl{Interface: evtCl}), true
```

`eventsv1client` is `k8s.io/client-go/kubernetes/typed/events/v1`, so the writes go to `events.k8s.io/v1` and are authorised against the `events.k8s.io` group. Without that grant every `TaintAdded`, `TaintRemoved` and `TaintAdopted` write comes back forbidden, and since the recorder does not surface an error to the caller the only sign is a message in the controller log.

The kubebuilder markers on the controller already declare both groups, and the generated `config/rbac/role.yaml` carries both, so the kustomize install path was never affected. This was Helm only, which also means the two documented install methods behaved differently.

This change brings the chart in line with the generated role and adds a chart unit test suite for the manager ClusterRole, pinning the events grant along with the node and rule permissions.

One thing worth flagging for a follow up rather than fixing here: nothing currently guards this. `hack/verify-chart-drift.sh` runs in the Helm workflow but only diffs the CRD, so any divergence in the ClusterRole goes unnoticed. Extending it to cover RBAC seems worthwhile, but the generated role and the templated one differ in name and labels so a plain `diff` will not do, and it felt like the wrong thing to bundle into a fix. Comparing the two by hand, the events rule was the only difference; nodes, nodes/status and the three nodereadinessrules rules all matched already, and the new test now covers those too.

## Related Issue

Fixes #350

## Type of Change

/kind bug

## Testing

Added `charts/nrr-controller/tests/rbac_test.yaml`, which asserts the events rule lists both groups, asserts the remaining manager permissions match the generated role, and checks that nothing is rendered when `rbac.create` is disabled.

Confirmed the new test genuinely catches the regression by stashing the template change and re-running against the unmodified chart:

```
 FAIL  Test Node Readiness Controller Manager RBAC	charts/nrr-controller/tests/rbac_test.yaml
	- grants events on both the core and events.k8s.io groups
Tests:       1 failed, 18 passed, 19 total
```

With the fix applied, the whole suite passes, using Helm v3.15.1 and helm-unittest 1.0.3 to match the Helm workflow:

```
$ helm unittest charts/nrr-controller --strict
 PASS  Test Node Readiness Controller Pod Annotations and Labels
 PASS  Test Node Readiness Controller Deployment
 PASS  Test Node Readiness Controller NodeReadinessRules
 PASS  Test Node Readiness Controller Manager RBAC
 PASS  Test Node Readiness Controller Webhook and Metrics Config

Charts:      1 passed, 1 total
Test Suites: 5 passed, 5 total
Tests:       19 passed, 19 total
```

`helm lint charts/nrr-controller` passes, and the rendered role now reads:

```yaml
  - apiGroups: ["", "events.k8s.io"]
    resources: ["events"]
    verbs: ["create", "patch"]
```

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Fixed the Helm chart's manager ClusterRole missing the events.k8s.io API group, which prevented the controller from recording TaintAdded, TaintRemoved and TaintAdopted events on nodes when installed with Helm.
```
