### PR TITLE
setup Helm chart publishing to kubernetes staging registry

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,4 @@
 https?://example\.com(/.*)?
 https?://localhost(:.*)?(\/.*)?
 https?://127\.0\.0\.1(:.*)?(\/.*)?
+https?://kubernetes\.slack\.com(/.*)?

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ GOVULNCHECK_PKG := golang.org/x/vuln/cmd/govulncheck
 IMG_PREFIX ?= controller
 IMG_TAG ?= latest
 
+# OCI registry to publish the Helm chart to
+HELM_IMAGE ?= registry.k8s.io/node-readiness-controller/charts
+
 # Kind cluster name for loading images
 KIND_CLUSTER ?= nrr-test
 
@@ -492,8 +495,15 @@ endif
 lint-chart: ensure-helm-install
 	helm lint ./charts/nrr-controller
 
-build-helm:
+inject-helm-version: ## Inject the release version into the Helm chart's appVersion and image tag
+	sed 's/tag: .*/tag: "$(RELEASE_VERSION)"/' charts/nrr-controller/values.yaml > charts/nrr-controller/values.yaml.tmp && mv charts/nrr-controller/values.yaml.tmp charts/nrr-controller/values.yaml
+	sed 's/^appVersion: .*/appVersion: "$(RELEASE_VERSION)"/' charts/nrr-controller/Chart.yaml > charts/nrr-controller/Chart.yaml.tmp && mv charts/nrr-controller/Chart.yaml.tmp charts/nrr-controller/Chart.yaml
+
+build-helm: inject-helm-version
 	helm package ./charts/nrr-controller --dependency-update --destination ./bin/chart
+
+publish-helm: ## Publish the packaged Helm chart to an OCI registry
+	helm push ./bin/chart/nrr-controller-*.tgz oci://$(HELM_IMAGE)
 
 kind-multi-node:
 	kind create cluster --name $(KIND_CLUSTER) --config ./config/testing/kind/kind-3node-config.yaml --wait 2m

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,16 +23,20 @@ The automation will:
 2. Create and push a git tag `vX.Y.Z` at the merged commit.
 3. If it is a minor or major release (e.g. `v0.2.0`), it will automatically branch off `release-vX.Y.Z` and push it to the repository.
 
-## 3. Promote the Images
+## 3. Promote the Images and Helm Chart
 
-After the release tag is pushed, the images must be built, pushed to staging, and then promoted to the official registry.
+After the release tag is pushed, the images and Helm chart must be built, pushed to staging, and then promoted to the official registry.
 
-### A. Verify Staging Images
-- Monitor the image push job status on [Testgrid (sig-node-image-pushes)](https://testgrid.k8s.io/sig-node-image-pushes#post-node-readiness-controller-push-images).
+### A. Verify Staging Images and Chart
+- Monitor the push job status on [Testgrid (sig-node-image-pushes)](https://testgrid.k8s.io/sig-node-image-pushes#post-node-readiness-controller-push-images).
 - The Prow job configuration is in [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-node-readiness-controller.yaml) if troubleshooting is needed.
 - Verify the images exist in the staging repository:
   ```sh
   skopeo list-tags docker://us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller/node-readiness-controller | grep vX.Y.Z
+  ```
+- Verify the chart exists in the staging repository (replace `<chart-version>` with the version in `charts/nrr-controller/Chart.yaml` at the tagged commit):
+  ```sh
+  helm pull oci://us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller/charts/nrr-controller --version <chart-version>
   ```
 
 ### B. Create PR for Promotion
@@ -41,21 +45,30 @@ After the release tag is pushed, the images must be built, pushed to staging, an
   skopeo inspect docker://us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller/node-readiness-controller:vX.Y.Z --format '{{.Digest}}'
   skopeo inspect docker://us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller/node-readiness-reporter:vX.Y.Z --format '{{.Digest}}'
   ```
+- Identify the chart digest:
+  ```sh
+  skopeo inspect --raw docker://us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller/charts/nrr-controller:<chart-version> | sha256sum
+  ```
+  Alternatively, note the digest printed by `helm push`/`helm pull` when the chart was published/verified above.
 - Fork [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io).
 - Update
   `registry.k8s.io/images/k8s-staging-node-readiness-controller/images.yaml`
-  with the new digests and tags ([sample PR](https://github.com/kubernetes/k8s.io/pull/9176)).
+  with the new digests and tags for the images and the chart ([sample PR](https://github.com/kubernetes/k8s.io/pull/9176)).
 - Submit the PR to `kubernetes/k8s.io`. Once it is approved and merged
   automation will schedule the promotion.
 
 ## 4. Final Verification and GitHub Release
 
-Before publishing the release, verify the images are available at k8s-registry:
+Before publishing the release, verify the images and chart are available at k8s-registry:
 
 ### A. Verify Official Registry
 - Ensure the images are available at `registry.k8s.io`:
   ```sh
   skopeo list-tags docker://registry.k8s.io/node-readiness-controller/node-readiness-controller | grep vX.Y.Z
+  ```
+- Ensure the chart is available at `registry.k8s.io`:
+  ```sh
+  helm pull oci://registry.k8s.io/node-readiness-controller/charts/nrr-controller --version <chart-version>
   ```
 
 ### B. Test Release Artifacts

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,13 +7,19 @@ options:
   substitution_option: ALLOW_LOOSE
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
-    entrypoint: ./scripts/build-and-publish-image.sh
+    entrypoint: ./scripts/build-and-publish.sh
     env:
     - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller
     - COMPONENT=controller
 
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
-    entrypoint: ./scripts/build-and-publish-image.sh
+    entrypoint: ./scripts/build-and-publish.sh
     env:
     - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller
     - COMPONENT=reporter
+
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
+    entrypoint: ./scripts/build-and-publish.sh
+    env:
+    - IMG_PREFIX=us-central1-docker.pkg.dev/k8s-staging-images/node-readiness-controller
+    - COMPONENT=chart

--- a/scripts/build-and-publish.sh
+++ b/scripts/build-and-publish.sh
@@ -41,6 +41,11 @@ if [[ "$COMPONENT" == "controller" ]]; then
 elif [[ "$COMPONENT" == "reporter" ]]; then
   echo "Building reporter..."
   IMG_TAG=${IMG_TAG} IMG_PREFIX=${IMG_PREFIX}/node-readiness-reporter make docker-buildx-reporter
+elif [[ "$COMPONENT" == "chart" ]]; then
+  echo "Building Helm chart..."
+  rm -rf ./bin/chart
+  RELEASE_VERSION=${IMG_TAG} make build-helm
+  RELEASE_VERSION=${IMG_TAG} HELM_IMAGE=${IMG_PREFIX}/charts make publish-helm
 else
   echo "Unknown component: $COMPONENT"
   exit 1


### PR DESCRIPTION
PR is adding setup to publish Helm chart artifacts to kubernetes staging registry (and eventually to registry.k8s.io)

Took inspiration from the `kubernetes-sigs/kro` repo - https://github.com/kubernetes-sigs/kro/commit/80d485024178c072d9c8bd126e7b0ed5e440aac8

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

/assign @ajaysundark 