### PR TITLE
docs: remove undocumented gracePeriod, fix taint comment

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -127,9 +127,6 @@ type NodeReadinessRuleSpec struct {
     // Node selector for targeting specific nodes
     NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
     
-    // Grace period before applying taint changes
-    GracePeriod *metav1.Duration `json:"gracePeriod,omitempty"`
-    
     // Dry run mode - preview changes without applying
     DryRun bool `json:"dryRun,omitempty"`
 }
@@ -281,7 +278,6 @@ spec:
     key: "readiness.k8s.io/StorageReady"
     effect: "NoSchedule"
   enforcementMode: "continuous"
-  gracePeriod: "60s"
   dryRun: true  # Preview mode
 ```
 


### PR DESCRIPTION


## Description
<!-- Brief description of changes -->
`Graceperiod` is documented in the documentation but never used in any controller logic using it, so it is currently documentation-only and misleading for users.
## Related Issue
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

## Type of Change

<!--
Add one of the following kinds:
/kind documentation

-->

## Testing
<!-- How was this tested? -->

## Checklist
- [ ] `make test` passes
- [ ] `make lint` passes

## Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
  1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
  2. Add 'Doc #(issue)' after the block if there is a follow up
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
Doc #(issue)