### PR TITLE
fix: emit Warning events on node and rule when taint operations fail

### DIFF
--- a/internal/controller/nodereadinessrule_controller.go
+++ b/internal/controller/nodereadinessrule_controller.go
@@ -416,6 +416,9 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 		}
 		if err != nil {
 			metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonRemoveTaintError)).Inc()
+			msg := fmt.Sprintf("Failed to remove taint '%s:%s': %v", rule.Spec.Taint.Key, rule.Spec.Taint.Effect, err)
+			r.EventRecorder.Eventf(node, nil, corev1.EventTypeWarning, "RemoveTaintFailed", "RemoveTaint", "Rule %s: %s", rule.Name, msg)
+			r.EventRecorder.Eventf(rule, nil, corev1.EventTypeWarning, "RemoveTaintFailed", "RemoveTaint", "Node %s: %s", node.Name, msg)
 			return fmt.Errorf("failed to remove taint: %w", err)
 		}
 
@@ -446,6 +449,9 @@ func (r *RuleReadinessController) evaluateRuleForNode(ctx context.Context, rule 
 		var added bool
 		if added, err = r.addTaintBySpec(ctx, node, rule); err != nil {
 			metrics.Failures.WithLabelValues(rule.Name, string(metrics.FailureReasonAddTaintError)).Inc()
+			msg := fmt.Sprintf("Failed to add taint '%s:%s': %v", rule.Spec.Taint.Key, rule.Spec.Taint.Effect, err)
+			r.EventRecorder.Eventf(node, nil, corev1.EventTypeWarning, "AddTaintFailed", "AddTaint", "Rule %s: %s", rule.Name, msg)
+			r.EventRecorder.Eventf(rule, nil, corev1.EventTypeWarning, "AddTaintFailed", "AddTaint", "Node %s: %s", node.Name, msg)
 			return fmt.Errorf("failed to add taint: %w", err)
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
This PR resolves an observability gap where the controller failed to emit `Warning` events when node taint operations failed.

Previously, if `addTaintBySpec` or `removeTaintBySpec` failed (e.g., due to API server RBAC restrictions or patch conflicts), the controller would log an error and increment `metrics.Failures`, but operators had no visibility into these failures through `kubectl describe nodereadinessrule` or `kubectl describe node`.

Now, if a taint addition or removal fails, the controller explicitly emits a `Warning` event on **both** the affected `Node` object and the managing `NodeReadinessRule` object with the exact underlying error message.

**Which issue(s) this PR fixes**:
Fixes #362

**Special notes for your reviewer**:
The events use the standard `RemoveTaintFailed` and `AddTaintFailed` reasons so they are easily recognizable in `kubectl get events`.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug where the controller failed to emit Kubernetes Warning events on Node and NodeReadinessRule objects when taint operations failed.
