### PR TITLE
fix: consistent dry-run behavior between NodeController and RuleContr…

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -140,10 +140,41 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 			continue
 		}
 
-		// Skip if dry run
+		// Handle dry run
 		if rule.Spec.DryRun {
-			log.Info("Skipping rule - dry run mode",
+			log.Info("Evaluating rule - dry run mode",
 				"node", node.Name, "rule", rule.Name)
+
+			nodeList := &corev1.NodeList{}
+			if err := r.List(ctx, nodeList); err != nil {
+				log.Error(err, "Failed to list nodes for dry run evaluation", "rule", rule.Name)
+				errs = append(errs, err)
+				continue
+			}
+
+			if err := r.processDryRun(ctx, rule, nodeList); err != nil {
+				log.Error(err, "Failed to process dry run for node",
+					"node", node.Name, "rule", rule.Name)
+				errs = append(errs, err)
+				continue
+			}
+
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latestRule := &readinessv1alpha1.NodeReadinessRule{}
+				if err := r.Get(ctx, client.ObjectKey{Name: rule.Name}, latestRule); err != nil {
+					return err
+				}
+				patch := client.MergeFrom(latestRule.DeepCopy())
+				latestRule.Status.DryRunResults = rule.Status.DryRunResults
+				latestRule.Status.ObservedGeneration = rule.Status.ObservedGeneration
+				return r.Status().Patch(ctx, latestRule, patch)
+			})
+
+			if err != nil {
+				log.Error(err, "Failed to update rule status after dry run evaluation",
+					"node", node.Name, "rule", rule.Name)
+				errs = append(errs, err)
+			}
 			continue
 		}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -543,15 +543,22 @@ status:
 			}, 10*time.Second, 2*time.Second).Should(BeTrue())
 
 			By("verifying rule has dry-run results showing what would happen")
-			Eventually(func() bool {
-				cmd := exec.Command("kubectl", "get", "nodereadinessrule", "dryrun-test-rule", "-o", "jsonpath={.status.dryRunResults}")
-				output, err := utils.Run(cmd)
-				if err != nil {
-					return false
-				}
-				// Check that dry run results exist and contain the node
-				return len(output) > 0
-			}, 30*time.Second, 2*time.Second).Should(BeTrue())
+			Eventually(func() string {
+				cmd := exec.Command("kubectl", "get", "nodereadinessrule", "dryrun-test-rule", "-o", "jsonpath={.status.dryRunResults.taintsToAdd}")
+				output, _ := utils.Run(cmd)
+				return output
+			}, 30*time.Second, 2*time.Second).Should(Equal("1"))
+
+			By("updating node condition to True")
+			err = patchNodeCondition(nodeName, "TestReady", "True")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying rule dry-run results update to reflect the change")
+			Eventually(func() string {
+				cmd := exec.Command("kubectl", "get", "nodereadinessrule", "dryrun-test-rule", "-o", "jsonpath={.status.dryRunResults.taintsToAdd}")
+				output, _ := utils.Run(cmd)
+				return output
+			}, 30*time.Second, 2*time.Second).Should(BeEmpty())
 
 			By("cleaning up test resources")
 			exec.Command("kubectl", "delete", "node", nodeName).Run()


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
This PR fixes inconsistent Dry-Run evaluation behavior between the `RuleController` and `NodeController`.

**Previously:** When `DryRun` was set to `true`, `NodeController` would completely skip rule evaluation for any node updates (`continue`). This resulted in stale `DryRunResults` being reported in the Rule's status when a Node's conditions transitioned, as the results would only update when the Rule itself was modified.
**Now:** `NodeController` catches the dry-run rules, safely evaluates them against all applicable nodes (via `processDryRun`), and persists the refreshed `DryRunResults` summary to the `NodeReadinessRule` status, giving real-time visibility into what actions would occur without actually applying the taints.

An E2E test verifying this live-update behavior has also been added.

**Which issue(s) this PR fixes**:
Fixes #54 

**Special notes for your reviewer**:
The update to the rule's status is done safely using `RetryOnConflict` within the `NodeController` loop.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug where `DryRunResults` on `NodeReadinessRules` would not dynamically update in response to Node condition changes.
