### PR TITLE
fix: avoid taint cleanup for dry-run rules (#374)

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -115,7 +115,10 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	log = log.WithValues("ruleName", rule.Name)
 	ctx = ctrl.LoggerInto(ctx, log)
 
-	// Add finalizer first if not set to avoid the race condition between init and delete.
+	// Add the cleanup finalizer only once the rule is enforceable. A dry-run-only
+	// rule must not perform taint cleanup when it is deleted. Once added, the
+	// finalizer is retained across later dry-run reconciliations as a persistent
+	// indication that the rule may have previously entered enforcement.
 	if finalizerAdded, err := r.ensureFinalizer(ctx, rule, finalizerName); err != nil {
 		return ctrl.Result{}, err
 	} else if finalizerAdded {
@@ -188,10 +191,14 @@ func (r *RuleReconciler) reconcileDelete(ctx context.Context, rule *readinessv1a
 	log.V(3).Info("Updating cache with deletion-marked rule before cleanup")
 	r.Controller.updateRuleCache(ctx, rule)
 
-	log.Info("Cleaning up taints for deleted rule", "rule", rule.Name)
-	if err := r.Controller.cleanupTaintsForRule(ctx, rule, nodeList); err != nil {
-		log.Error(err, "Failed to cleanup taints for rule", "rule", rule.Name)
-		return ctrl.Result{RequeueAfter: time.Minute}, err
+	if controllerutil.ContainsFinalizer(rule, finalizerName) {
+		log.Info("Cleaning up taints for deleted rule", "rule", rule.Name)
+		if err := r.Controller.cleanupTaintsForRule(ctx, rule, nodeList); err != nil {
+			log.Error(err, "Failed to cleanup taints for rule", "rule", rule.Name)
+			return ctrl.Result{RequeueAfter: time.Minute}, err
+		}
+	} else {
+		log.Info("Skipping taint cleanup for deleted rule without cleanup finalizer", "rule", rule.Name)
 	}
 
 	log.V(3).Info("Removing the rule from cache")
@@ -699,6 +706,11 @@ func (r *RuleReadinessController) cleanupTaintsForRule(ctx context.Context, rule
 func (r *RuleReconciler) ensureFinalizer(ctx context.Context, rule *readinessv1alpha1.NodeReadinessRule, finalizer string) (finalizerAdded bool, err error) {
 	// Finalizers can only be added when the deletionTimestamp is not set.
 	if !rule.GetDeletionTimestamp().IsZero() {
+		return false, nil
+	}
+	// Dry-run rules are previews and must not acquire deletion-time cleanup
+	// behavior until they first enter enforcement.
+	if rule.Spec.DryRun {
 		return false, nil
 	}
 	if controllerutil.ContainsFinalizer(rule, finalizer) {

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -1562,7 +1562,18 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 
 		AfterEach(func() {
 			_ = k8sClient.Delete(ctx, testNode)
-			_ = k8sClient.Delete(ctx, rule)
+			if err := k8sClient.Delete(ctx, rule); err == nil {
+				// The cleanup-rule is not reconciled by every test. Remove its
+				// finalizer so the shared fixture cannot leak into the next spec.
+				Eventually(func() error {
+					current := &nodereadinessiov1alpha1.NodeReadinessRule{}
+					if err := k8sClient.Get(ctx, types.NamespacedName{Name: rule.Name}, current); err != nil {
+						return client.IgnoreNotFound(err)
+					}
+					current.Finalizers = nil
+					return k8sClient.Update(ctx, current)
+				}, time.Second*5).Should(Succeed())
+			}
 		})
 
 		It("should remove taints from nodes when rule is deleted", func() {
@@ -1616,6 +1627,84 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: "cleanup-rule"}, deletedRule)
 				return err != nil && client.IgnoreNotFound(err) == nil
 			}, time.Second*10).Should(BeTrue(), "Rule should be fully deleted")
+		})
+
+		It("should not add a cleanup finalizer or remove taints for an always-dry-run rule", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "dry-run-delete-node",
+					Labels: map[string]string{"dry-run-delete": "true"},
+				},
+				Spec: corev1.NodeSpec{Taints: []corev1.Taint{{
+					Key: "readiness.k8s.io/dry-run-delete", Value: "pre-existing", Effect: corev1.TaintEffectNoSchedule,
+				}}},
+			}
+			dryRunRule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "dry-run-delete-rule"},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					DryRun:          true,
+					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"dry-run-delete": "true"}},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/dry-run-delete", Value: "pre-existing", Effect: corev1.TaintEffectNoSchedule},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			Expect(k8sClient.Create(ctx, dryRunRule)).To(Succeed())
+
+			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: dryRunRule.Name}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dryRunRule.Name}, updatedRule)).To(Succeed())
+			Expect(updatedRule.Finalizers).NotTo(ContainElement(finalizerName))
+
+			Expect(k8sClient.Delete(ctx, dryRunRule)).To(Succeed())
+			updatedNode := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Spec.Taints).To(ContainElement(corev1.Taint{
+				Key: "readiness.k8s.io/dry-run-delete", Value: "pre-existing", Effect: corev1.TaintEffectNoSchedule,
+			}))
+			Expect(k8sClient.Delete(ctx, node)).To(Succeed())
+		})
+
+		It("should add and retain the finalizer after a dry-run rule enters enforcement", func() {
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "dry-run-transition-rule"},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					DryRun:          true,
+					Conditions:      []nodereadinessiov1alpha1.ConditionRequirement{{Type: "Ready", RequiredStatus: corev1.ConditionTrue}},
+					NodeSelector:    metav1.LabelSelector{MatchLabels: map[string]string{"dry-run-transition": "true"}},
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/dry-run-transition", Effect: corev1.TaintEffectNoSchedule},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+			Expect(k8sClient.Create(ctx, rule)).To(Succeed())
+
+			_, err := ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: rule.Name}})
+			Expect(err).NotTo(HaveOccurred())
+			updatedRule := &nodereadinessiov1alpha1.NodeReadinessRule{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rule.Name}, updatedRule)).To(Succeed())
+			Expect(updatedRule.Finalizers).NotTo(ContainElement(finalizerName))
+
+			updatedRule.Spec.DryRun = false
+			Expect(k8sClient.Update(ctx, updatedRule)).To(Succeed())
+			_, err = ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: rule.Name}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rule.Name}, updatedRule)).To(Succeed())
+			Expect(updatedRule.Finalizers).To(ContainElement(finalizerName))
+
+			updatedRule.Spec.DryRun = true
+			Expect(k8sClient.Update(ctx, updatedRule)).To(Succeed())
+			_, err = ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: rule.Name}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rule.Name}, updatedRule)).To(Succeed())
+			Expect(updatedRule.Finalizers).To(ContainElement(finalizerName))
+			Expect(k8sClient.Delete(ctx, updatedRule)).To(Succeed())
+			_, err = ruleReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: rule.Name}})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
## Description

Prevent deleting an always-dry-run NodeReadinessRule from removing pre-existing Node taints. The cleanup finalizer is now added only when a rule enters enforcement and is retained across later transitions back to dry-run.

## Related Issue

Fixes #374

## Type of Change

/kind bug

## Testing

- `make test` passes (including controller-gen, gofmt, go vet, and all non-e2e tests; controller suite 64/64)
- `make lint` passes (golangci-lint and kube-api-linter)

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

Yes: deleting a rule that remained in dry-run mode no longer mutates Node taints.

```release-note
Deleting an always-dry-run NodeReadinessRule no longer removes matching pre-existing Node taints.
```