### PR TITLE
fix(reporter): reject non-positive CHECK_INTERVAL and HEARTBEAT_PERIOD

### DIFF
--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -55,6 +55,21 @@ type HealthResponse struct {
 	Message string `json:"message"`
 }
 
+func parseDurationWithDefault(input string, defaultVal time.Duration, name string) time.Duration {
+	if input == "" {
+		return defaultVal
+	}
+	parsed, err := time.ParseDuration(input)
+	if err != nil || parsed <= 0 {
+		klog.ErrorS(err, "Invalid duration, using default",
+			"setting", name,
+			"input", input,
+			"default", defaultVal)
+		return defaultVal
+	}
+	return parsed
+}
+
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -82,31 +97,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	checkInterval := os.Getenv(envCheckInterval)
-	interval := defaultCheckInterval
-	if checkInterval != "" {
-		parsedInterval, err := time.ParseDuration(checkInterval)
-		if err == nil {
-			interval = parsedInterval
-		} else {
-			klog.ErrorS(err, "Failed to parse check interval, using default",
-				"input", checkInterval,
-				"default", defaultCheckInterval)
-		}
-	}
-
-	heartbeatPeriodStr := os.Getenv(envHeartbeatPeriod)
-	heartbeatPeriod := defaultHeartbeatPeriod
-	if heartbeatPeriodStr != "" {
-		parsedPeriod, err := time.ParseDuration(heartbeatPeriodStr)
-		if err == nil {
-			heartbeatPeriod = parsedPeriod
-		} else {
-			klog.ErrorS(err, "Failed parse heartbeat period, using default",
-				"input", heartbeatPeriodStr,
-				"default", defaultHeartbeatPeriod)
-		}
-	}
+	interval := parseDurationWithDefault(os.Getenv(envCheckInterval), defaultCheckInterval, "check interval")
+	heartbeatPeriod := parseDurationWithDefault(os.Getenv(envHeartbeatPeriod), defaultHeartbeatPeriod, "heartbeat period")
 
 	// Create Kubernetes client
 	config, err := rest.InClusterConfig()

--- a/cmd/readiness-condition-reporter/main_test.go
+++ b/cmd/readiness-condition-reporter/main_test.go
@@ -267,3 +267,48 @@ func TestUpdateNodeCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDurationWithDefault(t *testing.T) {
+	defaultVal := 30 * time.Second
+
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+	}{
+		{
+			name:     "valid positive duration",
+			input:    "60s",
+			expected: 60 * time.Second,
+		},
+		{
+			name:     "zero duration",
+			input:    "0s",
+			expected: defaultVal,
+		},
+		{
+			name:     "negative duration",
+			input:    "-30s",
+			expected: defaultVal,
+		},
+		{
+			name:     "unparseable duration",
+			input:    "abc",
+			expected: defaultVal,
+		},
+		{
+			name:     "empty duration",
+			input:    "",
+			expected: defaultVal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDurationWithDefault(tt.input, defaultVal, "test duration")
+			if result != tt.expected {
+				t.Errorf("parseDurationWithDefault(%q) = %v, expected %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR addresses two defects in the parsing of environment-driven duration configurations (`CHECK_INTERVAL` and `HEARTBEAT_PERIOD`) within the `readiness-condition-reporter`.
Currently, `time.ParseDuration` accepts `"0s"` and negative values like `"-30s"` without returning an error. This causes `CHECK_INTERVAL` to pass through as `0s` and immediately panic at `time.NewTicker(interval)` with `non-positive interval for NewTicker`. Similarly, a negative `HEARTBEAT_PERIOD` causes the heartbeat check to evaluate to true continuously, silently spiking API server load on every tick.
This PR adds a strictly positive (`> 0`) check to both parsed durations. It preserves the file's existing convention to log a `klog.ErrorS` and fall back to the defaults without introducing a new structural pattern or a hard exit.

Composition note: [#334](https://github.com/kubernetes-sigs/node-readiness-controller/pull/334) (LightCreator1007) is refactoring line 284, `time.Since(...) >= heartbeatPeriod` — the exact line where the negative-`HEARTBEAT_PERIOD` symptom appears. Our fix lives at the *parse site* (lines 98–109), which no open PR touches, so the two compose rather than conflict.

## Related Issue
Fixes #368

## Type of Change
/kind bug

## Testing
Tested locally via a table test for `parseDurationWithDefault`. `make test` passes and `make lint` passes.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?
```release-note
NONE
```
