### PR TITLE
fix: reject anyOf conditionPolicy when defaultStatus equals requiredS…

### DIFF
--- a/api/v1alpha1/nodereadinessrule_types.go
+++ b/api/v1alpha1/nodereadinessrule_types.go
@@ -66,6 +66,7 @@ const (
 // NodeReadinessRuleSpec defines the desired state of NodeReadinessRule.
 //
 // +kubebuilder:validation:XValidation:rule="(!has(oldSelf.conditionPolicy) ? 'allOf' : oldSelf.conditionPolicy) == (!has(self.conditionPolicy) ? 'allOf' : self.conditionPolicy)",message="conditionPolicy is immutable"
+// +kubebuilder:validation:XValidation:rule="!has(self.conditionPolicy) || self.conditionPolicy != 'anyOf' || !self.conditions.exists(c, has(c.defaultStatus) && c.defaultStatus == c.requiredStatus)",message="defaultStatus cannot equal requiredStatus when conditionPolicy is anyOf"
 type NodeReadinessRuleSpec struct {
 	// conditions contains a list of the Node conditions that defines the specific
 	// criteria that must be met for taints to be managed on the target Node.

--- a/charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
+++ b/charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
@@ -266,6 +266,11 @@ spec:
             - message: conditionPolicy is immutable
               rule: '(!has(oldSelf.conditionPolicy) ? ''allOf'' : oldSelf.conditionPolicy)
                 == (!has(self.conditionPolicy) ? ''allOf'' : self.conditionPolicy)'
+            - message: defaultStatus cannot equal requiredStatus when conditionPolicy
+                is anyOf
+              rule: '!has(self.conditionPolicy) || self.conditionPolicy != ''anyOf''
+                || !self.conditions.exists(c, has(c.defaultStatus) && c.defaultStatus
+                == c.requiredStatus)'
           status:
             description: status defines the observed state of NodeReadinessRule
             minProperties: 1

--- a/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
+++ b/config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml
@@ -266,6 +266,11 @@ spec:
             - message: conditionPolicy is immutable
               rule: '(!has(oldSelf.conditionPolicy) ? ''allOf'' : oldSelf.conditionPolicy)
                 == (!has(self.conditionPolicy) ? ''allOf'' : self.conditionPolicy)'
+            - message: defaultStatus cannot equal requiredStatus when conditionPolicy
+                is anyOf
+              rule: '!has(self.conditionPolicy) || self.conditionPolicy != ''anyOf''
+                || !self.conditions.exists(c, has(c.defaultStatus) && c.defaultStatus
+                == c.requiredStatus)'
           status:
             description: status defines the observed state of NodeReadinessRule
             minProperties: 1

--- a/test/e2e/taint_validation_test.go
+++ b/test/e2e/taint_validation_test.go
@@ -247,5 +247,32 @@ spec:
 			Expect(err).To(HaveOccurred(), "Should fail with special characters")
 			Expect(string(output)).To(ContainSubstring("must consist of alphanumeric characters"))
 		})
+		It("should reject anyOf conditionPolicy when defaultStatus equals requiredStatus", func() {
+			manifest := `
+apiVersion: readiness.node.x-k8s.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: test-anyof-default-status
+spec:
+  conditionPolicy: anyOf
+  conditions:
+    - type: "test.condition"
+      requiredStatus: "True"
+      defaultStatus: "True"
+  taint:
+    key: "readiness.k8s.io/anyof-test"
+    effect: "NoSchedule"
+  enforcementMode: "continuous"
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux
+`
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(manifest)
+			output, err := cmd.CombinedOutput()
+
+			Expect(err).To(HaveOccurred(), "Should fail when conditionPolicy is anyOf and defaultStatus equals requiredStatus")
+			Expect(string(output)).To(ContainSubstring("defaultStatus cannot equal requiredStatus when conditionPolicy is anyOf"))
+		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
This PR prevents a silent failure mode where `conditionPolicy: anyOf` rules could short-circuit themselves due to a misconfiguration in `defaultStatus`.

As identified in #414, if an `anyOf` rule has a condition where `defaultStatus == requiredStatus`, the rule evaluates to "Satisfied" the moment the node is evaluated (assuming the condition is not present on the node, which is typical at startup). This causes the controller to immediately skip taint application, acting as a complete no-op without any logged warnings or errors.

This PR adds a CEL validation rule to `NodeReadinessRuleSpec` that rejects the CRD at the API server level if `conditionPolicy` is `anyOf` and any condition's `defaultStatus` equals its `requiredStatus`.

**Which issue(s) this PR fixes**:
Fixes #414

**Special notes for your reviewer**:
- Added an E2E test to verify that the API server correctly rejects the misconfigured manifest.

**Does this PR introduce a user-facing change?**:
```release-note
Added CEL validation to reject NodeReadinessRules with conditionPolicy `anyOf` when a condition's `defaultStatus` matches its `requiredStatus`, preventing silent misconfigurations.
