### PR TITLE
Add reporter metrics to examples

### DIFF
--- a/examples/cni-readiness/README.md
+++ b/examples/cni-readiness/README.md
@@ -10,3 +10,4 @@ This example demonstrates how to use the Node Readiness Controller to ensure nod
 3. The `NodeReadinessRule` (`network-readiness-rule.yaml`) instructs the controller to remove the startup taint once the `projectcalico.org/CalicoReady` condition becomes `True`.
 4. The reporter is deployed with `hostNetwork: true` to reach Calico's local health endpoint.
 5. The reporter needs a dedicated ServiceAccount (`cni-reporter`) with permissions to patch node status.
+6. The reporter exposes Prometheus metrics on port `9445` (`/metrics`). An optional `PodMonitor` (`cni-reporter-podmonitor.yaml`) is included for prometheus-operator users and can be applied separately with `kubectl apply -f cni-reporter-podmonitor.yaml`. Since the DaemonSet runs with `hostNetwork: true`, the metrics endpoint is exposed on the host network, not just inside the cluster.

--- a/examples/cni-readiness/cni-reporter-ds.yaml
+++ b/examples/cni-readiness/cni-reporter-ds.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       labels:
         app: cni-reporter
+        example: cni-readiness
     spec:
       hostNetwork: true
       serviceAccountName: cni-reporter
@@ -35,6 +36,10 @@ spec:
           capabilities:
             drop:
               - "ALL"
+        ports:
+        - name: metrics
+          containerPort: 9445
+          protocol: TCP
         env:
           - name: NODE_NAME
             valueFrom:

--- a/examples/cni-readiness/cni-reporter-podmonitor.yaml
+++ b/examples/cni-readiness/cni-reporter-podmonitor.yaml
@@ -1,0 +1,18 @@
+# Optional: enables Prometheus Operator to scrape metrics from the CNI Reporter.
+# Requires prometheus-operator and a Prometheus instance configured to watch this PodMonitor.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cni-readiness-reporter
+  namespace: kube-system
+  labels:
+    app: cni-reporter
+spec:
+  selector:
+    matchLabels:
+      app: cni-reporter
+      example: cni-readiness
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+    interval: 60s

--- a/examples/constrained-impersonation/reporter-ds.yaml
+++ b/examples/constrained-impersonation/reporter-ds.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       labels:
         app: cni-reporter
+        example: constrained-impersonation
     spec:
       hostNetwork: true
       serviceAccountName: cni-reporter
@@ -35,6 +36,10 @@ spec:
           capabilities:
             drop:
               - "ALL"
+        ports:
+        - name: metrics
+          containerPort: 9445
+          protocol: TCP
         env:
           - name: NODE_NAME
             valueFrom:

--- a/examples/constrained-impersonation/reporter-podmonitor.yaml
+++ b/examples/constrained-impersonation/reporter-podmonitor.yaml
@@ -1,0 +1,18 @@
+# Optional: enables Prometheus Operator to scrape metrics from the Reporter.
+# Requires prometheus-operator and a Prometheus instance configured to watch this PodMonitor.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: constrained-impersonation-reporter
+  namespace: kube-system
+  labels:
+    app: cni-reporter
+spec:
+  selector:
+    matchLabels:
+      app: cni-reporter
+      example: constrained-impersonation
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+    interval: 60s


### PR DESCRIPTION
## Description

This PR adds example config for the reporter metrics added in #379 

- Added the metrics port (`9445`) to both reporter DaemonSets (`cni-readiness`, `constrained-impersonation`).
- Added a `PodMonitor` manifest for each example, for anyone using prometheus-operator. Applying it is a separate step, not part of `apply-calico.sh`.
- Added an extra label to each example's pods so the two PodMonitors don't accidentally scrape each other's pods if both examples are deployed together.

### Related to #380 
### Builds on #379 


## Type of Change
/kind documentation

## Checklist
- [x] `make test` passes
- [x] `make lint` passes
