### PR TITLE
docs: sync netlify Go version with Makefile

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "docs/book"
-  command = "GO_VERSION=1.25.8 MDBOOK_VERSION=0.5.2 ./install-and-build-mdbook.sh"
+  command = "GO_VERSION=1.26.0 MDBOOK_VERSION=0.5.2 ./install-and-build-mdbook.sh"
   publish = "book"
 
 # Disables Pretty URLs feature so it doesn't break mdBook's heading navigation logic
@@ -8,7 +8,7 @@
   pretty_urls = false
 
 [context.deploy-preview]
-  command = "GO_VERSION=1.25.8 MDBOOK_VERSION=0.5.2 ./install-and-build-mdbook.sh"
+  command = "GO_VERSION=1.26.0 MDBOOK_VERSION=0.5.2 ./install-and-build-mdbook.sh"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION

## Description
<!-- Brief description of changes -->
Syncs `GO_VERSION` in `netlify.toml` with the value already used by the
Makefile and required by `go.mod`.

`netlify.toml` pinned `GO_VERSION=1.25.8` in both the `[build]` and
`[context.deploy-preview]` commands, while the Makefile's default
(`GO_VERSION ?= 1.26.0`) and `go.mod` (`go 1.26.0`) have since moved on.

it had also been discussed here 
<img width="1185" height="570" alt="image" src="https://github.com/user-attachments/assets/afbab26f-eab7-442d-965b-c6d0332b40e1" />

## Related Issue
None


## Type of Change
/kind cleanup




## Testing
<!-- How was this tested? -->

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
  1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
  2. Add 'Doc #(issue)' after the block if there is a follow up
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE 
```
Doc #(issue)