### PR TITLE
feat: add scrape-time metrics collector

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,12 +35,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	nodereadinessiov1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
 	"sigs.k8s.io/node-readiness-controller/internal/controller"
 	"sigs.k8s.io/node-readiness-controller/internal/info"
+	"sigs.k8s.io/node-readiness-controller/internal/metrics"
 	"sigs.k8s.io/node-readiness-controller/internal/webhook"
 	// +kubebuilder:scaffold:imports
 )
@@ -157,6 +159,9 @@ func main() {
 
 	// Create the main RuleReadinessController
 	readinessController := controller.NewRuleReadinessController(mgr, clientset, enableNodeStateMetrics)
+
+	// Register the scrape-time collector.
+	crmetrics.Registry.MustRegister(metrics.NewReadinessCollector(readinessController))
 
 	// Create reconcilers linked to the main controller
 	ruleReconciler := &controller.RuleReconciler{

--- a/docs/book/src/operations/monitoring.md
+++ b/docs/book/src/operations/monitoring.md
@@ -71,6 +71,8 @@ Total number of failure events recorded by the controller.
 
 ### `node_readiness_build_info`
 
+*Available starting from the v0.6.0 release.*
+
 Build information for the node-readiness-controller binary.
 
 | Property | Value |
@@ -84,6 +86,25 @@ Build information for the node-readiness-controller binary.
 | Label | Description | Values |
 | --- | --- | --- |
 | `version` | Build version of the running binary | Any version string, or `unknown` if not set at build time |
+
+### `node_readiness_rule_nodes`
+
+*Available starting from the v0.6.0 release.*
+
+Number of nodes currently held or released by each `NodeReadinessRule`, collected at scrape time from the controller cache.
+
+| Property | Value |
+| --- | --- |
+| Type | `gauge` |
+| Labels | `rule`, `state` |
+| Recorded when | Computed on each Prometheus scrape from the cached node list |
+
+#### Labels
+
+| Label | Description | Values |
+| --- | --- | --- |
+| `rule` | `NodeReadinessRule` name | Any non-dry-run rule name with a valid selector |
+| `state` | Whether matching nodes are still tainted by the rule or have had the taint removed | `held`, `released` |
 
 ### `node_readiness_bootstrap_completed_total`
 

--- a/internal/controller/collector_bench_test.go
+++ b/internal/controller/collector_bench_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	readinessv1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
+)
+
+// buildBenchController creates a fake client with the given nodes and rules for benchmarking.
+func buildBenchController(b *testing.B, nodeCount, ruleCount int) *RuleReadinessController {
+	b.Helper()
+
+	scheme := newTestScheme(b)
+	nodes := make([]client.Object, 0, nodeCount)
+	objs := make([]client.Object, 0, nodeCount+ruleCount)
+
+	rules := make(map[string]*readinessv1alpha1.NodeReadinessRule, ruleCount)
+	for i := range ruleCount {
+		ruleName := fmt.Sprintf("rule-%d", i)
+		rule := &readinessv1alpha1.NodeReadinessRule{
+			ObjectMeta: metav1.ObjectMeta{Name: ruleName},
+			Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+				NodeSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"rule-index": fmt.Sprintf("%d", i)},
+				},
+				Taint: corev1.Taint{
+					Key:    fmt.Sprintf("readiness.k8s.io/%s", ruleName),
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
+		}
+		rules[ruleName] = rule
+		objs = append(objs, rule)
+	}
+
+	for i := range nodeCount {
+		ruleIdx := i % ruleCount
+		ruleName := fmt.Sprintf("rule-%d", ruleIdx)
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   fmt.Sprintf("node-%d", i),
+				Labels: map[string]string{"rule-index": fmt.Sprintf("%d", ruleIdx)},
+			},
+		}
+		if i%3 == 0 {
+			node.Spec.Taints = []corev1.Taint{rules[ruleName].Spec.Taint}
+		}
+		nodes = append(nodes, node)
+	}
+	objs = append(objs, nodes...)
+
+	fc := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	return &RuleReadinessController{
+		Client: fc,
+	}
+}
+
+func BenchmarkListRuleNodeStates(b *testing.B) {
+	nodeCounts := []int{100, 1000, 5000, 15000}
+	ruleCounts := []int{5, 20, 50}
+
+	for _, nodeCount := range nodeCounts {
+		for _, ruleCount := range ruleCounts {
+			b.Run(fmt.Sprintf("nodes=%d/rules=%d", nodeCount, ruleCount), func(b *testing.B) {
+				c := buildBenchController(b, nodeCount, ruleCount)
+				ctx := b.Context()
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				for range b.N {
+					if _, err := c.ListRuleNodeStates(ctx); err != nil {
+						b.Fatalf("ListRuleNodeStates failed: %v", err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -519,6 +519,52 @@ func (r *RuleReadinessController) getApplicableRulesForNode(ctx context.Context,
 	return applicableRules
 }
 
+// ListRuleNodeStates returns the number of held and released nodes for each rule.
+func (r *RuleReadinessController) ListRuleNodeStates(ctx context.Context) (map[string]metrics.RuleNodeCounts, error) {
+	ruleList := &readinessv1alpha1.NodeReadinessRuleList{}
+	if err := r.List(ctx, ruleList); err != nil {
+		return nil, err
+	}
+
+	nodeList := &corev1.NodeList{}
+	if err := r.List(ctx, nodeList); err != nil {
+		return nil, err
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+
+	counts := make(map[string]metrics.RuleNodeCounts, len(ruleList.Items))
+	for i := range ruleList.Items {
+		rule := &ruleList.Items[i]
+		if rule.Spec.DryRun {
+			continue
+		}
+
+		// Parse the selector once per rule.
+		selector, err := metav1.LabelSelectorAsSelector(&rule.Spec.NodeSelector)
+		if err != nil {
+			log.V(2).Info("Invalid node selector for rule", "rule", rule.Name, "error", err)
+			continue
+		}
+
+		rc := metrics.RuleNodeCounts{}
+		for i := range nodeList.Items {
+			node := &nodeList.Items[i]
+			if !selector.Matches(labels.Set(node.Labels)) {
+				continue
+			}
+			if r.hasTaintBySpec(node, rule.Spec.Taint) {
+				rc.Held++
+			} else {
+				rc.Released++
+			}
+		}
+		counts[rule.Name] = rc
+	}
+
+	return counts, nil
+}
+
 // ruleAppliesTo checks if a rule applies to a node.
 func (r *RuleReadinessController) ruleAppliesTo(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule, node *corev1.Node) bool {
 	log := ctrl.LoggerFrom(ctx)

--- a/internal/controller/rule_node_states_test.go
+++ b/internal/controller/rule_node_states_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	readinessv1alpha1 "sigs.k8s.io/node-readiness-controller/api/v1alpha1"
+	"sigs.k8s.io/node-readiness-controller/internal/metrics"
+)
+
+func newTestScheme(tb testing.TB) *runtime.Scheme {
+	tb.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		tb.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	if err := readinessv1alpha1.AddToScheme(scheme); err != nil {
+		tb.Fatalf("failed to add readinessv1alpha1 to scheme: %v", err)
+	}
+	return scheme
+}
+
+func gpuTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "readiness.k8s.io/gpu-ready",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+}
+
+func gpuRule() *readinessv1alpha1.NodeReadinessRule {
+	return &readinessv1alpha1.NodeReadinessRule{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-ready"},
+		Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+			NodeSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"gpu": "true"},
+			},
+			Taint: gpuTaint(),
+		},
+	}
+}
+
+func gpuNode(name string, tainted bool) *corev1.Node {
+	n := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{"gpu": "true"},
+		},
+	}
+	if tainted {
+		n.Spec.Taints = []corev1.Taint{gpuTaint()}
+	}
+	return n
+}
+
+func TestListRuleNodeStates_NoRules(t *testing.T) {
+	g := NewWithT(t)
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleNodeStates(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(BeEmpty())
+}
+
+func TestListRuleNodeStates_ZeroMatches(t *testing.T) {
+	g := NewWithT(t)
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		gpuRule(),
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "cpu-node"}},
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleNodeStates(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(Equal(map[string]metrics.RuleNodeCounts{
+		"gpu-ready": {Held: 0, Released: 0},
+	}))
+}
+
+func TestListRuleNodeStates_MixedHeldReleased(t *testing.T) {
+	g := NewWithT(t)
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		gpuRule(),
+		gpuNode("held-1", true),
+		gpuNode("held-2", true),
+		gpuNode("released-1", false),
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "non-matching"}},
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleNodeStates(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(Equal(map[string]metrics.RuleNodeCounts{
+		"gpu-ready": {Held: 2, Released: 1},
+	}))
+}
+
+func TestListRuleNodeStates_DryRunRuleExcluded(t *testing.T) {
+	g := NewWithT(t)
+	rule := gpuRule()
+	rule.Spec.DryRun = true
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		rule,
+		gpuNode("held-1", true),
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleNodeStates(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(BeEmpty())
+}
+
+func TestListRuleNodeStates_DeletingRuleIncluded(t *testing.T) {
+	g := NewWithT(t)
+	rule := gpuRule()
+	now := metav1.Now()
+	rule.DeletionTimestamp = &now
+	rule.Finalizers = []string{"readiness.node.x-k8s.io/cleanup-taints"}
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		rule,
+		gpuNode("held-1", true),
+		gpuNode("held-2", true),
+		gpuNode("released-1", false),
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleNodeStates(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(Equal(map[string]metrics.RuleNodeCounts{
+		"gpu-ready": {Held: 2, Released: 1},
+	}))
+}
+
+func TestListRuleNodeStates_DeletingRulePersistsUntilFinalizer(t *testing.T) {
+	g := NewWithT(t)
+	rule := gpuRule()
+	now := metav1.Now()
+	rule.DeletionTimestamp = &now
+	rule.Finalizers = []string{"readiness.node.x-k8s.io/cleanup-taints"}
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		rule,
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleNodeStates(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(Equal(map[string]metrics.RuleNodeCounts{
+		"gpu-ready": {Held: 0, Released: 0},
+	}))
+}
+
+func TestListRuleNodeStates_OneRuleHeldOtherReleased(t *testing.T) {
+	g := NewWithT(t)
+	taintA := corev1.Taint{Key: "readiness.k8s.io/rule-a", Effect: corev1.TaintEffectNoSchedule}
+	taintB := corev1.Taint{Key: "readiness.k8s.io/rule-b", Effect: corev1.TaintEffectNoSchedule}
+
+	ruleA := &readinessv1alpha1.NodeReadinessRule{
+		ObjectMeta: metav1.ObjectMeta{Name: "rule-a"},
+		Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+			NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{"gpu": "true"}},
+			Taint:        taintA,
+		},
+	}
+	ruleB := &readinessv1alpha1.NodeReadinessRule{
+		ObjectMeta: metav1.ObjectMeta{Name: "rule-b"},
+		Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+			NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{"gpu": "true"}},
+			Taint:        taintB,
+		},
+	}
+
+	// Node matches both rules' selectors but only carries taintA, not taintB.
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "shared-node",
+			Labels: map[string]string{"gpu": "true"},
+		},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{taintA},
+		},
+	}
+
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		ruleA, ruleB, node,
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleNodeStates(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).To(Equal(map[string]metrics.RuleNodeCounts{
+		"rule-a": {Held: 1, Released: 0},
+		"rule-b": {Held: 0, Released: 1},
+	}))
+}
+
+func TestListRuleNodeStates_InvalidSelectorSkipped(t *testing.T) {
+	g := NewWithT(t)
+	validRule := gpuRule()
+	invalidRule := &readinessv1alpha1.NodeReadinessRule{
+		ObjectMeta: metav1.ObjectMeta{Name: "invalid-selector-rule"},
+		Spec: readinessv1alpha1.NodeReadinessRuleSpec{
+			NodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "gpu", Operator: "BogusOperator", Values: []string{"true"}},
+				},
+			},
+			Taint: corev1.Taint{
+				Key:    "readiness.k8s.io/invalid-selector",
+				Effect: corev1.TaintEffectNoSchedule,
+			},
+		},
+	}
+	fc := fakeclient.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(
+		validRule,
+		invalidRule,
+		gpuNode("held-1", true),
+		gpuNode("released-1", false),
+	).Build()
+	c := &RuleReadinessController{
+		Client: fc,
+	}
+
+	counts, err := c.ListRuleNodeStates(t.Context())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(counts).NotTo(HaveKey(invalidRule.Name))
+	g.Expect(counts).To(Equal(map[string]metrics.RuleNodeCounts{
+		"gpu-ready": {Held: 1, Released: 1},
+	}))
+}

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -1,0 +1,77 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// collectTimeout limits how long a scrape can wait for cached data.
+const collectTimeout = 5 * time.Second
+
+// RuleNodeCounts holds the number of held and released nodes for a rule.
+type RuleNodeCounts struct {
+	Held     float64
+	Released float64
+}
+
+// RuleNodeStateLister lists held and released nodes for each rule.
+type RuleNodeStateLister interface {
+	ListRuleNodeStates(ctx context.Context) (map[string]RuleNodeCounts, error)
+}
+
+var ruleNodesDesc = prometheus.NewDesc(
+	"node_readiness_rule_nodes",
+	"Number of nodes currently gated or released by the rule.",
+	[]string{"rule", "state"},
+	nil,
+)
+
+// ReadinessCollector is a prometheus.Collector that reads at scrape time.
+type ReadinessCollector struct {
+	lister RuleNodeStateLister
+}
+
+func NewReadinessCollector(lister RuleNodeStateLister) *ReadinessCollector {
+	return &ReadinessCollector{lister: lister}
+}
+
+// Describe implements prometheus.Collector.
+func (c *ReadinessCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- ruleNodesDesc
+}
+
+// Collect implements prometheus.Collector.
+func (c *ReadinessCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), collectTimeout)
+	defer cancel()
+
+	counts, err := c.lister.ListRuleNodeStates(ctx)
+	if err != nil {
+		ctrl.Log.V(2).Info("Failed to list rule node states", "error", err)
+		return
+	}
+
+	for rule, rc := range counts {
+		ch <- prometheus.MustNewConstMetric(ruleNodesDesc, prometheus.GaugeValue, rc.Held, rule, string(RuleNodeStateHeld))
+		ch <- prometheus.MustNewConstMetric(ruleNodesDesc, prometheus.GaugeValue, rc.Released, rule, string(RuleNodeStateReleased))
+	}
+}

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// stubLister is a test double for RuleNodeStateLister.
+type stubLister struct {
+	counts map[string]RuleNodeCounts
+	err    error
+}
+
+func (s *stubLister) ListRuleNodeStates(_ context.Context) (map[string]RuleNodeCounts, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.counts, nil
+}
+
+func TestReadinessCollector_NoRules(t *testing.T) {
+	c := NewReadinessCollector(&stubLister{counts: map[string]RuleNodeCounts{}})
+
+	expected := ``
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "node_readiness_rule_nodes"); err != nil {
+		t.Fatalf("unexpected collect mismatch: %v", err)
+	}
+}
+
+func TestReadinessCollector_ZeroMatches(t *testing.T) {
+	c := NewReadinessCollector(&stubLister{counts: map[string]RuleNodeCounts{
+		"gpu-ready": {Held: 0, Released: 0},
+	}})
+
+	expected := `
+		# HELP node_readiness_rule_nodes Number of nodes currently gated or released by the rule.
+		# TYPE node_readiness_rule_nodes gauge
+		node_readiness_rule_nodes{rule="gpu-ready",state="held"} 0
+		node_readiness_rule_nodes{rule="gpu-ready",state="released"} 0
+	`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "node_readiness_rule_nodes"); err != nil {
+		t.Fatalf("unexpected collect mismatch: %v", err)
+	}
+}
+
+func TestReadinessCollector_MixedHeldReleased(t *testing.T) {
+	c := NewReadinessCollector(&stubLister{counts: map[string]RuleNodeCounts{
+		"gpu-ready": {Held: 3, Released: 7},
+		"cni-ready": {Held: 0, Released: 10},
+	}})
+
+	expected := `
+		# HELP node_readiness_rule_nodes Number of nodes currently gated or released by the rule.
+		# TYPE node_readiness_rule_nodes gauge
+		node_readiness_rule_nodes{rule="gpu-ready",state="held"} 3
+		node_readiness_rule_nodes{rule="gpu-ready",state="released"} 7
+		node_readiness_rule_nodes{rule="cni-ready",state="held"} 0
+		node_readiness_rule_nodes{rule="cni-ready",state="released"} 10
+	`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "node_readiness_rule_nodes"); err != nil {
+		t.Fatalf("unexpected collect mismatch: %v", err)
+	}
+}
+
+func TestReadinessCollector_PassesThroughLister(t *testing.T) {
+	c := NewReadinessCollector(&stubLister{counts: map[string]RuleNodeCounts{
+		"active-rule": {Held: 1, Released: 1},
+	}})
+
+	expected := `
+		# HELP node_readiness_rule_nodes Number of nodes currently gated or released by the rule.
+		# TYPE node_readiness_rule_nodes gauge
+		node_readiness_rule_nodes{rule="active-rule",state="held"} 1
+		node_readiness_rule_nodes{rule="active-rule",state="released"} 1
+	`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "node_readiness_rule_nodes"); err != nil {
+		t.Fatalf("unexpected collect mismatch: %v", err)
+	}
+}
+
+func TestReadinessCollector_ListError(t *testing.T) {
+	c := NewReadinessCollector(&stubLister{err: errors.New("cache not synced")})
+
+	expected := ``
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "node_readiness_rule_nodes"); err != nil {
+		t.Fatalf("unexpected collect mismatch: %v", err)
+	}
+}
+
+func TestReadinessCollector_ConcurrentCollect(t *testing.T) {
+	c := NewReadinessCollector(&stubLister{counts: map[string]RuleNodeCounts{
+		"gpu-ready": {Held: 3, Released: 7},
+	}})
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Exercise concurrent Collect calls for race detection.
+			ch := make(chan prometheus.Metric, 2)
+			done := make(chan struct{})
+			go func() {
+				for range ch {
+				}
+				close(done)
+			}()
+			c.Collect(ch)
+			close(ch)
+			<-done
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -57,6 +57,14 @@ const (
 	NodeStateBootstrapping NodeState = "bootstrapping"
 )
 
+// RuleNodeState represents whether a node is held or released by a rule.
+type RuleNodeState string
+
+const (
+	RuleNodeStateHeld     RuleNodeState = "held"
+	RuleNodeStateReleased RuleNodeState = "released"
+)
+
 var (
 	// RulesTotal tracks the number of NodeReadinessRules .
 	RulesTotal = prometheus.NewGauge(


### PR DESCRIPTION
## Description

Adds `node_readiness_rule_nodes{rule, state="held"|"released"}`, a scrape-time metric for tracking the number of nodes currently held or released by each `NodeReadinessRule`, as described in design doc [New Scrape-Time Collector Surface](https://github.com/ajaysundark/node-readiness-controller/blob/9244f4eef28234321fecc988435b846fd3c12507/docs/observability-design.md#4-new-scrape-time-collector-surface)

The metric is collected directly from the controller runtime cache on each Prometheus scrape using a custom `prometheus.Collector`.

### Changes
- Added the scrape-time `ReadinessCollector`.
- Added `node_readiness_rule_nodes` metric with `rule` and `state` labels.
- Tracks held/released state based on the rule's taint, status conditions are handled separately by `node_readiness_blocked_nodes` (will implement next).
- Added unit tests and benchmark coverage.
- Updated the monitoring doc.

### Fixes #397 

## Type of Change
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Testing
- `make test`, `make lint`, `go test ./... -race` all pass
- Verified against a live cluster, counts matched node taints and updated correctly after rule changes.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes