### PR TITLE
fix: align reporter builder with Go 1.26

### DIFF
--- a/Dockerfile.reporter
+++ b/Dockerfile.reporter
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25.8 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.0 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Description

The Reporter image build uses Go 1.25.8 while the project now declares Go 1.26.0 in `go.mod`. As a result, `make docker-build-reporter` fails during `go mod download`.

Update the Reporter builder image to Go 1.26.0, matching the manager Dockerfile and the project toolchain.

## Related Issue

Fixes #354

## Type of Change

/kind bug
/kind regression

## Testing

- Confirmed `make docker-build-reporter IMG_PREFIX=nrc-reporter-local IMG_TAG=freshness-baseline` fails on current main with:
  `go.mod requires go >= 1.26.0 (running go 1.25.8; GOTOOLCHAIN=local)`
- Confirmed `make docker-build-reporter IMG_PREFIX=nrc-reporter-local IMG_TAG=go126-fix` succeeds after the change
- Confirmed `go test ./cmd/readiness-condition-reporter` passes
- Confirmed the resulting image starts and serves `/reporter --help`
- Confirmed `git diff --check` passes

## Checklist

- [ ] `make test` passes
- [ ] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Fix Reporter container image builds after the project upgrade to Go 1.26.
```