### PR TITLE
feat: add suspend field to NodeReadinessRuleSpec

### DIFF
--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -128,6 +128,12 @@ type NodeReadinessRuleSpec struct {
 	// +optional
 	ConditionPolicy ConditionPolicy `json:"conditionPolicy,omitempty"` // Use GetConditionPolicy() for safe access; field may be empty even when allOf applies.
 
+	// suspend when set to true, temporarily pauses the evaluation of the rule.
+	// The controller will skip processing this rule and make no changes to node taints or rule status.
+	//
+	// +optional
+	Suspend bool `json:"suspend,omitempty"` //nolint:kubeapilinter
+
 	// dryRun when set to true, The controller will evaluate Node conditions and log intended taint modifications
 	// without persisting changes to the cluster. Proposed actions are reflected in the resource status.
 	//

--- a/charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
+++ b/charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
@@ -128,6 +128,11 @@ spec:
                 x-kubernetes-validations:
                 - message: conditions is immutable
                   rule: self == oldSelf
+              suspend:
+                description: |-
+                  suspend when set to true, temporarily pauses the evaluation of the rule.
+                  The controller will skip processing this rule and make no changes to node taints or rule status.
+                type: boolean
               dryRun:
                 description: |-
                   dryRun when set to true, The controller will evaluate Node conditions and log intended taint modifications

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -128,6 +128,11 @@ spec:
                 x-kubernetes-validations:
                 - message: conditions is immutable
                   rule: self == oldSelf
+              suspend:
+                description: |-
+                  suspend when set to true, temporarily pauses the evaluation of the rule.
+                  The controller will skip processing this rule and make no changes to node taints or rule status.
+                type: boolean
               dryRun:
                 description: |-
                   dryRun when set to true, The controller will evaluate Node conditions and log intended taint modifications

--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -140,6 +140,13 @@ func (r *RuleReadinessController) processNodeAgainstAllRules(ctx context.Context
 			continue
 		}
 
+		// Skip if suspended
+		if rule.Spec.Suspend {
+			log.V(4).Info("Skipping suspended rule",
+				"node", node.Name, "rule", rule.Name)
+			continue
+		}
+
 		// Skip if dry run
 		if rule.Spec.DryRun {
 			log.Info("Skipping rule - dry run mode",

--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -138,6 +138,11 @@ func (r *RuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// Update rule cache (after cleanup)
 	r.Controller.updateRuleCache(ctx, rule)
 
+	if rule.Spec.Suspend {
+		log.Info("Rule is suspended, skipping processing", "rule", rule.Name)
+		return ctrl.Result{}, nil
+	}
+
 	// Handle dry run
 	if rule.Spec.DryRun {
 		if err := r.Controller.processDryRun(ctx, rule, nodeList); err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -558,6 +558,66 @@ status:
 			exec.Command("kubectl", "delete", "nodereadinessrule", "dryrun-test-rule").Run()
 		})
 
+		It("should pause rule evaluation when suspend is true", func() {
+			nodeName := "suspend-test-node"
+
+			By("creating a test node")
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(fmt.Sprintf(`
+apiVersion: v1
+kind: Node
+metadata:
+  name: %s
+  labels:
+    e2e-test: "suspend"
+status:
+  conditions:
+    - type: SuspendTest
+      status: "False"
+      lastHeartbeatTime: %s
+      lastTransitionTime: %s
+`, nodeName, time.Now().Format(time.RFC3339), time.Now().Format(time.RFC3339)))
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("applying a suspended rule")
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(`
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: suspend-test-rule
+spec:
+  suspend: true
+  conditions:
+    - type: SuspendTest
+      requiredStatus: "True"
+  taint:
+    key: readiness.k8s.io/SuspendTest
+    effect: NoSchedule
+  nodeSelector:
+    matchLabels:
+      e2e-test: "suspend"
+  enforcementMode: continuous
+`)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying no taint is added because rule is suspended")
+			Consistently(func() bool {
+				cmd := exec.Command("kubectl", "get", "node", nodeName, "-o", "jsonpath={.spec.taints}")
+				output, err := utils.Run(cmd)
+				if err != nil {
+					return false
+				}
+				return !strings.Contains(output, "readiness.k8s.io/SuspendTest")
+			}, 10*time.Second, 2*time.Second).Should(BeTrue())
+
+			By("cleaning up test resources")
+			exec.Command("kubectl", "delete", "node", nodeName).Run()
+			exec.Command("kubectl", "delete", "nodereadinessrule", "suspend-test-rule").Run()
+		})
+
 		It("should emit events for taint operations", func() {
 			nodeName := "event-test-node"
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
This PR adds a `suspend` boolean field to the `NodeReadinessRuleSpec`. 

Currently, there is no way to temporarily disable or pause the evaluation of a `NodeReadinessRule`. If an administrator needs to perform maintenance on a cluster, test a change, or debug an issue without the controller constantly evaluating and applying/removing taints, their only option is to delete the rule entirely (which un-taints all nodes) or switch it to dry-run mode (which still consumes controller cycles to compute node evaluations).

By setting `suspend: true`, the controllers will simply skip the reconciliation loop for that rule, making no changes to the cluster or the rule's status. The rule essentially becomes frozen in its current state.

**Which issue(s) this PR fixes**:
Fixes #335

**Special notes for your reviewer**:
- A check for `rule.Spec.Suspend` was added at the top of the `RuleReconciler` and within the `NodeReconciler` rule loop.
- The CRDs were regenerated and a new E2E test was added to verify that a suspended rule does not take action on unsatisfied node conditions.

**Does this PR introduce a user-facing change?**:
```release-note
Added a `suspend` field to `NodeReadinessRuleSpec`. When set to true, the controller will temporarily bypass all evaluations and taint modifications for the rule, freezing its current cluster state.
