### PR TITLE
feat: add suspend field to NodeReadinessRuleSpec to pause rule evalua…

### DIFF
--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -104,6 +104,11 @@ type NodeReadinessRuleSpec struct {
 	//
 	// +optional
 	DryRun bool `json:"dryRun,omitempty"` //nolint:kubeapilinter
+
+	// suspend tells the controller to suspend operations for this NodeReadinessRule.
+	//
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
 }
 
 // ConditionRequirement defines a specific Node condition and the status value
@@ -327,6 +332,7 @@ type DryRunResults struct {
 // +kubebuilder:printcolumn:name="Effect",type=string,JSONPath=`.spec.taint.effect`,description="The taint effect: NoSchedule, PreferNoSchedule or NoExecute."
 // +kubebuilder:printcolumn:name="DryRun",type=boolean,JSONPath=`.spec.dryRun`,description="Whether the rule is in dry-run mode and only previews taint changes."
 // +kubebuilder:selectablefield:JSONPath=`.spec.dryRun`
+// +kubebuilder:printcolumn:name="Suspend",type=boolean,JSONPath=`.spec.suspend`,description="Whether operations for this rule are suspended."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="The age of this resource"
 
 // NodeReadinessRule is the Schema for the NodeReadinessRules API.

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -33,6 +33,10 @@ spec:
       jsonPath: .spec.dryRun
       name: DryRun
       type: boolean
+    - description: Whether operations for this rule are suspended.
+      jsonPath: .spec.suspend
+      name: Suspend
+      type: boolean
     - description: The age of this resource
       jsonPath: .metadata.creationTimestamp
       name: Age
@@ -185,6 +189,10 @@ spec:
                 x-kubernetes-validations:
                 - message: nodeSelector is immutable
                   rule: self == oldSelf
+              suspend:
+                description: suspend tells the controller to suspend operations for
+                  this NodeReadinessRule.
+                type: boolean
               taint:
                 description: |-
                   taint defines the specific Taint (Key, Value, and Effect) to be managed

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -115,6 +115,11 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	log = log.WithValues("ruleName", rule.Name)
 	ctx = ctrl.LoggerInto(ctx, log)
 
+	if rule.Spec.Suspend {
+		log.Info("NodeReadinessRule is suspended, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
 	// Add finalizer first if not set to avoid the race condition between init and delete.
 	if finalizerAdded, err := r.ensureFinalizer(ctx, rule, finalizerName); err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -107,6 +107,46 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 	})
 
 	Context("Rule Reconciliation", func() {
+		It("should skip reconciliation when rule is suspended", func() {
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-rule-suspend",
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Suspend: true,
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{Type: "Ready", RequiredStatus: corev1.ConditionTrue},
+					},
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"node-role.kubernetes.io/worker": "",
+						},
+					},
+					Taint: corev1.Taint{
+						Key:    "readiness.k8s.io/test-taint",
+						Effect: corev1.TaintEffectNoSchedule,
+					},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
+
+			res, err := ruleReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "test-rule-suspend"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{}))
+
+			// Verify finalizer is NOT added to the rule
+			updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rule-suspend"}, updatedRule)).To(Succeed())
+			Expect(updatedRule.Finalizers).To(BeEmpty())
+
+			// Cleanup
+			Expect(k8sClient.Delete(ctx, rule)).To(Succeed())
+		})
+
 		It("should handle rule creation and add the finalizer to the rule", func() {
 			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

## Description
This PR introduces a `suspend` boolean field to the `NodeReadinessRuleSpec`. When a rule is suspended (`suspend: true`), the controller skips the reconciliation loop for that specific rule, leaving any existing taints and the cluster state exactly as they are. This provides a safe, standard mechanism to pause rule evaluation during maintenance windows or debugging, without needing to delete the rule.

## Related Issue
Fixes #335

## Type of Change

/kind feature
/kind api-change

## Testing
- Added a unit test in `nodereadinessrule_controller_test.go` to explicitly verify that when `suspend: true` is set, the controller skips evaluation and does not append a finalizer.
- Regenerated CRD manifests and deepcopy functions.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Added `suspend` field to `NodeReadinessRuleSpec`. When `suspend: true` is set, the controller skips evaluation of the rule, effectively pausing taint management while preserving the current cluster state.
