### PR TITLE
Fix memory leak of deleted nodes in FailedNodes

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -241,15 +241,24 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 		}
 	}
 
-	if len(newNodeEvaluations) == len(rule.Status.NodeEvaluations) {
+	var newFailedNodes []readinessv1alpha1.NodeFailure
+	for _, failure := range rule.Status.FailedNodes {
+		if existingNodes[failure.NodeName] {
+			newFailedNodes = append(newFailedNodes, failure)
+		}
+	}
+
+	if len(newNodeEvaluations) == len(rule.Status.NodeEvaluations) && len(newFailedNodes) == len(rule.Status.FailedNodes) {
 		log.V(4).Info("No deleted nodes to clean up", "rule", rule.Name)
 		return nil
 	}
 
 	log.V(4).Info("Cleaning up deleted nodes from rule status",
 		"rule", rule.Name,
-		"before", len(rule.Status.NodeEvaluations),
-		"after", len(newNodeEvaluations))
+		"evaluationsBefore", len(rule.Status.NodeEvaluations),
+		"evaluationsAfter", len(newNodeEvaluations),
+		"failedNodesBefore", len(rule.Status.FailedNodes),
+		"failedNodesAfter", len(newFailedNodes))
 
 	// Use retry on conflict to update status to avoid race conditions from node updates
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -265,12 +274,20 @@ func (r *RuleReadinessController) cleanupDeletedNodes(ctx context.Context, rule 
 			}
 		}
 
-		if len(freshNodeEvaluations) == len(fresh.Status.NodeEvaluations) {
+		var freshFailedNodes []readinessv1alpha1.NodeFailure
+		for _, failure := range fresh.Status.FailedNodes {
+			if existingNodes[failure.NodeName] {
+				freshFailedNodes = append(freshFailedNodes, failure)
+			}
+		}
+
+		if len(freshNodeEvaluations) == len(fresh.Status.NodeEvaluations) && len(freshFailedNodes) == len(fresh.Status.FailedNodes) {
 			return nil
 		}
 
 		patch := client.MergeFrom(fresh.DeepCopy())
 		fresh.Status.NodeEvaluations = freshNodeEvaluations
+		fresh.Status.FailedNodes = freshFailedNodes
 		return r.Status().Patch(ctx, fresh, patch)
 	})
 }


### PR DESCRIPTION
## Description
This PR fixes a logical and memory leak in the `cleanupDeletedNodes` function. When nodes are deleted, the controller successfully purges them from `rule.Status.NodeEvaluations`, but neglects to remove them from `rule.Status.FailedNodes`. This causes deleted nodes to linger indefinitely in the `FailedNodes` slice. This PR ensures that `FailedNodes` is also filtered during cleanup, and the early return condition now properly checks both `NodeEvaluations` and `FailedNodes` for changes.

## Related Issue
None

## Type of Change

## Testing
Tested locally. `make test` passes and `make lint` passes.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?
```release-note
NONE
```
