### PR TITLE
infra: add release notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  categories:
+    - title: "API Changes"
+      labels:
+        - kind/api-change
+        - kind/deprecation
+    - title: "New Features"
+      labels:
+        - kind/feature
+    - title: "Fixes"
+      labels:
+        - kind/bug
+        - kind/regression
+    - title: "Docs"
+      labels:
+        - kind/documentation
+        - documentation
+    - title: "Chores"
+      labels:
+        - area/dependency
+        - kind/flake
+        - kind/failing-test
+        - kind/cleanup
+    - title: "Other"
+      labels:
+        - "*"


### PR DESCRIPTION
This PR adds a configuration file for the release notes generated by GitHub.

See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes

#### Prior art:

- cluster-api-provider-aws:
  - config: https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/67de5c25543b2ec9c76897670fc928309473fbe1/.github/release.yml#L4
  - release notes: https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/tag/v2.12.1

- secrets-store-sync-controller:
  - config: https://github.com/kubernetes-sigs/secrets-store-sync-controller/blob/35418ee1ac4e81d9cca4b44182bf19ef355f80b2/.github/release.yml#L4
  - release notes: https://github.com/kubernetes-sigs/secrets-store-sync-controller/releases/tag/v0.0.5

> [!NOTE]
> I'm only adding labels currently available for the repo.  We can add more [here](https://github.com/kubernetes/test-infra/blob/50f8ef5e15cfa16916e64d424adb5e55ed6d8016/label_sync/labels.yaml) if needed. I specially missed something like a `kind/tests` label. 

#### Open question

Should we try some emojis ⚠️ ✨ 🐛 📖 🧹 ?

xref #225 #227 