### PR TITLE
feat: allow Cluster Autoscaler startup-taint prefix in NodeReadinessR…

### DIFF
--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -101,7 +101,7 @@ type NodeReadinessRuleSpec struct {
 	// when combined with continuous enforcement mode. Prefer NoSchedule for most use cases.
 	//
 	// +required
-	// +kubebuilder:validation:XValidation:rule="self.key.startsWith('readiness.k8s.io/')",message="taint key must start with 'readiness.k8s.io/'"
+	// +kubebuilder:validation:XValidation:rule="self.key.startsWith('readiness.k8s.io/') || self.key.startsWith('startup-taint.cluster-autoscaler.kubernetes.io/') || self.key.startsWith('ignore-taint.cluster-autoscaler.kubernetes.io/')",message="taint key must start with 'readiness.k8s.io/', 'startup-taint.cluster-autoscaler.kubernetes.io/', or 'ignore-taint.cluster-autoscaler.kubernetes.io/'"
 	// +kubebuilder:validation:XValidation:rule="self.key.size() <= 253",message="taint key length must be at most 253 characters"
 	// +kubebuilder:validation:XValidation:rule="size(self.key.split('/')) == 2",message="taint key must have exactly one '/' separator (prefix/name format)"
 	// +kubebuilder:validation:XValidation:rule="size(self.key.split('/')[1]) > 0 && size(self.key.split('/')[1]) <= 63",message="taint key name part must be 1-63 characters"

--- a/charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
+++ b/charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
@@ -232,8 +232,8 @@ spec:
                 - key
                 type: object
                 x-kubernetes-validations:
-                - message: taint key must start with 'readiness.k8s.io/'
-                  rule: self.key.startsWith('readiness.k8s.io/')
+                - message: taint key must start with 'readiness.k8s.io/', 'startup-taint.cluster-autoscaler.kubernetes.io/', or 'ignore-taint.cluster-autoscaler.kubernetes.io/'
+                  rule: self.key.startsWith('readiness.k8s.io/') || self.key.startsWith('startup-taint.cluster-autoscaler.kubernetes.io/') || self.key.startsWith('ignore-taint.cluster-autoscaler.kubernetes.io/')
                 - message: taint key length must be at most 253 characters
                   rule: self.key.size() <= 253
                 - message: taint key must have exactly one '/' separator (prefix/name

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -232,8 +232,8 @@ spec:
                 - key
                 type: object
                 x-kubernetes-validations:
-                - message: taint key must start with 'readiness.k8s.io/'
-                  rule: self.key.startsWith('readiness.k8s.io/')
+                - message: taint key must start with 'readiness.k8s.io/', 'startup-taint.cluster-autoscaler.kubernetes.io/', or 'ignore-taint.cluster-autoscaler.kubernetes.io/'
+                  rule: self.key.startsWith('readiness.k8s.io/') || self.key.startsWith('startup-taint.cluster-autoscaler.kubernetes.io/') || self.key.startsWith('ignore-taint.cluster-autoscaler.kubernetes.io/')
                 - message: taint key length must be at most 253 characters
                   rule: self.key.size() <= 253
                 - message: taint key must have exactly one '/' separator (prefix/name

--- a/test/e2e/taint_validation_test.go
+++ b/test/e2e/taint_validation_test.go
@@ -163,6 +163,8 @@ spec:
 				"readiness.k8s.io/with.dots",
 				"readiness.k8s.io/Mixed-Case_123.OK",
 				"readiness.k8s.io/security-agent-ready",
+				"startup-taint.cluster-autoscaler.kubernetes.io/gpu-ready",
+				"ignore-taint.cluster-autoscaler.kubernetes.io/legacy-ready",
 			}
 
 			for i, key := range validKeys {


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
This PR extends the `NodeReadinessRule` CRD validation to accept Cluster Autoscaler startup-taint prefixes in the `taint.key` field. 

Previously, only the `readiness.k8s.io/` prefix was allowed. On managed platforms like GKE and AKS, the `--startup-taints` flag is often not user-editable, so the only way to get startup-taint semantics from the Cluster Autoscaler is to use its reserved prefix. By extending validation, NRC can now serve as the component that removes these boot-time taints once conditions (like GPU readiness published by NPD) are met.

Supported prefixes added:
- `startup-taint.cluster-autoscaler.kubernetes.io/`
- `ignore-taint.cluster-autoscaler.kubernetes.io/` (legacy, but useful for older CA versions)

**Which issue(s) this PR fixes**:
Fixes #279 

**Special notes for your reviewer**:
The OpenAPI v3 validation rules on the CRD manifest and the `taint_validation_test.go` Ginkgo suite have been updated to reflect the new CEL rules.

**Does this PR introduce a user-facing change?**:
```release-note
Extended NodeReadinessRule CRD validation to accept Cluster Autoscaler startup-taint prefixes (`startup-taint.cluster-autoscaler.kubernetes.io/` and `ignore-taint.cluster-autoscaler.kubernetes.io/`) in the `taint.key` field.
