### PR TITLE
test trigger for testgrid-email-alert in periodics-e2e* prow job

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -26,6 +26,10 @@ USE_EXISTING_CLUSTER="${USE_EXISTING_CLUSTER:-false}"
 ARTIFACTS="${ARTIFACTS:-.}"
 E2E_KIND_VERSION="${E2E_KIND_VERSION:-v1.36}"
 
+# TODO(psaggu): Remove once trigger for testgrid-alert-email is done!
+echo "early exit, for trigger of testgrid-alert-email"
+exit 1
+
 if [[ "$E2E_KIND_VERSION" =~ ^v[0-9]+\.[0-9]+$ ]]; then
     K8S_VERSION=$(curl -sf --retry 3 --retry-delay 5 --max-time 30 \
         "https://api.github.com/repos/kubernetes/kubernetes/git/matching-refs/tags/${E2E_KIND_VERSION}." \


### PR DESCRIPTION
Note: Changes need to be reverted back once we are able to get a successful email trigger on failing periodics e2e prowjobs - https://testgrid.k8s.io/sig-node-node-readiness-controller

ref slack thread: https://kubernetes.slack.com/archives/C09TW8DUVF1/p1785129076281859?thread_ts=1783722487.528179&cid=C09TW8DUVF1

/assign @ajaysundark