### PR TITLE
Replace metric label literals with constants

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -158,7 +158,7 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 			// Continue with other rules even if one fails
 			r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
 			errs = append(errs, err)
-			metrics.Failures.WithLabelValues(rule.Name, "EvaluationError").Inc()
+			metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonEvaluationError)).Inc()
 		}
 
 		// Persist the rule status
@@ -443,7 +443,7 @@ func (r *RuleReadinessController) SyncNodeStateMetrics(ctx context.Context, rule
 		}
 	}
 
-	metrics.NodesByState.WithLabelValues(rule.Name, "ready").Set(ready)
-	metrics.NodesByState.WithLabelValues(rule.Name, "not_ready").Set(notReady)
-	metrics.NodesByState.WithLabelValues(rule.Name, "bootstrapping").Set(bootstrapping)
+	metrics.NodesByState.WithLabelValues(rule.Name, string(metrics.NodeStateReady)).Set(ready)
+	metrics.NodesByState.WithLabelValues(rule.Name, string(metrics.NodeStateNotReady)).Set(notReady)
+	metrics.NodesByState.WithLabelValues(rule.Name, string(metrics.NodeStateBootstrapping)).Set(bootstrapping)
 }

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -1141,14 +1141,14 @@ var _ = Describe("Node Controller", func() {
 
 			// Read the failure counter before the call.
 			beforeM := &dto.Metric{}
-			_ = metrics.Failures.WithLabelValues(rule.Name, "EvaluationError").Write(beforeM)
+			_ = metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonEvaluationError)).Write(beforeM)
 			before := beforeM.GetCounter().GetValue()
 
 			err := controller.processNodeAgainstAllRules(ctx, node)
 			Expect(err).To(HaveOccurred())
 
 			afterM := &dto.Metric{}
-			_ = metrics.Failures.WithLabelValues(rule.Name, "EvaluationError").Write(afterM)
+			_ = metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonEvaluationError)).Write(afterM)
 			after := afterM.GetCounter().GetValue()
 
 			Expect(after).To(BeNumerically(">", before),

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -290,7 +290,7 @@ func (r *RuleReadinessController) processAllNodesForRule(ctx context.Context, ru
 			if err := r.evaluateRuleForNode(ctx, rule, &node); err != nil {
 				log.Error(err, "Failed to evaluate node for rule", "rule", rule.Name, "node", node.Name)
 				r.recordNodeFailure(rule, node.Name, "EvaluationError", err.Error())
-				metrics.Failures.WithLabelValues(rule.Name, "EvaluationError").Inc()
+				metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonEvaluationError)).Inc()
 			} else {
 				appliedNodes = append(appliedNodes, node.Name)
 				var updatedFailedNodes []readinessv1alpha1.NodeFailure
@@ -402,13 +402,13 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 		log.Info("Removing taint", "node", node.Name, "rule", rule.Name, "taint", rule.Spec.Taint.Key)
 
 		if err = r.removeTaintBySpec(ctx, node, rule.Spec.Taint, rule.Name); err != nil {
-			metrics.Failures.WithLabelValues(rule.Name, "RemoveTaintError").Inc()
+			metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonRemoveTaintError)).Inc()
 			return fmt.Errorf("failed to remove taint: %w", err)
 		}
 
 		// Record taint removal latency and taint operation counter.
-		metrics.TaintOperations.WithLabelValues(rule.Name, "remove").Inc()
-		recordLatency("remove_taint")
+		metrics.TaintOperations.WithLabelValues(rule.Name, string(metrics.TaintOperationRemove)).Inc()
+		recordLatency(string(metrics.ReconciliationOperationRemoveTaint))
 
 		// Mark bootstrap completed if bootstrap-only mode
 		if rule.Spec.EnforcementMode == readinessv1alpha1.EnforcementModeBootstrapOnly {
@@ -434,13 +434,13 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 		log.Info("Adding taint", "node", node.Name, "rule", rule.Name, "taint", rule.Spec.Taint.Key)
 
 		if err = r.addTaintBySpec(ctx, node, rule.Spec.Taint, rule.Name); err != nil {
-			metrics.Failures.WithLabelValues(rule.Name, "AddTaintError").Inc()
+			metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonAddTaintError)).Inc()
 			return fmt.Errorf("failed to add taint: %w", err)
 		}
 
 		// Record add taint latency and taint operation counter
-		metrics.TaintOperations.WithLabelValues(rule.Name, "add").Inc()
-		recordLatency("add_taint")
+		metrics.TaintOperations.WithLabelValues(rule.Name, string(metrics.TaintOperationAdd)).Inc()
+		recordLatency(string(metrics.ReconciliationOperationAddTaint))
 
 	case !shouldRemoveTaint && currentlyHasTaint:
 		if isFirstEvaluation {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -21,6 +21,40 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+// FailureReason represents the reason for a failed operation.
+type FailureReason string
+
+const (
+	FailureReasonEvaluationError  FailureReason = "EvaluationError"
+	FailureReasonAddTaintError    FailureReason = "AddTaintError"
+	FailureReasonRemoveTaintError FailureReason = "RemoveTaintError"
+)
+
+// TaintOperation represents a taint operation.
+type TaintOperation string
+
+const (
+	TaintOperationRemove TaintOperation = "remove"
+	TaintOperationAdd    TaintOperation = "add"
+)
+
+// ReconciliationOperation represents a reconciliation operation.
+type ReconciliationOperation string
+
+const (
+	ReconciliationOperationRemoveTaint ReconciliationOperation = "remove_taint"
+	ReconciliationOperationAddTaint    ReconciliationOperation = "add_taint"
+)
+
+// NodeState defines node states.
+type NodeState string
+
+const (
+	NodeStateReady         NodeState = "ready"
+	NodeStateNotReady      NodeState = "not_ready"
+	NodeStateBootstrapping NodeState = "bootstrapping"
+)
+
 var (
 	// RulesTotal tracks the number of NodeReadinessRules .
 	RulesTotal = prometheus.NewGauge(


### PR DESCRIPTION
## Summary

This PR replaces metric label string literals with typed constants to keep metric label values consistent and avoid accidental changes.

### Changes
- Replace hardcoded metric label values with typed constants.
- Update controllers and tests to use the new constants.
- Standardize failure reasons, operations, and node state labels.