### PR TITLE
helm: fix chart versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,19 +502,21 @@ crd-ref-docs:
 # helm
 
 HELM ?= go run helm.sh/helm/v3/cmd/helm@v3.15.1
+CHART_VERSION ?= $(shell echo "$(RELEASE_VERSION)" | sed 's/^v//')
 
 lint-chart:
 	$(HELM) lint ./charts/node-readiness-controller
 
-inject-helm-version: ## Inject the release version into the Helm chart's appVersion and image tag
-	sed 's/tag: .*/tag: "$(RELEASE_VERSION)"/' charts/node-readiness-controller/values.yaml > charts/node-readiness-controller/values.yaml.tmp && mv charts/node-readiness-controller/values.yaml.tmp charts/node-readiness-controller/values.yaml
-	sed 's/^appVersion: .*/appVersion: "$(RELEASE_VERSION)"/' charts/node-readiness-controller/Chart.yaml > charts/node-readiness-controller/Chart.yaml.tmp && mv charts/node-readiness-controller/Chart.yaml.tmp charts/node-readiness-controller/Chart.yaml
-
-build-helm: inject-helm-version
-	$(HELM) package ./charts/node-readiness-controller --dependency-update --destination ./bin/chart
+build-helm: ## Package Helm chart with dynamic version and appVersion
+	mkdir -p ./bin/chart
+	$(HELM) package ./charts/node-readiness-controller \
+		--version "$(CHART_VERSION)" \
+		--app-version "$(RELEASE_VERSION)" \
+		--dependency-update \
+		--destination ./bin/chart
 
 publish-helm: ## Publish the packaged Helm chart to an OCI registry
-	$(HELM) push ./bin/chart/node-readiness-controller-*.tgz oci://$(HELM_IMAGE)
+	$(HELM) push ./bin/chart/node-readiness-controller-$(CHART_VERSION).tgz oci://$(HELM_IMAGE)
 
 kind-multi-node:
 	kind create cluster --name $(KIND_CLUSTER) --config ./config/testing/kind/kind-3node-config.yaml --wait 2m


### PR DESCRIPTION
## Description

This PR refactors how the Helm chart version is resolved.

Instead of injecting the appVersion using sed, we pass it through `--app-version`. Additionally, we pass the chart version using `--version`. 

The `version` and `appVersion` are now correctly being populated by the current annotated tag.

If no tag is detected, a pseudo-version that matches the one created for the controller and reporter images is attributed to the `appVersion` and `version`.

## Related Issue

xref #427 

## Type of Change

/kind cleanup

## Testing

With a tagged commit:

```
$ git tag -a v0.5.1 -m "Release v0.5.1"

$ git describe
v0.5.1

$ IMG_PREFIX=test COMPONENT=chart ./scripts/build-and-publish.sh 
Using IMG_TAG=v0.5.1
Building Helm chart...
mkdir -p ./bin/chart
go run helm.sh/helm/v3/cmd/helm@v3.15.1 package ./charts/node-readiness-controller \
        --version "0.5.1" \
        --app-version "v0.5.1" \
        --dependency-update \
        --destination ./bin/chart
Successfully packaged chart and saved it to: bin/chart/node-readiness-controller-0.5.1.tgz
go run helm.sh/helm/v3/cmd/helm@v3.15.1 push ./bin/chart/node-readiness-controller-0.5.1.tgz oci://test/charts
Error: failed to do request: Head "https://test/v2/charts/node-readiness-controller/blobs/sha256:c0d461e5502817eb51158967912ded6202f0a2dde412723522a5bfccd77c9706": dial tcp: lookup test: no such host
exit status 1
make: *** [Makefile:519: publish-helm] Error 1

$ tar -zxvf bin/chart/node-readiness-controller-0.5.1.tgz 
node-readiness-controller/Chart.yaml
node-readiness-controller/values.yaml
node-readiness-controller/templates/_helpers.tpl
node-readiness-controller/templates/certificates.yaml
node-readiness-controller/templates/deployment.yaml
node-readiness-controller/templates/issuer.yaml
node-readiness-controller/templates/nodereadinessrules.yaml
node-readiness-controller/templates/rbac.yaml
node-readiness-controller/templates/serviceaccount.yaml
node-readiness-controller/templates/servicemetrics.yaml
node-readiness-controller/templates/servicewebhook.yaml
node-readiness-controller/templates/validatingwebhookconfiguration.yaml
node-readiness-controller/.helmignore
node-readiness-controller/README.md
node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
node-readiness-controller/tests/annotations_test.yaml
node-readiness-controller/tests/deployment_test.yaml
node-readiness-controller/tests/nodereadinessrules_test.yaml
node-readiness-controller/tests/rbac_test.yaml
node-readiness-controller/tests/webhook_and_metrics_test.yaml

$ cat node-readiness-controller/Chart.yaml 
apiVersion: v2
appVersion: v0.5.1
description: A Helm chart for the Node Readiness Controller
home: https://github.com/kubernetes-sigs/node-readiness-controller
keywords:
- kubernetes
- controller
- readiness
- node
kubeVersion: '>=1.25.0-0'
name: node-readiness-controller
sources:
- https://github.com/kubernetes-sigs/node-readiness-controller
type: application
version: 0.5.1
```

With an untagged commit:

```
$ git describe --exact-match 
fatal: no tag exactly matches '95e50f99c5eb7099cb73d80634ecb7e8b3acde0d'

$ IMG_PREFIX=test COMPONENT=chart ./scripts/build-and-publish.sh 
Using IMG_TAG=v20260819-95e50f9
Building Helm chart...
mkdir -p ./bin/chart
go run helm.sh/helm/v3/cmd/helm@v3.15.1 package ./charts/node-readiness-controller \
        --version "20260819-95e50f9" \
        --app-version "v20260819-95e50f9" \
        --dependency-update \
        --destination ./bin/chart
Successfully packaged chart and saved it to: bin/chart/node-readiness-controller-20260819-95e50f9.tgz
go run helm.sh/helm/v3/cmd/helm@v3.15.1 push ./bin/chart/node-readiness-controller-20260819-95e50f9.tgz oci://test/charts
Error: failed to do request: Head "https://test/v2/charts/node-readiness-controller/blobs/sha256:8f24e57571c0c0826eccb4ac78e82ae4448351f914631d50efb86611e5930d78": dial tcp: lookup test: no such host
exit status 1
make: *** [Makefile:519: publish-helm] Error 1

$ tar -zxvf bin/chart/node-readiness-controller-20260819-95e50f9.tgz 
node-readiness-controller/Chart.yaml
node-readiness-controller/values.yaml
node-readiness-controller/templates/_helpers.tpl
node-readiness-controller/templates/certificates.yaml
node-readiness-controller/templates/deployment.yaml
node-readiness-controller/templates/issuer.yaml
node-readiness-controller/templates/nodereadinessrules.yaml
node-readiness-controller/templates/rbac.yaml
node-readiness-controller/templates/serviceaccount.yaml
node-readiness-controller/templates/servicemetrics.yaml
node-readiness-controller/templates/servicewebhook.yaml
node-readiness-controller/templates/validatingwebhookconfiguration.yaml
node-readiness-controller/.helmignore
node-readiness-controller/README.md
node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
node-readiness-controller/tests/annotations_test.yaml
node-readiness-controller/tests/deployment_test.yaml
node-readiness-controller/tests/nodereadinessrules_test.yaml
node-readiness-controller/tests/rbac_test.yaml
node-readiness-controller/tests/webhook_and_metrics_test.yaml

$ cat node-readiness-controller/Chart.yaml 
apiVersion: v2
appVersion: v20260819-95e50f9
description: A Helm chart for the Node Readiness Controller
home: https://github.com/kubernetes-sigs/node-readiness-controller
keywords:
- kubernetes
- controller
- readiness
- node
kubeVersion: '>=1.25.0-0'
name: node-readiness-controller
sources:
- https://github.com/kubernetes-sigs/node-readiness-controller
type: application
version: 20260819-95e50f9
```