### PR TITLE
fix(reporter): limit response body read to prevent unbounded memory consumption

### DIFF
--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -225,7 +225,7 @@ func checkHealth(ctx context.Context, client *http.Client, endpoint string) (*He
 		}, nil
 	}
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	bodyString := ""
 	if err == nil {
 		bodyString = string(bodyBytes)


### PR DESCRIPTION
## Description
This PR addresses a potential memory exhaustion vulnerability in the `readiness-condition-reporter`.
The `checkHealth` function previously read the entire health check response body into memory using `io.ReadAll(resp.Body)` without any bounds limit. If an endpoint were misconfigured or compromised to return an infinite or excessively large stream of data, the reporter process would consume unbounded memory, ultimately causing an Out-Of-Memory (OOM) crash on the node.
This PR wraps `resp.Body` in an `io.LimitReader` (capped at 64KB) before reading it, ensuring that the reporter's memory footprint remains strictly bounded regardless of the endpoint's behavior.

## Related Issue
None

## Type of Change
/kind bug

## Testing
Verified by `make test` and `make lint`, ensuring that standard endpoint payloads (which are small JSON or text strings) are unaffected while large streams are truncated safely.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?
```release-note
NONE
```
