### PR TITLE
feat: add node_readiness_build_info metric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@
 FROM --platform=$BUILDPLATFORM golang:1.26.0 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=unknown
+ARG GIT_COMMIT=unknown
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -32,7 +34,9 @@ COPY . .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
+	-ldflags "-X sigs.k8s.io/node-readiness-controller/internal/info.version=${VERSION} -X sigs.k8s.io/node-readiness-controller/internal/info.gitCommit=${GIT_COMMIT}" \
+	-o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ IMG_TAG ?= latest
 
 # OCI registry to publish the Helm chart to
 HELM_IMAGE ?= registry.k8s.io/node-readiness-controller/charts
+# Version metadata embedded into the binary via -ldflags.
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo unknown)
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+LDFLAGS := -X sigs.k8s.io/node-readiness-controller/internal/info.version=$(VERSION) -X sigs.k8s.io/node-readiness-controller/internal/info.gitCommit=$(GIT_COMMIT)
 
 # Kind cluster name for loading images
 KIND_CLUSTER ?= nrr-test
@@ -190,7 +194,7 @@ verify: ## Run all verification scripts.
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build -ldflags "$(LDFLAGS)" -o bin/manager cmd/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -202,11 +206,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build container image with Docker.
-	DOCKER_BUILDKIT=1 docker build -t ${IMG_PREFIX}:${IMG_TAG} .
+	DOCKER_BUILDKIT=1 docker build --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) -t ${IMG_PREFIX}:${IMG_TAG} .
 
 .PHONY: podman-build
 podman-build: ## Build container image with Podman.
-	podman build -t localhost/${IMG_PREFIX}:${IMG_TAG} .
+	podman build --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) -t localhost/${IMG_PREFIX}:${IMG_TAG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -223,7 +227,7 @@ PLATFORMS ?= linux/arm64,linux/amd64
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	- $(CONTAINER_TOOL) buildx create --name nrrcontroller-builder
 	$(CONTAINER_TOOL) buildx use nrrcontroller-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG_PREFIX}:${IMG_TAG} .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --tag ${IMG_PREFIX}:${IMG_TAG} .
 	- $(CONTAINER_TOOL) buildx rm nrrcontroller-builder
 
 .PHONY: kind-load
@@ -258,7 +262,7 @@ docker-push-reporter: ## Push docker image with the reporter.
 docker-buildx-reporter: ## Build and push docker image for the reporter for cross-platform support
 	- $(CONTAINER_TOOL) buildx create --name reporter-builder
 	$(CONTAINER_TOOL) buildx use reporter-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG_PREFIX}:${IMG_TAG} -f Dockerfile.reporter .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --build-arg VERSION=$(VERSION) --build-arg GIT_COMMIT=$(GIT_COMMIT) --tag ${IMG_PREFIX}:${IMG_TAG} -f Dockerfile.reporter .
 	- $(CONTAINER_TOOL) buildx rm reporter-builder
 
 .PHONY: build-installer

--- a/docs/book/src/operations/monitoring.md
+++ b/docs/book/src/operations/monitoring.md
@@ -69,6 +69,22 @@ Total number of failure events recorded by the controller.
 | `rule` | `NodeReadinessRule` name | Any rule name |
 | `reason` | Failure label recorded by the controller | `EvaluationError`, `AddTaintError`, `RemoveTaintError` |
 
+### `node_readiness_build_info`
+
+Build information for the node-readiness-controller binary.
+
+| Property | Value |
+| --- | --- |
+| Type | `gauge` |
+| Labels | `version` |
+| Recorded when | The controller starts up |
+
+#### Labels
+
+| Label | Description | Values |
+| --- | --- | --- |
+| `version` | Build version of the running binary | Any version string, or `unknown` if not set at build time |
+
 ### `node_readiness_bootstrap_completed_total`
 
 Total number of nodes that have completed bootstrap.

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/info/version.go
+++ b/internal/info/version.go
@@ -18,11 +18,11 @@ package info
 
 import "strings"
 
-// version must be set by go build's -X main.version= option in the Makefile.
+// version must be set by go build's -X sigs.k8s.io/node-readiness-controller/internal/info.version= option in the Makefile.
 var version = "unknown"
 
 // gitCommit will be the hash that the binary was built from
-// and will be populated by the Makefile.
+// and will be populated by the Makefile via -X sigs.k8s.io/node-readiness-controller/internal/info.gitCommit=.
 var gitCommit = ""
 
 // GetVersionParts returns the different version components.
@@ -34,6 +34,11 @@ func GetVersionParts() []string {
 	}
 
 	return v
+}
+
+// GetVersion returns the raw version string.
+func GetVersion() string {
+	return version
 }
 
 // GetVersionString returns the string representation of the version.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,6 +19,8 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"sigs.k8s.io/node-readiness-controller/internal/info"
 )
 
 // FailureReason represents the reason for a failed operation.
@@ -152,6 +154,18 @@ var (
 		},
 		[]string{"rule"},
 	)
+
+	// BuildInfo exposes the running binary's build version.
+	BuildInfo = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "node_readiness_build_info",
+			Help: "Build information for the node-readiness-controller binary.",
+			ConstLabels: prometheus.Labels{
+				"version": info.GetVersion(),
+			},
+		},
+		func() float64 { return 1 },
+	)
 )
 
 func init() {
@@ -166,4 +180,5 @@ func init() {
 	metrics.Registry.MustRegister(NodesByState)
 	metrics.Registry.MustRegister(ConditionEvaluationFailures)
 	metrics.Registry.MustRegister(RuleLastReconciliationTime)
+	metrics.Registry.MustRegister(BuildInfo)
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func TestBuildInfo(t *testing.T) {
+	expected := `
+# HELP node_readiness_build_info Build information for the node-readiness-controller binary.
+# TYPE node_readiness_build_info gauge
+node_readiness_build_info{version="unknown"} 1
+`
+	if err := testutil.CollectAndCompare(BuildInfo, strings.NewReader(expected), "node_readiness_build_info"); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
+
+	gathered, err := metrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+
+	var found bool
+	for _, mf := range gathered {
+		if mf.GetName() == "node_readiness_build_info" {
+			found = true
+			if got := mf.GetType().String(); got != "GAUGE" {
+				t.Fatalf("expected node_readiness_build_info to be a gauge, got %s", got)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected node_readiness_build_info to be registered with the controller-runtime metrics registry")
+	}
+}


### PR DESCRIPTION
### Description
Adds `node_readiness_build_info` metric from [observability design doc](https://github.com/ajaysundark/node-readiness-controller/blob/9244f4eef28234321fecc988435b846fd3c12507/docs/observability-design.md#controller-metrics)

### Changes
- Add `node_readiness_build_info` gauge with a `version` label.
- Set the metric at controller startup using the build version.
- Wire build version and git commit metadata through `-ldflags` in the Makefile and Dockerfile.

### Implementation choices
- Use the build version as the `version` label, while keeping commit information in the existing startup version log.
- Added `-ldflags` wiring because the existing `internal/info` version variables were not being populated during builds, which otherwise left the version as `unknown`.

### Related to Issue #182 

## Type of Change
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## Verification
- Verified the metric reports the actual git-derived version from a locally built binary.
- Verified the same version is propagated through the Docker build path.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes