### PR TITLE
fix: stop reporting adoption for taints the controller applied itself

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -152,6 +152,21 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 			"rule", rule.Name,
 			"ruleResourceVersion", rule.ResourceVersion)
 
+		// The cached rule carries a status snapshot taken the last time
+		// RuleReconciler ran. Node evaluations persisted since then are missing
+		// from it, and because the rule spec is immutable that reconcile rarely
+		// runs again, so the snapshot can stay stale for the lifetime of the
+		// process. Refresh the evaluations from the live object first, otherwise
+		// every pass looks like the node's first evaluation. This reads through
+		// the controller-runtime cache, so it is not an extra API call.
+		latestRule := &readinessv1alpha1.NodeReadinessRule{}
+		if err := r.Get(ctx, client.ObjectKey{Name: rule.Name}, latestRule); err != nil {
+			log.V(4).Info("Could not refresh rule status before evaluation, using cached copy",
+				"node", node.Name, "rule", rule.Name, "error", err.Error())
+		} else {
+			rule.Status.NodeEvaluations = latestRule.Status.NodeEvaluations
+		}
+
 		if err := r.evaluateRuleForNode(ctx, rule, node); err != nil {
 			log.Error(err, "Failed to evaluate rule for node",
 				"node", node.Name, "rule", rule.Name)

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -1153,6 +1154,149 @@ var _ = Describe("Node Controller", func() {
 
 			Expect(after).To(BeNumerically(">", before),
 				"metrics.Failures{rule, EvaluationError} must increment when the node reconciler hits an evaluation error")
+		})
+	})
+
+	Context("when a node is re-evaluated while still unready", func() {
+		const (
+			adoptNodeName = "adopt-events-node"
+			adoptRuleName = "adopt-events-rule"
+			adoptTaintKey = "readiness.k8s.io/adopt-events"
+			adoptCondType = "AdoptEventsCondition"
+		)
+
+		var (
+			adoptRecorder *events.FakeRecorder
+			adoptCtrl     *RuleReadinessController
+			adoptNodeRec  *NodeReconciler
+		)
+
+		countAdoptedEvents := func() int {
+			count := 0
+			for {
+				select {
+				case e := <-adoptRecorder.Events:
+					if strings.Contains(e, "TaintAdopted") {
+						count++
+					}
+				default:
+					return count
+				}
+			}
+		}
+
+		BeforeEach(func() {
+			adoptRecorder = events.NewFakeRecorder(100)
+			adoptCtrl = &RuleReadinessController{
+				Client:        k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: adoptRecorder,
+			}
+			adoptNodeRec = &NodeReconciler{
+				Client:     k8sClient,
+				Scheme:     k8sClient.Scheme(),
+				Controller: adoptCtrl,
+			}
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   adoptNodeName,
+					Labels: map[string]string{"env": "adopt-events"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+
+			fetched := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: adoptNodeName}, fetched)).To(Succeed())
+			fetched.Status.Conditions = []corev1.NodeCondition{{
+				Type:               corev1.NodeConditionType(adoptCondType),
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+				LastHeartbeatTime:  metav1.Now(),
+				Reason:             "NotReady",
+				Message:            "still starting up",
+			}}
+			Expect(k8sClient.Status().Update(ctx, fetched)).To(Succeed())
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       adoptRuleName,
+					Finalizers: []string{finalizerName},
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Conditions: []nodereadinessiov1alpha1.ConditionRequirement{
+						{Type: adoptCondType, RequiredStatus: corev1.ConditionTrue},
+					},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"env": "adopt-events"}},
+					Taint:           corev1.Taint{Key: adoptTaintKey, Effect: corev1.TaintEffectNoSchedule},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
+
+			// Seed the cache the way RuleReconciler does on its first pass, before
+			// any node evaluation has been persisted.
+			adoptCtrl.updateRuleCache(ctx, rule)
+		})
+
+		AfterEach(func() {
+			node := &corev1.Node{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: adoptNodeName}, node); err == nil {
+				_ = k8sClient.Delete(ctx, node)
+			}
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: adoptRuleName}, rule); err == nil {
+				rule.Finalizers = nil
+				_ = k8sClient.Update(ctx, rule)
+				_ = k8sClient.Delete(ctx, rule)
+			}
+			adoptCtrl.removeRuleFromCache(ctx, adoptRuleName)
+		})
+
+		It("should not report adoption for a taint the controller applied itself", func() {
+			By("applying the taint on the first reconcile")
+			_, err := adoptNodeRec.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: adoptNodeName},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(countAdoptedEvents()).To(Equal(0), "applying a taint is not an adoption")
+
+			By("persisting the evaluation for that node")
+			persisted := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: adoptRuleName}, persisted)).To(Succeed())
+			Expect(persisted.Status.NodeEvaluations).To(ContainElement(HaveField("NodeName", adoptNodeName)))
+
+			By("re-evaluating while the node is still unready")
+			for range 3 {
+				_, err = adoptNodeRec.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: adoptNodeName},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			Expect(countAdoptedEvents()).To(Equal(0),
+				"the rule already owns this taint, so no further TaintAdopted events should be emitted")
+		})
+
+		It("should still report adoption for a taint that pre-existed the rule", func() {
+			By("putting the taint on the node before the rule ever evaluates it")
+			node := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: adoptNodeName}, node)).To(Succeed())
+			node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+				Key:    adoptTaintKey,
+				Effect: corev1.TaintEffectNoSchedule,
+			})
+			Expect(k8sClient.Update(ctx, node)).To(Succeed())
+
+			_, err := adoptNodeRec.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: adoptNodeName},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(countAdoptedEvents()).To(Equal(1),
+				"a taint the controller did not apply should still be reported as adopted once")
 		})
 	})
 })


### PR DESCRIPTION
## Description

`NodeReconciler` evaluates rules from the in-memory cache, and the cached copy carries whatever status the rule had the last time `RuleReconciler` ran. Node evaluations persisted since then are not in it, and because the rule spec is immutable `GenerationChangedPredicate` means that reconcile rarely fires again, so the snapshot can stay stale for the life of the process.

`evaluateRuleForNode` decides adoption from that status, so for a node the snapshot never contained `isFirstEvaluation` is always true and the adoption branch fires on every pass. The result is a `TaintAdopted` event and an `Adopting pre-existing taint` log line every time an unready, already tainted node reconciles, for a taint the controller applied itself.

The fix refreshes `NodeEvaluations` from the live object before evaluating. That read goes through the controller-runtime cache, so it is not an extra API call, and the persist block a few lines below already does the same `Get`. It deliberately touches only `NodeEvaluations` and leaves `FailedNodes` alone, so it does not overlap with #381 or #209.

## Related Issue

Fixes #383

## Type of Change

/kind bug

## Testing

Two specs added under `when a node is re-evaluated while still unready`:

The first applies the taint, confirms the evaluation is persisted, then reconciles three more times and asserts no further `TaintAdopted` events. It fails on `main`:

```
INFO  Adopting pre-existing taint  {"node": "adopt-events-node", ...}
INFO  Adopting pre-existing taint  {"node": "adopt-events-node", ...}
INFO  Adopting pre-existing taint  {"node": "adopt-events-node", ...}
[FAILED] the rule already owns this taint, so no further TaintAdopted events should be emitted
```

The second puts the taint on the node before the rule ever evaluates it and asserts exactly one `TaintAdopted` event, so the feature still works. That one passes both with and without the fix, which is what shows the change is narrow rather than just switching adoption off.

Full controller suite passes, 64 of 64 specs, up from 62 before these two. `internal/webhook` and `cmd/readiness-condition-reporter` pass too. Run against envtest with Kubernetes 1.36.2 binaries. `golangci-lint` v2.12.1 reports 0 issues.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Fixed repeated TaintAdopted events being recorded for taints the controller applied itself. The event is now emitted only when a taint was already on the node before the rule took ownership of it.
```
