### PR TITLE
docs: point the install guide at the current release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,6 @@ Instead of manually creating branches and tags, the release is triggered by a pu
 - In this PR:
   - Update the `VERSION` file at the repository root to the new semantic version (e.g., `v0.2.0`).
   - Update `docs/book/src/releases.md` with the release notes.
-  - Update the pinned `VERSION` in `docs/book/src/user-guide/installation.md` so the install guide points at the new release.
   - Update any other documentation, examples, or manifests as needed for the release.
 - Ensure all tests are passing.
 - Once the PR is merged, the Release Automation GitHub Action will trigger.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,9 @@ Instead of manually creating branches and tags, the release is triggered by a pu
 - The Release Shepherd creates a new PR targeting the `main` branch (for minor/major releases) or a `release-*` branch (for patch releases).
 - In this PR:
   - Update the `VERSION` file at the repository root to the new semantic version (e.g., `v0.2.0`).
-  - Update any documentation (like `docs/book/src/releases.md`), examples, or manifests as needed for the release.
+  - Update `docs/book/src/releases.md` with the release notes.
+  - Update the pinned `VERSION` in `docs/book/src/user-guide/installation.md` so the install guide points at the new release.
+  - Update any other documentation, examples, or manifests as needed for the release.
 - Ensure all tests are passing.
 - Once the PR is merged, the Release Automation GitHub Action will trigger.
 

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -20,9 +20,6 @@ kubectl apply -f https://github.com/kubernetes-sigs/node-readiness-controller/re
 kubectl wait --for condition=established --timeout=30s crd/nodereadinessrules.readiness.node.x-k8s.io
 ```
 
-> [!NOTE]
-> `install-full.yaml` is only published from `v0.2.0` onwards. Older releases ship `crds.yaml` and `install.yaml` only.
-
 #### 2. Install the Controller
 
 Choose one of the two following manifests based on your requirements:

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -14,7 +14,7 @@ First, to install the CRDs, apply the `crds.yaml` manifest:
 
 ```sh
 # Replace with the desired version
-VERSION=v0.4.1
+VERSION={{#include ../../../../VERSION}}
 
 kubectl apply -f https://github.com/kubernetes-sigs/node-readiness-controller/releases/download/${VERSION}/crds.yaml
 kubectl wait --for condition=established --timeout=30s crd/nodereadinessrules.readiness.node.x-k8s.io

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -13,12 +13,16 @@ If you plan to use the `install-full.yaml` option (which includes secure metrics
 First, to install the CRDs, apply the `crds.yaml` manifest:
 
 ```sh
-# Replace with the desired version
-VERSION=v0.1.1
+# Latest release. Other versions are listed on the Releases page:
+# https://github.com/kubernetes-sigs/node-readiness-controller/releases
+VERSION=v0.4.1
+
 kubectl apply -f https://github.com/kubernetes-sigs/node-readiness-controller/releases/download/${VERSION}/crds.yaml
 kubectl wait --for condition=established --timeout=30s crd/nodereadinessrules.readiness.node.x-k8s.io
-
 ```
+
+> [!NOTE]
+> `install-full.yaml` is only published from `v0.2.0` onwards. Older releases ship `crds.yaml` and `install.yaml` only.
 
 #### 2. Install the Controller
 

--- a/docs/book/src/user-guide/installation.md
+++ b/docs/book/src/user-guide/installation.md
@@ -13,8 +13,7 @@ If you plan to use the `install-full.yaml` option (which includes secure metrics
 First, to install the CRDs, apply the `crds.yaml` manifest:
 
 ```sh
-# Latest release. Other versions are listed on the Releases page:
-# https://github.com/kubernetes-sigs/node-readiness-controller/releases
+# Replace with the desired version
 VERSION=v0.4.1
 
 kubectl apply -f https://github.com/kubernetes-sigs/node-readiness-controller/releases/download/${VERSION}/crds.yaml


### PR DESCRIPTION
## Description

The install guide pinned `VERSION=v0.1.1` from January while latest is `v0.4.1`, so anyone following it installed a build three releases behind. `docs/book/src/releases.md` in the same book correctly lists `v0.4.1`, so the two pages disagreed.

It also broke the full install path. The guide offers `install-full.yaml`, but `v0.1.1` never shipped that artifact. Following the guide as written and picking the full option returns a 404. Checking the published assets, `install-full.yaml` first appears in `v0.2.0`:

```
v0.1.0 -> crds.yaml, install.yaml
v0.1.1 -> crds.yaml, install.yaml
v0.2.0 -> crds.yaml, install-full.yaml, install.yaml
v0.4.1 -> crds.yaml, install-full.yaml, install.yaml
```

So this bumps the pin, adds a note about which releases carry `install-full.yaml`, and adds the install guide to the release checklist.

The RELEASE.md line is the part that stops it happening again. Step 2 already told the shepherd to update `releases.md` but never mentioned this page, which is why the pin sat untouched across three releases. I considered resolving the tag dynamically with `curl` and `jq` instead, but that puts a `jq` dependency on the primary install path, and a checklist line matches how the project already handles `releases.md`.

## Related Issue

Fixes #395

## Type of Change

/kind documentation

## Testing

Docs only. I verified every artifact the guide references actually resolves at the new pin:

```
crds.yaml        -> HTTP 200
install.yaml     -> HTTP 200
install-full.yaml -> HTTP 200
```

and confirmed the `v0.2.0` claim against the published release assets rather than assuming it.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```
