### PR TITLE
fix(reporter): add system:nodes group to node impersonation config

### DIFF
--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -120,6 +120,7 @@ func main() {
 	if os.Getenv(envImpersonateNode) == "true" {
 		config.Impersonate = rest.ImpersonationConfig{
 			UserName: "system:node:" + nodeName,
+			Groups:   []string{"system:nodes"},
 		}
 		klog.InfoS("Node impersonation enabled", "impersonating", config.Impersonate.UserName)
 	}


### PR DESCRIPTION
## Description
This PR addresses a defect in the `readiness-condition-reporter` where node impersonation (`IMPERSONATE_NODE=true`) fails to include the `system:nodes` group in the `rest.ImpersonationConfig`.
In Kubernetes, Node authorization strictly requires the `system:nodes` group alongside the `system:node:<nodeName>` username. Without this group, the API server rejects the `UpdateStatus` call under the `NodeRestriction` admission plugin or RBAC, causing the reporter to silently fail in patching the node condition.
This PR adds `Groups: []string{"system:nodes"}` to the impersonation config, enabling the reporter to successfully impersonate the node and report conditions.

## Related Issue
None

## Type of Change
/kind bug

## Testing
Verified by reviewing Kubernetes Node authorization requirements. `make lint` and `make test` pass cleanly.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?
```release-note
NONE
```
