### PR TITLE
docs: add Cilium CNI integration example and documentation (#121)

### DIFF
--- a/docs/book/src/examples/cni-readiness.md
+++ b/docs/book/src/examples/cni-readiness.md
@@ -144,3 +144,35 @@ To test this, add a new node to the cluster.
 
 3.  **Check Taint Removal**:
     As soon as the condition becomes `True`, the Node Readiness Controller will remove the taint, and workloads will be scheduled.
+
+## Cilium CNI Integration & Bootstrap Taints
+
+When using **Cilium** as your CNI plugin:
+
+1. **Align Bootstrap Taints**: Configure Cilium's agent not-ready taint flag to use the standardized `readiness.k8s.io/*` prefix:
+   ```yaml
+   # Helm values for Cilium
+   extraArgs:
+     - --agent-not-ready-taint-key=readiness.k8s.io/network-not-ready
+   ```
+
+2. **Bootstrap NodeReadinessRule**: Once Cilium initializes networking, it sets the built-in Kubernetes node condition `NetworkUnavailable=False`. You can define a rule to untaint nodes based on `NetworkUnavailable`:
+   ```yaml
+   # cilium-network-readiness-rule.yaml
+   apiVersion: readiness.node.x-k8s.io/v1alpha1
+   kind: NodeReadinessRule
+   metadata:
+     name: cilium-network-readiness-rule
+   spec:
+     conditions:
+       - type: "NetworkUnavailable"
+         requiredStatus: "False"
+     taint:
+       key: "readiness.k8s.io/network-not-ready"
+       effect: "NoSchedule"
+       value: "true"
+     enforcementMode: "bootstrap-only"
+   ```
+
+> [!NOTE]
+> Cilium updates `NetworkUnavailable=False` during node bootstrap. For continuous post-startup health monitoring, pair this with a custom DaemonSet probe and `enforcementMode: "continuous"`.

--- a/examples/cni-readiness/README.md
+++ b/examples/cni-readiness/README.md
@@ -10,3 +10,7 @@ This example demonstrates how to use the Node Readiness Controller to ensure nod
 3. The `NodeReadinessRule` (`network-readiness-rule.yaml`) instructs the controller to remove the startup taint once the `projectcalico.org/CalicoReady` condition becomes `True`.
 4. The reporter is deployed with `hostNetwork: true` to reach Calico's local health endpoint.
 5. The reporter needs a dedicated ServiceAccount (`cni-reporter`) with permissions to patch node status.
+
+### Cilium Integration:
+For Cilium CNI, configure `--agent-not-ready-taint-key=readiness.k8s.io/network-not-ready` and apply `cilium-network-readiness-rule.yaml` targeting `NetworkUnavailable=False`.
+

--- a/examples/cni-readiness/cilium-network-readiness-rule.yaml
+++ b/examples/cni-readiness/cilium-network-readiness-rule.yaml
@@ -1,0 +1,17 @@
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: cilium-network-readiness-rule
+spec:
+  conditions:
+    - type: "NetworkUnavailable"
+      requiredStatus: "False"
+  taint:
+    key: "readiness.k8s.io/network-not-ready"
+    effect: "NoSchedule"
+    value: "true"
+  enforcementMode: "bootstrap-only"
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist


### PR DESCRIPTION
Fixes #121

### Summary
Adds documentation and an example manifest for integrating **Cilium CNI** with the Node Readiness Controller.

### Key Details
- **Taint Key Alignment:** Details configuring Cilium's `--agent-not-ready-taint-key` to match `readiness.k8s.io/network-not-ready`.
- **NodeReadinessRule:** Demonstrates using `NetworkUnavailable=False` for bootstrap network readiness.
- **Continuous Health:** Explains differences between bootstrap `NetworkUnavailable` status and continuous runtime health probes.

### Changes
- `examples/cni-readiness/cilium-network-readiness-rule.yaml`: Manifest for Cilium network readiness rule.
- `docs/book/src/examples/cni-readiness.md`: Added Cilium CNI integration guide.
- `examples/cni-readiness/README.md`: Added Cilium note.
