### PR TITLE
docs: add Helm installation guide

### DIFF
--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -110,6 +110,21 @@ helm install nrr-controller ./charts/nrr-controller \
 
 Both `webhook.enabled` and `validatingWebhook.enabled` are needed. The first runs the webhook server in the controller and mounts its certificate, the second registers the `ValidatingWebhookConfiguration` with the API server.
 
+#### Tuning for larger clusters
+
+The values under `controller` map to the manager's own flags, and each one is only passed to the container when you move it off its default:
+
+| Value | Flag | Default |
+| :--- | :--- | :--- |
+| `controller.nodeConcurrentReconciles` | `--node-concurrent-reconciles` | `1` |
+| `controller.ruleConcurrentReconciles` | `--rule-concurrent-reconciles` | `1` |
+| `controller.kubeAPIQPS` | `--kube-api-qps` | `-1`, client-side throttling off |
+| `controller.kubeAPIBurst` | `--kube-api-burst` | `-1`, client-side throttling off |
+| `controller.enableNodeStateMetrics` | `--enable-node-state-metrics` | `false` |
+| `controller.pprofBindAddress` | `--pprof-bind-address` | unset, disabled |
+
+Raising the two concurrency values is the usual response to readiness taints lagging behind node joins on a large cluster. `enableNodeStateMetrics` adds the per-rule `node_readiness_nodes_by_state` gauge at the cost of extra API reads on node updates, so turn it on when you want the fleet view and can afford the reads.
+
 #### Managing rules through the chart
 
 `NodeReadinessRule` objects can be shipped with the release through the `nodeReadinessRules` value:

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -64,13 +64,13 @@ docker pull $REPO:$TAG
 ```
 ### Option 2: Helm Chart
 
-The chart lives in the repository under `charts/nrr-controller`. Published chart releases via `registry.k8s.io` OCI are still work in progress, so install it from a checkout for now.
+The chart lives in the repository under `charts/node-readiness-controller`. Published chart releases via `registry.k8s.io` OCI are still work in progress, so install it from a checkout for now.
 
 ```sh
 git clone https://github.com/kubernetes-sigs/node-readiness-controller.git
 cd node-readiness-controller
 
-helm install nrr-controller ./charts/nrr-controller \
+helm install node-readiness-controller ./charts/node-readiness-controller \
   --namespace nrr-system --create-namespace
 ```
 
@@ -79,9 +79,9 @@ Requires Helm 3.x. This deploys the controller with the same defaults as the sta
 For anything beyond a couple of overrides, keep your settings in a file instead of a long `--set` list:
 
 ```sh
-helm show values ./charts/nrr-controller > custom-values.yaml
+helm show values ./charts/node-readiness-controller > custom-values.yaml
 
-helm install nrr-controller ./charts/nrr-controller \
+helm install node-readiness-controller ./charts/node-readiness-controller \
   --namespace nrr-system --create-namespace \
   -f custom-values.yaml
 ```
@@ -99,7 +99,7 @@ Everything beyond the core controller is opt-in, matching the kustomize componen
 The webhook rejects rules whose taint key and effect collide with an existing rule over an overlapping node selector, so it is worth enabling in production.
 
 ```sh
-helm install nrr-controller ./charts/nrr-controller \
+helm install node-readiness-controller ./charts/node-readiness-controller \
   --namespace nrr-system --create-namespace \
   --set certManager.enabled=true \
   --set webhook.enabled=true \
@@ -157,7 +157,7 @@ Pull the version of the chart you want and upgrade the release in place. Values 
 ```sh
 git pull
 
-helm upgrade nrr-controller ./charts/nrr-controller \
+helm upgrade node-readiness-controller ./charts/node-readiness-controller \
   --namespace nrr-system \
   -f custom-values.yaml
 ```
@@ -167,7 +167,7 @@ helm upgrade nrr-controller ./charts/nrr-controller \
 Check what changed before applying it to a live cluster:
 
 ```sh
-helm diff upgrade nrr-controller ./charts/nrr-controller --namespace nrr-system   # needs the helm-diff plugin
+helm diff upgrade node-readiness-controller ./charts/node-readiness-controller --namespace nrr-system   # needs the helm-diff plugin
 ```
 
 Read the CRD note below first. Helm will not update the CRD for you, so a chart bump that changes the schema needs that step done by hand.
@@ -179,7 +179,7 @@ Helm installs the CRD from the chart's `crds/` directory on first install only. 
 Before moving to a chart version that changes the `NodeReadinessRule` schema, apply the CRD yourself:
 
 ```sh
-kubectl apply -f charts/nrr-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
+kubectl apply -f charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
 ```
 
 Skipping this leaves the old schema in place, and rules using newly added fields are rejected by the API server even though the controller supports them.
@@ -230,13 +230,13 @@ After installation, verify that the controller is running successfully.
 
 1.  **Check Pod Status**:
     ```sh
-    kubectl get pods -n ${NAMESPACE} -l component=node-readiness-controller
+    kubectl get pods -n ${NAMESPACE} -l control-plane=controller-manager
     ```
     You should see the controller pods in `Running` status.
 
 2.  **Check Logs**:
     ```sh
-    kubectl logs -n ${NAMESPACE} -l component=node-readiness-controller
+    kubectl logs -n ${NAMESPACE} -l control-plane=controller-manager
     ```
     Look for "Starting EventSource" or "Starting Controller" messages indicating the manager is active.
 
@@ -280,7 +280,7 @@ The controller uses a **finalizer** (`readiness.node.x-k8s.io/cleanup-taints`) o
     kubectl delete -k config/default
 
     # OR if using Helm
-    helm uninstall nrr-controller --namespace nrr-system
+    helm uninstall node-readiness-controller --namespace nrr-system
 
     # OR if using Static Pods
     # Remove the manifest from /etc/kubernetes/manifests/ on all control-plane nodes

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -62,7 +62,82 @@ REPO="registry.k8s.io/node-readiness-controller/node-readiness-controller"
 TAG=$(skopeo list-tags docker://$REPO | jq .'Tags[-1]' | tr -d '"')
 docker pull $REPO:$TAG
 ```
-### Option 2: Advanced Deployment (Kustomize)
+### Option 2: Helm Chart
+
+The chart lives in the repository under `charts/nrr-controller`. Published chart releases via `registry.k8s.io` OCI are still work in progress, so install it from a checkout for now.
+
+```sh
+git clone https://github.com/kubernetes-sigs/node-readiness-controller.git
+cd node-readiness-controller
+
+helm install nrr-controller ./charts/nrr-controller \
+  --namespace nrr-system --create-namespace
+```
+
+Requires Helm 3.x. This deploys the controller with the same defaults as the standard manifest: leader election on, metrics off, and the validating webhook off.
+
+#### Optional components
+
+Everything beyond the core controller is opt-in, matching the kustomize components.
+
+| Feature | Values | Prerequisites |
+| :--- | :--- | :--- |
+| Metrics endpoint | `metrics.enabled=true` | None for plain HTTP |
+| Metrics over TLS | `metrics.enabled=true`, `metrics.secure=true`, `certManager.enabled=true` | `cert-manager` |
+| Validating webhook | `webhook.enabled=true`, `validatingWebhook.enabled=true`, `certManager.enabled=true` | `cert-manager` |
+
+The webhook rejects rules whose taint key and effect collide with an existing rule over an overlapping node selector, so it is worth enabling in production.
+
+```sh
+helm install nrr-controller ./charts/nrr-controller \
+  --namespace nrr-system --create-namespace \
+  --set certManager.enabled=true \
+  --set webhook.enabled=true \
+  --set validatingWebhook.enabled=true \
+  --set metrics.enabled=true \
+  --set metrics.secure=true
+```
+
+Both `webhook.enabled` and `validatingWebhook.enabled` are needed. The first runs the webhook server in the controller and mounts its certificate, the second registers the `ValidatingWebhookConfiguration` with the API server.
+
+#### Managing rules through the chart
+
+`NodeReadinessRule` objects can be shipped with the release through the `nodeReadinessRules` value:
+
+```yaml
+nodeReadinessRules:
+  - name: kube-proxy-unhealthy-noschedule
+    enforcementMode: continuous
+    conditions:
+      - type: KubeProxyUnhealthy
+        requiredStatus: "False"
+    taint:
+      key: readiness.k8s.io/KubeProxyUnhealthy
+      value: "true"
+      effect: NoSchedule
+    nodeSelector:
+      matchLabels:
+        kubernetes.io/os: linux
+```
+
+`nodeSelector` is required on every entry. Set it explicitly, since an empty selector matches every node in the cluster.
+
+> [!NOTE]
+> With the validating webhook enabled, apply rules only once the controller is serving admission requests. On a first install the webhook is not ready while the rules in the same release are being created, so install the controller first and add the rules in a follow-up `helm upgrade`.
+
+#### CRD upgrades
+
+Helm installs the CRD from the chart's `crds/` directory on first install only. It does not upgrade or remove it on `helm upgrade` or `helm uninstall`.
+
+Before moving to a chart version that changes the `NodeReadinessRule` schema, apply the CRD yourself:
+
+```sh
+kubectl apply -f charts/nrr-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
+```
+
+Skipping this leaves the old schema in place, and rules using newly added fields are rejected by the API server even though the controller supports them.
+
+### Option 3: Advanced Deployment (Kustomize)
 
 If you need deeper customization, you can use Kustomize directly from the source.
 
@@ -76,7 +151,7 @@ kubectl apply -k config/default
 
 You can enable optional components (Metrics, TLS, Webhook) by creating a `kustomization.yaml` that includes the relevant components from the `config/` directory. For reference on how these components can be combined, see the `deploy-with-metrics`, `deploy-with-tls`, `deploy-with-webhook`, and `deploy-full` targets in the projects [`Makefile`](https://github.com/kubernetes-sigs/node-readiness-controller/blob/main/Makefile).
 
-### Option 3: Deploy as a Static Pod (Control Plane)
+### Option 4: Deploy as a Static Pod (Control Plane)
 
 Running the controller as a **Static Pod** on control-plane nodes is useful for self-managed clusters (e.g., `kubeadm`) where you want the controller to be available alongside core components like the API server.
 
@@ -157,14 +232,21 @@ The controller uses a **finalizer** (`readiness.node.x-k8s.io/cleanup-taints`) o
     # OR if using Kustomize
     kubectl delete -k config/default
 
+    # OR if using Helm
+    helm uninstall nrr-controller --namespace nrr-system
+
     # OR if using Static Pods
     # Remove the manifest from /etc/kubernetes/manifests/ on all control-plane nodes
     ```
+
+    > [!CAUTION]
+    > Rules declared through the chart's `nodeReadinessRules` value are part of the release, so `helm uninstall` deletes them and the controller in one operation. Helm does not wait for the finalizer to run, which is exactly the situation described in [Recovering from Stuck Resources](#recovering-from-stuck-resources). Delete the rules and let them finish terminating before uninstalling the release.
 
 3.  **Uninstall CRDs** (Optional):
     ```sh
     kubectl delete -k config/crd
     ```
+    Helm does not remove the CRD it installed from the chart's `crds/` directory, so delete it explicitly if you used the chart.
 
 ### Recovering from Stuck Resources
 

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -230,13 +230,13 @@ After installation, verify that the controller is running successfully.
 
 1.  **Check Pod Status**:
     ```sh
-    kubectl get pods -n ${NAMESPACE} -l control-plane=controller-manager
+    kubectl get pods -n ${NAMESPACE} -l component=node-readiness-controller
     ```
     You should see the controller pods in `Running` status.
 
 2.  **Check Logs**:
     ```sh
-    kubectl logs -n ${NAMESPACE} -l control-plane=controller-manager
+    kubectl logs -n ${NAMESPACE} -l component=node-readiness-controller
     ```
     Look for "Starting EventSource" or "Starting Controller" messages indicating the manager is active.
 

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -76,6 +76,16 @@ helm install nrr-controller ./charts/nrr-controller \
 
 Requires Helm 3.x. This deploys the controller with the same defaults as the standard manifest: leader election on, metrics off, and the validating webhook off.
 
+For anything beyond a couple of overrides, keep your settings in a file instead of a long `--set` list:
+
+```sh
+helm show values ./charts/nrr-controller > custom-values.yaml
+
+helm install nrr-controller ./charts/nrr-controller \
+  --namespace nrr-system --create-namespace \
+  -f custom-values.yaml
+```
+
 #### Optional components
 
 Everything beyond the core controller is opt-in, matching the kustomize components.
@@ -124,6 +134,28 @@ nodeReadinessRules:
 
 > [!NOTE]
 > With the validating webhook enabled, apply rules only once the controller is serving admission requests. On a first install the webhook is not ready while the rules in the same release are being created, so install the controller first and add the rules in a follow-up `helm upgrade`.
+
+#### Upgrading
+
+Pull the version of the chart you want and upgrade the release in place. Values you set at install time are carried over, so only pass the ones you are changing:
+
+```sh
+git pull
+
+helm upgrade nrr-controller ./charts/nrr-controller \
+  --namespace nrr-system \
+  -f custom-values.yaml
+```
+
+`helm upgrade --install` works too if you want one command that handles both the first install and later upgrades.
+
+Check what changed before applying it to a live cluster:
+
+```sh
+helm diff upgrade nrr-controller ./charts/nrr-controller --namespace nrr-system   # needs the helm-diff plugin
+```
+
+Read the CRD note below first. Helm will not update the CRD for you, so a chart bump that changes the schema needs that step done by hand.
 
 #### CRD upgrades
 

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -64,24 +64,35 @@ docker pull $REPO:$TAG
 ```
 ### Option 2: Helm Chart
 
-The chart lives in the repository under `charts/node-readiness-controller`. Published chart releases via `registry.k8s.io` OCI are still work in progress, so install it from a checkout for now.
+The official Helm chart is published to the OCI registry at `registry.k8s.io/node-readiness-controller/charts/node-readiness-controller`.
 
 ```sh
-git clone https://github.com/kubernetes-sigs/node-readiness-controller.git
-cd node-readiness-controller
+# Replace with the desired version
+VERSION=0.5.0
 
-helm install node-readiness-controller ./charts/node-readiness-controller \
+helm install node-readiness-controller \
+  oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
+  --version ${VERSION} \
   --namespace nrr-system --create-namespace
 ```
 
-Requires Helm 3.x. This deploys the controller with the same defaults as the standard manifest: leader election on, metrics off, and the validating webhook off.
+Requires Helm 3.8+ (native OCI support). This deploys the controller with the same defaults as the standard manifest: leader election on, metrics off, and the validating webhook off.
+
+> [!NOTE]
+> You can also install the chart directly from a local repository checkout if developing locally:
+> ```sh
+> helm install node-readiness-controller ./charts/node-readiness-controller \
+>   --namespace nrr-system --create-namespace
+> ```
 
 For anything beyond a couple of overrides, keep your settings in a file instead of a long `--set` list:
 
 ```sh
-helm show values ./charts/node-readiness-controller > custom-values.yaml
+helm show values oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller --version ${VERSION} > custom-values.yaml
 
-helm install node-readiness-controller ./charts/node-readiness-controller \
+helm install node-readiness-controller \
+  oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
+  --version ${VERSION} \
   --namespace nrr-system --create-namespace \
   -f custom-values.yaml
 ```
@@ -99,7 +110,9 @@ Everything beyond the core controller is opt-in, matching the kustomize componen
 The webhook rejects rules whose taint key and effect collide with an existing rule over an overlapping node selector, so it is worth enabling in production.
 
 ```sh
-helm install node-readiness-controller ./charts/node-readiness-controller \
+helm install node-readiness-controller \
+  oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
+  --version ${VERSION} \
   --namespace nrr-system --create-namespace \
   --set certManager.enabled=true \
   --set webhook.enabled=true \
@@ -152,12 +165,12 @@ nodeReadinessRules:
 
 #### Upgrading
 
-Pull the version of the chart you want and upgrade the release in place. Values you set at install time are carried over, so only pass the ones you are changing:
+Upgrade the release in place using the OCI chart. Values you set at install time are carried over, so only pass the ones you are changing:
 
 ```sh
-git pull
-
-helm upgrade node-readiness-controller ./charts/node-readiness-controller \
+helm upgrade node-readiness-controller \
+  oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
+  --version ${VERSION} \
   --namespace nrr-system \
   -f custom-values.yaml
 ```
@@ -167,7 +180,10 @@ helm upgrade node-readiness-controller ./charts/node-readiness-controller \
 Check what changed before applying it to a live cluster:
 
 ```sh
-helm diff upgrade node-readiness-controller ./charts/node-readiness-controller --namespace nrr-system   # needs the helm-diff plugin
+helm diff upgrade node-readiness-controller \
+  oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
+  --version ${VERSION} \
+  --namespace nrr-system   # needs the helm-diff plugin
 ```
 
 Read the CRD note below first. Helm will not update the CRD for you, so a chart bump that changes the schema needs that step done by hand.
@@ -179,7 +195,7 @@ Helm installs the CRD from the chart's `crds/` directory on first install only. 
 Before moving to a chart version that changes the `NodeReadinessRule` schema, apply the CRD yourself:
 
 ```sh
-kubectl apply -f charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/node-readiness-controller/releases/download/${VERSION}/crds.yaml
 ```
 
 Skipping this leaves the old schema in place, and rules using newly added fields are rejected by the API server even though the controller supports them.

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -78,24 +78,20 @@ helm install node-readiness-controller \
 
 Requires Helm 3.8+ (native OCI support). This deploys the controller with the same defaults as the standard manifest: leader election on, metrics off, and the validating webhook off.
 
-> [!NOTE]
-> You can also install the chart from a local checkout when developing:
-> ```sh
-> helm install node-readiness-controller ./charts/node-readiness-controller \
->   --namespace nrr-system --create-namespace \
->   --set image.tag=v0.5.0
-> ```
->
-> Set `image.tag` explicitly here. The real chart and app versions are injected at
-> package time by `make build-helm`, so `Chart.yaml` in the repository keeps a
-> placeholder `appVersion`. Installing straight from a checkout without an override
-> therefore deploys whatever that placeholder points at rather than the release you
-> checked out.
-
-For anything beyond a couple of overrides, keep your settings in a file instead of a long `--set` list:
+`helm show values` lists everything the chart exposes, and redirecting it gives you a starting point to edit:
 
 ```sh
 helm show values oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller --version ${CHART_VERSION} > custom-values.yaml
+```
+
+Override them with `--set`, or from a file with `-f`:
+
+```sh
+helm install node-readiness-controller \
+  oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
+  --version ${CHART_VERSION} \
+  --namespace nrr-system --create-namespace \
+  --set metrics.enabled=true
 
 helm install node-readiness-controller \
   oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
@@ -144,31 +140,6 @@ The values under `controller` map to the manager's own flags, and each one is on
 | `controller.pprofBindAddress` | `--pprof-bind-address` | unset, disabled |
 
 Raising the two concurrency values is the usual response to readiness taints lagging behind node joins on a large cluster. `enableNodeStateMetrics` adds the per-rule `node_readiness_nodes_by_state` gauge at the cost of extra API reads on node updates, so turn it on when you want the fleet view and can afford the reads.
-
-#### Managing rules through the chart
-
-`NodeReadinessRule` objects can be shipped with the release through the `nodeReadinessRules` value:
-
-```yaml
-nodeReadinessRules:
-  - name: kube-proxy-unhealthy-noschedule
-    enforcementMode: continuous
-    conditions:
-      - type: KubeProxyUnhealthy
-        requiredStatus: "False"
-    taint:
-      key: readiness.k8s.io/KubeProxyUnhealthy
-      value: "true"
-      effect: NoSchedule
-    nodeSelector:
-      matchLabels:
-        kubernetes.io/os: linux
-```
-
-`nodeSelector` is required on every entry. Set it explicitly, since an empty selector matches every node in the cluster.
-
-> [!NOTE]
-> With the validating webhook enabled, apply rules only once the controller is serving admission requests. On a first install the webhook is not ready while the rules in the same release are being created, so install the controller first and add the rules in a follow-up `helm upgrade`.
 
 #### Upgrading
 
@@ -312,9 +283,6 @@ The controller uses a **finalizer** (`readiness.node.x-k8s.io/cleanup-taints`) o
     # OR if using Static Pods
     # Remove the manifest from /etc/kubernetes/manifests/ on all control-plane nodes
     ```
-
-    > [!CAUTION]
-    > Rules declared through the chart's `nodeReadinessRules` value are part of the release, so `helm uninstall` deletes them and the controller in one operation. Helm does not wait for the finalizer to run, which is exactly the situation described in [Recovering from Stuck Resources](#recovering-from-stuck-resources). Delete the rules and let them finish terminating before uninstalling the release.
 
 3.  **Uninstall CRDs** (Optional):
     ```sh

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -67,32 +67,39 @@ docker pull $REPO:$TAG
 The official Helm chart is published to the OCI registry at `registry.k8s.io/node-readiness-controller/charts/node-readiness-controller`.
 
 ```sh
-# Replace with the desired version
-VERSION=0.5.0
+# Chart version, which is independent of the controller release tag above.
+CHART_VERSION=0.5.0
 
 helm install node-readiness-controller \
   oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
-  --version ${VERSION} \
+  --version ${CHART_VERSION} \
   --namespace nrr-system --create-namespace
 ```
 
 Requires Helm 3.8+ (native OCI support). This deploys the controller with the same defaults as the standard manifest: leader election on, metrics off, and the validating webhook off.
 
 > [!NOTE]
-> You can also install the chart directly from a local repository checkout if developing locally:
+> You can also install the chart from a local checkout when developing:
 > ```sh
 > helm install node-readiness-controller ./charts/node-readiness-controller \
->   --namespace nrr-system --create-namespace
+>   --namespace nrr-system --create-namespace \
+>   --set image.tag=v0.5.0
 > ```
+>
+> Set `image.tag` explicitly here. The real chart and app versions are injected at
+> package time by `make build-helm`, so `Chart.yaml` in the repository keeps a
+> placeholder `appVersion`. Installing straight from a checkout without an override
+> therefore deploys whatever that placeholder points at rather than the release you
+> checked out.
 
 For anything beyond a couple of overrides, keep your settings in a file instead of a long `--set` list:
 
 ```sh
-helm show values oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller --version ${VERSION} > custom-values.yaml
+helm show values oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller --version ${CHART_VERSION} > custom-values.yaml
 
 helm install node-readiness-controller \
   oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
-  --version ${VERSION} \
+  --version ${CHART_VERSION} \
   --namespace nrr-system --create-namespace \
   -f custom-values.yaml
 ```
@@ -112,7 +119,7 @@ The webhook rejects rules whose taint key and effect collide with an existing ru
 ```sh
 helm install node-readiness-controller \
   oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
-  --version ${VERSION} \
+  --version ${CHART_VERSION} \
   --namespace nrr-system --create-namespace \
   --set certManager.enabled=true \
   --set webhook.enabled=true \
@@ -170,7 +177,7 @@ Upgrade the release in place using the OCI chart. Values you set at install time
 ```sh
 helm upgrade node-readiness-controller \
   oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
-  --version ${VERSION} \
+  --version ${CHART_VERSION} \
   --namespace nrr-system \
   -f custom-values.yaml
 ```
@@ -182,7 +189,7 @@ Check what changed before applying it to a live cluster:
 ```sh
 helm diff upgrade node-readiness-controller \
   oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
-  --version ${VERSION} \
+  --version ${CHART_VERSION} \
   --namespace nrr-system   # needs the helm-diff plugin
 ```
 
@@ -192,10 +199,14 @@ Read the CRD note below first. Helm will not update the CRD for you, so a chart 
 
 Helm installs the CRD from the chart's `crds/` directory on first install only. It does not upgrade or remove it on `helm upgrade` or `helm uninstall`.
 
-Before moving to a chart version that changes the `NodeReadinessRule` schema, apply the CRD yourself:
+Before moving to a chart version that changes the `NodeReadinessRule` schema, apply the CRD yourself. Use the controller release that the chart version ships, which `helm show chart` reports as its `appVersion`:
 
 ```sh
-kubectl apply -f https://github.com/kubernetes-sigs/node-readiness-controller/releases/download/${VERSION}/crds.yaml
+RELEASE=$(helm show chart \
+  oci://registry.k8s.io/node-readiness-controller/charts/node-readiness-controller \
+  --version ${CHART_VERSION} | awk '/^appVersion:/ {print $2}')
+
+kubectl apply -f https://github.com/kubernetes-sigs/node-readiness-controller/releases/download/${RELEASE}/crds.yaml
 ```
 
 Skipping this leaves the old schema in place, and rules using newly added fields are rejected by the API server even though the controller supports them.


### PR DESCRIPTION
## Description

The chart has been in the repo since #163 but Helm is not mentioned anywhere in the book. The install page only covered release manifests, kustomize and static pods, so there was no documented Helm path at all.

Adds a Helm section to the installation guide covering install from a checkout, since OCI chart releases are still WIP, which values turn on metrics, TLS and the validating webhook, and how to ship rules through `nodeReadinessRules`.

It also documents two things that are specific to Helm and easy to get caught by:

Helm installs the CRD from `crds/` on first install only and never touches it again, so a chart bump that changes the schema needs the CRD applied by hand or rules using new fields get rejected while the controller supports them. This is in the chart README already but not where someone following the install guide would see it.

Rules declared in `nodeReadinessRules` are release resources, so `helm uninstall` deletes them together with the controller. The taint finalizer then has no controller left to run it, which is the stuck-resource case already documented further down the same page.

## Related Issue

Fixes #387

## Type of Change

/kind documentation

## Testing

Docs only, no code change. I checked every value and default against the chart rather than writing from memory. `leaderElection.enabled` true, `metrics.enabled` and `metrics.secure` false, `webhook.enabled` and `validatingWebhook.enabled` false, `certManager.enabled` false. The `ValidatingWebhookConfiguration` is gated on `and .Values.webhook.enabled .Values.validatingWebhook.enabled`, which is why the guide says both are needed.

I also rendered the exact commands in the guide. The default install produces the controller, RBAC and service account only. The full one produces what the table promises:

```
      2 kind: Certificate
      6 kind: ClusterRole
      2 kind: ClusterRoleBinding
      1 kind: Deployment
      1 kind: Issuer
      1 kind: Role
      1 kind: RoleBinding
      2 kind: Service
      1 kind: ServiceAccount
      1 kind: ValidatingWebhookConfiguration
```

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```
