### PR TITLE
docs: note inotify limits for scale test

### DIFF
--- a/docs/TEST_README.md
+++ b/docs/TEST_README.md
@@ -149,6 +149,30 @@ examples/cni-readiness/apply-calico.sh
 
 This section tests how the controller handles new nodes being added to the cluster, simulating an autoscaler.
 
+> **Note: inotify limits on Linux hosts**
+> Each `kind` worker node runs its own systemd instance inside a container,
+> and each consumes several `inotify` instances (journald, udev, service
+> watchers, etc.). The default Linux limit (`fs.inotify.max_user_instances`,
+> often 128) is shared across your entire user session — desktop
+> environment, editors, browsers, and other file-watching tools all draw
+> from the same pool. On some dev enviroments, this budget can already be
+> significantly consumed before any kind nodes start, making it easy to
+> hit `Failed to allocate manager object: Too many open files` when
+> scaling to more worker nodes.
+>
+> If you see this error, increase the host's limits and retry:
+> ```bash
+> sudo sysctl fs.inotify.max_user_instances=1024
+> sudo sysctl fs.inotify.max_user_watches=1048576
+>
+> # Persist across reboots
+> echo "fs.inotify.max_user_instances = 1024" | sudo tee -a /etc/sysctl.d/99-kind.conf
+> echo "fs.inotify.max_user_watches = 1048576" | sudo tee -a /etc/sysctl.d/99-kind.conf
+> sudo sysctl --system
+> ```
+> Delete the affected node and re-run the scale-up command once the
+> limits are raised.
+
 1.  **Scale up the worker nodes:**
     ```bash
     # Add 2 new worker nodes (for a total of 4 workers)


### PR DESCRIPTION

## Description
<!-- Brief description of changes -->

Adds a troubleshooting note to Step 9 (Autoscaling Simulation Test) in
DEMO_ENVIRONMENT_SETUP.md, documenting `inotify` limit issue
encountered when scaling up to 4 kind worker nodes.

<img width="1892" height="548" alt="Screenshot From 2026-08-05 18-53-52" src="https://github.com/user-attachments/assets/4c1b2ed4-91b1-40dd-9ebb-b3cabb83d319" />


## Related Issue
<!--
None
-->

## Type of Change

kind documentation

## Testing
<!-- How was this tested? -->

Manually reproduced and verified on a local Fedora dev machine:

1. Ran the existing Step 9 scale-up command (`kindscaler.sh nrr-test 2`)
   to go from 2 to 4 worker nodes, with default
   `fs.inotify.max_user_instances=128`.
2. Confirmed the failure: `docker logs nrr-test-worker4` showed
   `Failed to allocate manager object: Too many open files`.
3. Applied the documented fix (raised `fs.inotify.max_user_instances`
   and `fs.inotify.max_user_watches` via `sysctl`).
4. Deleted the failed worker node and re-ran the scale-up command.
5. Confirmed all 4 worker nodes started successfully and the rest of
   Step 9 (taint verification) completed as expected.

## Checklist
- [X] `make test` passes
- [X] `make lint` passes

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
  1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
  2. Add 'Doc #(issue)' after the block if there is a follow up
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
Doc #(issue)