### PR TITLE
Make bootstrap completion and taint writes mutually exclusive

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -134,7 +134,7 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 		}
 
 		// Skip if bootstrap-only and already completed
-		if r.isBootstrapCompleted(ctx, node.Name, rule.Name, rule.GetUID()) && rule.Spec.EnforcementMode == readinessv1alpha1.EnforcementModeBootstrapOnly {
+		if rule.Spec.EnforcementMode == readinessv1alpha1.EnforcementModeBootstrapOnly && r.isBootstrapCompleted(ctx, node.Name, rule.Name, rule.GetUID()) {
 			log.Info("Skipping bootstrap-only rule - already completed",
 				"node", node.Name, "rule", rule.Name)
 			continue
@@ -271,14 +271,22 @@ func (r *RuleReadinessController) hasTaintBySpec(node *corev1.Node, taintSpec co
 	return false
 }
 
-// addTaintBySpec adds a taint to a node.
+// addTaintBySpec adds the rule's taint to a node. It returns whether the
+// taint was added. For bootstrap-only rule, if completion annotation is
+// already on the node, the add is refused.
 // We use client.MergeFromWithOptimisticLock because patching a list with a
 // JSON merge patch can cause races due to the fact that it fully replaces
 // the list on a change. Optimistic locking ensures the patch fails with a
 // conflict error if the node was modified concurrently, allowing the
 // controller to retry with fresh state.
-func (r *RuleReadinessController) addTaintBySpec(ctx context.Context, node *corev1.Node, taintSpec corev1.Taint, ruleName string) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+func (r *RuleReadinessController) addTaintBySpec(ctx context.Context, node *corev1.Node, rule *readinessv1alpha1.NodeReadinessRule) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	taintSpec := rule.Spec.Taint
+	added := false
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		added = false
+
 		// Fetch latest node state
 		latestNode := &corev1.Node{}
 		if err := r.Get(ctx, client.ObjectKey{Name: node.Name}, latestNode); err != nil {
@@ -290,61 +298,132 @@ func (r *RuleReadinessController) addTaintBySpec(ctx context.Context, node *core
 			return nil
 		}
 
+		if rule.Spec.EnforcementMode == readinessv1alpha1.EnforcementModeBootstrapOnly &&
+			nodeHasBootstrapAnnotation(latestNode, rule) {
+			log.Info("Skipping taint addition - bootstrap already completed",
+				"node", latestNode.Name, "rule", rule.Name, "taint", taintSpec.Key)
+			return nil
+		}
+
 		stored := latestNode.DeepCopy()
 		latestNode.Spec.Taints = append(latestNode.Spec.Taints, taintSpec)
 		if err := r.Patch(ctx, latestNode, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
 			return err
 		}
 
-		message := fmt.Sprintf("Taint '%s:%s' added by rule '%s'", taintSpec.Key, taintSpec.Effect, ruleName)
+		message := fmt.Sprintf("Taint '%s:%s' added by rule '%s'", taintSpec.Key, taintSpec.Effect, rule.Name)
 		r.EventRecorder.Eventf(latestNode, nil, corev1.EventTypeNormal, "TaintAdded", "AddTaint", "%s", message)
 
 		// Update the original node reference with the latest state
 		*node = *latestNode
 
+		added = true
 		return nil
 	})
+	if err != nil {
+		return false, err
+	}
+	return added, nil
 }
 
 // removeTaintBySpec removes a taint from a node.
+func (r *RuleReadinessController) removeTaintBySpec(ctx context.Context, node *corev1.Node, taintSpec corev1.Taint, ruleName string) error {
+	_, err := r.removeTaint(ctx, node, taintSpec, ruleName, nil)
+	return err
+}
+
+// removeTaintAndCompleteBootstrap removes the rule's taint and writes the
+// bootstrap completion annotation.
+func (r *RuleReadinessController) removeTaintAndCompleteBootstrap(ctx context.Context, node *corev1.Node, rule *readinessv1alpha1.NodeReadinessRule) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	annotations := map[string]string{
+		bootstrapAnnotationKey(rule.GetUID()): bootstrapAnnotationValue(rule.Name),
+	}
+	marked, err := r.removeTaint(ctx, node, rule.Spec.Taint, rule.Name, annotations)
+	if err != nil {
+		return err
+	}
+	if marked {
+		log.Info("Marked bootstrap completed", "node", node.Name, "rule", rule.Name, "uid", rule.GetUID())
+		metrics.BootstrapCompleted.WithLabelValues(rule.Name).Inc()
+	}
+	return nil
+}
+
+// removeTaint removes taintSpec from the node and sets any of the given
+// annotations if not already present atomically in the same patch
+// It returns whether any annotation was newly written.
 // We use client.MergeFromWithOptimisticLock because patching a list with a
 // JSON merge patch can cause races due to the fact that it fully replaces
 // the list on a change. Optimistic locking ensures the patch fails with a
 // conflict error if the node was modified concurrently, allowing the
 // controller to retry with fresh state.
-func (r *RuleReadinessController) removeTaintBySpec(ctx context.Context, node *corev1.Node, taintSpec corev1.Taint, ruleName string) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+func (r *RuleReadinessController) removeTaint(ctx context.Context, node *corev1.Node, taintSpec corev1.Taint, ruleName string, annotations map[string]string) (bool, error) {
+	hasNewAnnotations := false
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Fetch latest node state
 		latestNode := &corev1.Node{}
 		if err := r.Get(ctx, client.ObjectKey{Name: node.Name}, latestNode); err != nil {
 			return err
 		}
 
-		// Check if taint is already absent
-		if !r.hasTaintBySpec(latestNode, taintSpec) {
+		hasTaint := r.hasTaintBySpec(latestNode, taintSpec)
+		var missing []string
+		for key := range annotations {
+			if _, exists := latestNode.Annotations[key]; !exists {
+				missing = append(missing, key)
+			}
+		}
+
+		hasNewAnnotations = len(missing) > 0
+		// Check if taint is already absent and no annotations to add
+		if !hasTaint && !hasNewAnnotations {
 			return nil
 		}
 
 		stored := latestNode.DeepCopy()
-		var newTaints []corev1.Taint
-		for _, taint := range latestNode.Spec.Taints {
-			if taint.Key != taintSpec.Key || taint.Effect != taintSpec.Effect {
-				newTaints = append(newTaints, taint)
+		if hasTaint {
+			var newTaints []corev1.Taint
+			for _, taint := range latestNode.Spec.Taints {
+				if taint.Key != taintSpec.Key || taint.Effect != taintSpec.Effect {
+					newTaints = append(newTaints, taint)
+				}
 			}
+			latestNode.Spec.Taints = newTaints
 		}
-		latestNode.Spec.Taints = newTaints
+		if latestNode.Annotations == nil && hasNewAnnotations {
+			latestNode.Annotations = make(map[string]string)
+		}
+		for _, key := range missing {
+			latestNode.Annotations[key] = annotations[key]
+		}
 		if err := r.Patch(ctx, latestNode, client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
 			return err
 		}
 
-		message := fmt.Sprintf("Taint '%s:%s' removed by rule '%s'", taintSpec.Key, taintSpec.Effect, ruleName)
-		r.EventRecorder.Eventf(latestNode, nil, corev1.EventTypeNormal, "TaintRemoved", "RemoveTaint", "%s", message)
+		if hasTaint {
+			message := fmt.Sprintf("Taint '%s:%s' removed by rule '%s'", taintSpec.Key, taintSpec.Effect, ruleName)
+			r.EventRecorder.Eventf(latestNode, nil, corev1.EventTypeNormal, "TaintRemoved", "RemoveTaint", "%s", message)
+		}
 
 		// Update the original node reference with the latest state
 		*node = *latestNode
 
 		return nil
 	})
+	if err != nil {
+		return false, err
+	}
+	return hasNewAnnotations, nil
+}
+
+// nodeHasBootstrapAnnotation reports whether the given node object carries
+// the rule's bootstrap completion annotation (UID-based or legacy key).
+func nodeHasBootstrapAnnotation(node *corev1.Node, rule *readinessv1alpha1.NodeReadinessRule) bool {
+	_, existsNew := node.Annotations[bootstrapAnnotationKey(rule.GetUID())]
+	_, existsLegacy := node.Annotations[legacyBootstrapAnnotationKey(rule.Name)]
+	return existsNew || existsLegacy
 }
 
 func (r *RuleReadinessController) isBootstrapCompleted(ctx context.Context, nodeName string, ruleName string, ruleUID types.UID) bool {
@@ -357,10 +436,14 @@ func (r *RuleReadinessController) isBootstrapCompleted(ctx context.Context, node
 	return existsNew || existsLegacy
 }
 
-func (r *RuleReadinessController) markBootstrapCompleted(ctx context.Context, nodeName, ruleName string, ruleUID types.UID) {
+// markBootstrapCompleted records bootstrap completion for a rule when a
+// node didnt have a taint remove action. For the nodes already carrying taint,
+// it is deferred and handled eventually by removeTaintAndCompleteBootstrap.
+func (r *RuleReadinessController) markBootstrapCompleted(ctx context.Context, nodeName string, rule *readinessv1alpha1.NodeReadinessRule) {
 	log := ctrl.LoggerFrom(ctx)
 	marked := false
-	annotationKey := bootstrapAnnotationKey(ruleUID)
+	deferred := false
+	annotationKey := bootstrapAnnotationKey(rule.GetUID())
 
 	// retry to handle conflict with concurrent node updates
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -374,14 +457,20 @@ func (r *RuleReadinessController) markBootstrapCompleted(ctx context.Context, no
 			return nil
 		}
 
-		patch := client.MergeFrom(node.DeepCopy())
+		if r.hasTaintBySpec(node, rule.Spec.Taint) {
+			deferred = true
+			return nil
+		}
+		deferred = false
+
+		patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 
 		// Initialize annotations map if nil.
 		if node.Annotations == nil {
 			node.Annotations = make(map[string]string)
 		}
 
-		node.Annotations[annotationKey] = bootstrapAnnotationValue(ruleName)
+		node.Annotations[annotationKey] = bootstrapAnnotationValue(rule.Name)
 		if err := r.Patch(ctx, node, patch); err != nil {
 			return err
 		}
@@ -392,12 +481,15 @@ func (r *RuleReadinessController) markBootstrapCompleted(ctx context.Context, no
 
 	switch {
 	case err != nil:
-		log.Error(err, "Failed to mark bootstrap completed", "node", nodeName, "rule", ruleName, "uid", ruleUID)
+		log.Error(err, "Failed to mark bootstrap completed", "node", nodeName, "rule", rule.Name, "uid", rule.GetUID())
+	case deferred:
+		log.Info("Deferring bootstrap completion - rule taint still present on node",
+			"node", nodeName, "rule", rule.Name, "taint", rule.Spec.Taint.Key)
 	case marked:
-		log.Info("Marked bootstrap completed", "node", nodeName, "rule", ruleName, "uid", ruleUID)
-		metrics.BootstrapCompleted.WithLabelValues(ruleName).Inc()
+		log.Info("Marked bootstrap completed", "node", nodeName, "rule", rule.Name, "uid", rule.GetUID())
+		metrics.BootstrapCompleted.WithLabelValues(rule.Name).Inc()
 	default:
-		log.V(4).Info("Bootstrap already completed", "node", nodeName, "rule", ruleName, "uid", ruleUID)
+		log.V(4).Info("Bootstrap already completed", "node", nodeName, "rule", rule.Name, "uid", rule.GetUID())
 	}
 }
 

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -313,6 +313,29 @@ var _ = Describe("Node Controller", func() {
 				}).Should(HaveKey(bootstrapAnnotationKey(rule.GetUID())))
 			})
 
+			It("should not re-add the taint to a completed node even when conditions are unsatisfied", func() {
+				By("Marking the node completed and removing the taint")
+				seededNode := &corev1.Node{}
+				Expect(k8sClient.Get(ctx, namespacedName, seededNode)).To(Succeed())
+				if seededNode.Annotations == nil {
+					seededNode.Annotations = map[string]string{}
+				}
+				seededNode.Annotations[bootstrapAnnotationKey(rule.GetUID())] = bootstrapAnnotationValue(rule.Name)
+				seededNode.Spec.Taints = nil
+				Expect(k8sClient.Update(ctx, seededNode)).To(Succeed())
+
+				By("Evaluating the rule directly as the rule reconciler")
+				Expect(k8sClient.Get(ctx, namespacedName, seededNode)).To(Succeed())
+				Expect(readinessController.evaluateRuleForNode(ctx, rule, seededNode)).To(Succeed())
+
+				By("Verifying no taint was added despite unsatisfied conditions")
+				Consistently(func() bool {
+					updatedNode := &corev1.Node{}
+					_ = k8sClient.Get(ctx, namespacedName, updatedNode)
+					return readinessController.hasTaintBySpec(updatedNode, rule.Spec.Taint)
+				}, time.Second*2).Should(BeFalse())
+			})
+
 			It("should not re-add the taint if conditions regress after completion", func() {
 				// Step 1: Meet conditions and remove taint
 				node.Status.Conditions[0].Status = corev1.ConditionTrue
@@ -904,13 +927,18 @@ var _ = Describe("Node Controller", func() {
 
 			Expect(fc.Get(ctx, types.NamespacedName{Name: node.Name}, node)).To(Succeed())
 
-			err := controller.addTaintBySpec(ctx, node, corev1.Taint{
-				Key:    "readiness.k8s.io/test",
-				Effect: corev1.TaintEffectNoSchedule,
-			}, "test-rule")
+			addRule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-rule"},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/test", Effect: corev1.TaintEffectNoSchedule},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeContinuous,
+				},
+			}
+			added, err := controller.addTaintBySpec(ctx, node, addRule)
 
 			// Should succeed after retry
 			Expect(err).NotTo(HaveOccurred())
+			Expect(added).To(BeTrue())
 
 			// Verify both taints are present (ours and the concurrent one)
 			updated := &corev1.Node{}
@@ -928,6 +956,122 @@ var _ = Describe("Node Controller", func() {
 
 			// Verify that the patch was attempted twice (first failed, second succeeded)
 			Expect(patchCount.Load()).To(BeNumerically(">=", 2))
+		})
+
+		It("should not mark bootstrap completed when the rule taints concurrently", func() {
+			Expect(nodereadinessiov1alpha1.AddToScheme(testScheme)).To(Succeed())
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "race-mark-rule",
+					UID:  types.UID("77777777-7777-7777-7777-777777777777"),
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/race-test", Effect: corev1.TaintEffectNoSchedule},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeBootstrapOnly,
+				},
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "race-mark-node"},
+			}
+
+			var patchCount atomic.Int32
+
+			// simulate another writer adds rule taint between markBootstrapCompleted's Get and its Patch. The annotation patch must conflict
+			// due to optimistic lock and retry and must observe the taint.
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if obj.GetName() == "race-mark-node" && patchCount.Add(1) == 1 {
+							current := &corev1.Node{}
+							Expect(c.Get(ctx, types.NamespacedName{Name: obj.GetName()}, current)).To(Succeed())
+							current.Spec.Taints = append(current.Spec.Taints, rule.Spec.Taint)
+							Expect(c.Update(ctx, current)).To(Succeed())
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: events.NewFakeRecorder(10),
+			}
+
+			controller.markBootstrapCompleted(ctx, node.Name, rule)
+
+			updated := &corev1.Node{}
+			Expect(fc.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
+			Expect(updated.Annotations).NotTo(HaveKey(bootstrapAnnotationKey(rule.GetUID())),
+				"completion must be deferred when the taint won the race")
+			Expect(controller.hasTaintBySpec(updated, rule.Spec.Taint)).To(BeTrue(),
+				"the concurrently added taint must survive")
+		})
+
+		It("should not add the taint when bootstrap completion annotated concurrently", func() {
+			Expect(nodereadinessiov1alpha1.AddToScheme(testScheme)).To(Succeed())
+
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "race-add-rule",
+					UID:  types.UID("88888888-8888-8888-8888-888888888888"),
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Taint:           corev1.Taint{Key: "readiness.k8s.io/race-test", Effect: corev1.TaintEffectNoSchedule},
+					EnforcementMode: nodereadinessiov1alpha1.EnforcementModeBootstrapOnly,
+				},
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "race-add-node"},
+			}
+
+			var patchCount atomic.Int32
+
+			// another writer marks bootstrap completed Between addTaintBySpec Get and its Patch
+			// The taint patch must conflict due to optimistic lock and retry, but the retry must observe the annotation and abort the add.
+			fc := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(node).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if obj.GetName() == "race-add-node" && patchCount.Add(1) == 1 {
+							current := &corev1.Node{}
+							Expect(c.Get(ctx, types.NamespacedName{Name: obj.GetName()}, current)).To(Succeed())
+							if current.Annotations == nil {
+								current.Annotations = map[string]string{}
+							}
+							current.Annotations[bootstrapAnnotationKey(rule.GetUID())] = bootstrapAnnotationValue(rule.Name)
+							Expect(c.Update(ctx, current)).To(Succeed())
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			controller := &RuleReadinessController{
+				Client:        fc,
+				Scheme:        testScheme,
+				clientset:     fake.NewSimpleClientset(),
+				ruleCache:     make(map[string]*nodereadinessiov1alpha1.NodeReadinessRule),
+				EventRecorder: events.NewFakeRecorder(10),
+			}
+
+			Expect(fc.Get(ctx, types.NamespacedName{Name: node.Name}, node)).To(Succeed())
+			added, err := controller.addTaintBySpec(ctx, node, rule)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(added).To(BeFalse(), "the add must yield when completion won the race")
+
+			updated := &corev1.Node{}
+			Expect(fc.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
+			Expect(controller.hasTaintBySpec(updated, rule.Spec.Taint)).To(BeFalse(),
+				"a completed node must not end up tainted")
+			Expect(updated.Annotations).To(HaveKey(bootstrapAnnotationKey(rule.GetUID())),
+				"the concurrently written completion must survive")
 		})
 
 		It("should succeed when no concurrent modification occurs", func() {

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -402,7 +402,12 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 	case shouldRemoveTaint && currentlyHasTaint:
 		log.Info("Removing taint", "node", node.Name, "rule", rule.Name, "taint", rule.Spec.Taint.Key)
 
-		if err = r.removeTaintBySpec(ctx, node, rule.Spec.Taint, rule.Name); err != nil {
+		if rule.Spec.EnforcementMode == readinessv1alpha1.EnforcementModeBootstrapOnly {
+			err = r.removeTaintAndCompleteBootstrap(ctx, node, rule)
+		} else {
+			err = r.removeTaintBySpec(ctx, node, rule.Spec.Taint, rule.Name)
+		}
+		if err != nil {
 			metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonRemoveTaintError)).Inc()
 			return fmt.Errorf("failed to remove taint: %w", err)
 		}
@@ -411,10 +416,7 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 		metrics.TaintOperations.WithLabelValues(rule.Name, string(metrics.TaintOperationRemove)).Inc()
 		recordLatency(string(metrics.ReconciliationOperationRemoveTaint))
 
-		// Mark bootstrap completed if bootstrap-only mode
 		if rule.Spec.EnforcementMode == readinessv1alpha1.EnforcementModeBootstrapOnly {
-			r.markBootstrapCompleted(ctx, node.Name, rule.Name, rule.GetUID())
-
 			// Only record the bootstrap duration if the node was created AFTER the rule.
 			// This prevents legacy nodes from poisoning the histogram with massive outliers.
 			if !node.CreationTimestamp.Time.Before(rule.CreationTimestamp.Time) && !latestTransition.IsZero() {
@@ -434,14 +436,17 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 	case !shouldRemoveTaint && !currentlyHasTaint:
 		log.Info("Adding taint", "node", node.Name, "rule", rule.Name, "taint", rule.Spec.Taint.Key)
 
-		if err = r.addTaintBySpec(ctx, node, rule.Spec.Taint, rule.Name); err != nil {
+		var added bool
+		if added, err = r.addTaintBySpec(ctx, node, rule); err != nil {
 			metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonAddTaintError)).Inc()
 			return fmt.Errorf("failed to add taint: %w", err)
 		}
 
-		// Record add taint latency and taint operation counter
-		metrics.TaintOperations.WithLabelValues(rule.Name, string(metrics.TaintOperationAdd)).Inc()
-		recordLatency(string(metrics.ReconciliationOperationAddTaint))
+		if added {
+			// Record add taint latency and taint operation counter
+			metrics.TaintOperations.WithLabelValues(rule.Name, string(metrics.TaintOperationAdd)).Inc()
+			recordLatency(string(metrics.ReconciliationOperationAddTaint))
+		}
 
 	case !shouldRemoveTaint && currentlyHasTaint:
 		if isFirstEvaluation {
@@ -454,9 +459,9 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 	default:
 		log.Info("No taint action needed", "node", node.Name, "rule", rule.Name,
 			"shouldRemove", shouldRemoveTaint, "hasTaint", currentlyHasTaint)
-		// Mark bootstrap completed if bootstrap-only mode
+		// Mark bootstrap completed in bootstrap-only mode when conditions satisfied even if taint is already absent.
 		if rule.Spec.EnforcementMode == readinessv1alpha1.EnforcementModeBootstrapOnly {
-			r.markBootstrapCompleted(ctx, node.Name, rule.Name, rule.GetUID())
+			r.markBootstrapCompleted(ctx, node.Name, rule)
 		}
 	}
 

--- a/internal/controller/nodereadinessrule_controller_test.go
+++ b/internal/controller/nodereadinessrule_controller_test.go
@@ -1146,11 +1146,18 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 
 		It("should handle bootstrap completion tracking", func() {
 			nodeName := "bootstrap-test-node"
-			ruleName := "bootstrap-test-rule"
-			ruleUID := types.UID("11111111-1111-1111-1111-111111111111")
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bootstrap-test-rule",
+					UID:  types.UID("11111111-1111-1111-1111-111111111111"),
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Taint: corev1.Taint{Key: "readiness.k8s.io/bootstrap-test", Effect: corev1.TaintEffectNoSchedule},
+				},
+			}
 
 			// Initially not completed
-			completed := readinessController.isBootstrapCompleted(ctx, nodeName, ruleName, ruleUID)
+			completed := readinessController.isBootstrapCompleted(ctx, nodeName, rule.Name, rule.GetUID())
 			Expect(completed).To(BeFalse())
 
 			// Create a node for testing
@@ -1163,11 +1170,11 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 			defer func() { _ = k8sClient.Delete(ctx, node) }()
 
 			// Mark as completed
-			readinessController.markBootstrapCompleted(ctx, nodeName, ruleName, ruleUID)
+			readinessController.markBootstrapCompleted(ctx, nodeName, rule)
 
 			// Should now be completed
 			Eventually(func() bool {
-				return readinessController.isBootstrapCompleted(ctx, nodeName, ruleName, ruleUID)
+				return readinessController.isBootstrapCompleted(ctx, nodeName, rule.Name, rule.GetUID())
 			}).Should(BeTrue())
 		})
 
@@ -1199,8 +1206,15 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 
 		It("should set bootstrap annotation via patch in markBootstrapCompleted", func() {
 			nodeName := "bootstrap-patch-test-node"
-			ruleName := "bootstrap-patch-test-rule"
-			ruleUID := types.UID("33333333-3333-3333-3333-333333333333")
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bootstrap-patch-test-rule",
+					UID:  types.UID("33333333-3333-3333-3333-333333333333"),
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Taint: corev1.Taint{Key: "readiness.k8s.io/bootstrap-patch-test", Effect: corev1.TaintEffectNoSchedule},
+				},
+			}
 
 			// Create a node with existing annotations that should be preserved
 			node := &corev1.Node{
@@ -1215,16 +1229,16 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 			defer func() { _ = k8sClient.Delete(ctx, node) }()
 
 			// Mark bootstrap completed
-			readinessController.markBootstrapCompleted(ctx, nodeName, ruleName, ruleUID)
+			readinessController.markBootstrapCompleted(ctx, nodeName, rule)
 
 			// Verify UID-based annotation was added and existing annotation is preserved
 			Eventually(func(g Gomega) {
 				updatedNode := &corev1.Node{}
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, updatedNode)).To(Succeed())
 				g.Expect(updatedNode.Annotations).To(HaveKey(
-					bootstrapAnnotationKey(ruleUID)))
-				g.Expect(updatedNode.Annotations[bootstrapAnnotationKey(ruleUID)]).To(
-					ContainSubstring(ruleName))
+					bootstrapAnnotationKey(rule.GetUID())))
+				g.Expect(updatedNode.Annotations[bootstrapAnnotationKey(rule.GetUID())]).To(
+					ContainSubstring(rule.Name))
 				g.Expect(updatedNode.Annotations).To(HaveKeyWithValue(
 					"existing-annotation", "should-be-preserved"))
 			}).Should(Succeed())
@@ -1232,8 +1246,15 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 
 		It("should increment bootstrap completed metric only when newly marked", func() {
 			nodeName := "bootstrap-metric-test-node"
-			ruleName := "bootstrap-metric-test-rule"
-			ruleUID := types.UID("44444444-4444-4444-4444-444444444444")
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bootstrap-metric-test-rule",
+					UID:  types.UID("44444444-4444-4444-4444-444444444444"),
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Taint: corev1.Taint{Key: "readiness.k8s.io/bootstrap-metric-test", Effect: corev1.TaintEffectNoSchedule},
+				},
+			}
 
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1243,12 +1264,106 @@ var _ = Describe("NodeReadinessRule Controller", func() {
 			Expect(k8sClient.Create(ctx, node)).To(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, node) }()
 
-			counter := metrics.BootstrapCompleted.WithLabelValues(ruleName)
+			counter := metrics.BootstrapCompleted.WithLabelValues(rule.Name)
 			before := counterValue(counter)
 
-			readinessController.markBootstrapCompleted(ctx, nodeName, ruleName, ruleUID)
-			readinessController.markBootstrapCompleted(ctx, nodeName, ruleName, ruleUID)
+			readinessController.markBootstrapCompleted(ctx, nodeName, rule)
+			readinessController.markBootstrapCompleted(ctx, nodeName, rule)
 
+			Expect(counterValue(counter)).To(Equal(before + 1))
+		})
+
+		It("should refuse to mark bootstrap completed while the rule's taint is on the node", func() {
+			nodeName := "bootstrap-defer-test-node"
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bootstrap-defer-test-rule",
+					UID:  types.UID("55555555-5555-5555-5555-555555555555"),
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Taint: corev1.Taint{Key: "readiness.k8s.io/bootstrap-defer-test", Effect: corev1.TaintEffectNoSchedule},
+				},
+			}
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{Key: "readiness.k8s.io/bootstrap-defer-test", Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, node) }()
+
+			// Marking must be deferred: completion with the bootstrap taint still
+			// present would orphan the taint forever.
+			readinessController.markBootstrapCompleted(ctx, nodeName, rule)
+
+			updatedNode := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, updatedNode)).To(Succeed())
+			Expect(updatedNode.Annotations).NotTo(HaveKey(bootstrapAnnotationKey(rule.GetUID())))
+
+			// Once the taint is gone, marking succeeds.
+			updatedNode.Spec.Taints = nil
+			Expect(k8sClient.Update(ctx, updatedNode)).To(Succeed())
+
+			readinessController.markBootstrapCompleted(ctx, nodeName, rule)
+
+			Eventually(func() map[string]string {
+				recheckedNode := &corev1.Node{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, recheckedNode)
+				return recheckedNode.Annotations
+			}).Should(HaveKey(bootstrapAnnotationKey(rule.GetUID())))
+		})
+
+		It("should remove the taint and write the completion annotation in a single patch", func() {
+			nodeName := "bootstrap-atomic-test-node"
+			rule := &nodereadinessiov1alpha1.NodeReadinessRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bootstrap-atomic-test-rule",
+					UID:  types.UID("66666666-6666-6666-6666-666666666666"),
+				},
+				Spec: nodereadinessiov1alpha1.NodeReadinessRuleSpec{
+					Taint: corev1.Taint{Key: "readiness.k8s.io/bootstrap-atomic-test", Effect: corev1.TaintEffectNoSchedule},
+				},
+			}
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{Key: "readiness.k8s.io/bootstrap-atomic-test", Effect: corev1.TaintEffectNoSchedule},
+						{Key: "other-controller/taint", Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, node) }()
+
+			counter := metrics.BootstrapCompleted.WithLabelValues(rule.Name)
+			before := counterValue(counter)
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			Expect(readinessController.removeTaintAndCompleteBootstrap(ctx, node, rule)).To(Succeed())
+
+			// Taint gone, annotation present, unrelated taint preserved.
+			// (envtest's admission plugins may add taints of their own, e.g.
+			// node.kubernetes.io/not-ready, so assert by key.)
+			updatedNode := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, updatedNode)).To(Succeed())
+			Expect(readinessController.hasTaintBySpec(updatedNode, rule.Spec.Taint)).To(BeFalse())
+			Expect(updatedNode.Annotations).To(HaveKey(bootstrapAnnotationKey(rule.GetUID())))
+			taintKeys := make([]string, 0, len(updatedNode.Spec.Taints))
+			for _, t := range updatedNode.Spec.Taints {
+				taintKeys = append(taintKeys, t.Key)
+			}
+			Expect(taintKeys).To(ContainElement("other-controller/taint"))
+
+			Expect(counterValue(counter)).To(Equal(before + 1))
+
+			// A second call is a no-op and does not double-count the metric.
+			Expect(readinessController.removeTaintAndCompleteBootstrap(ctx, node, rule)).To(Succeed())
 			Expect(counterValue(counter)).To(Equal(before + 1))
 		})
 


### PR DESCRIPTION
## Description

Both NodeReconciler and RuleReconciler now carry an optimistic lock on the node and re-check the other fields inside their retry loops. Also refactored so the taint removal and bootstrap annotation is now patched atomically in remove-taint path.

Assisted, Tests written by AI.

## Related Issue

Fixes #382 

## Type of Change

/kind bug

## Testing
unit tests

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
NONE
```
