### PR TITLE
feat(chart): Adds topologySpreadConstraints for multi-zone HA

### DIFF
--- a/charts/node-readiness-controller/templates/deployment.yaml
+++ b/charts/node-readiness-controller/templates/deployment.yaml
@@ -133,3 +133,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/node-readiness-controller/tests/deployment_test.yaml
+++ b/charts/node-readiness-controller/tests/deployment_test.yaml
@@ -161,3 +161,21 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --leader-election-namespace=kube-system
+
+  - it: renders topologySpreadConstraints when set
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: node-readiness-controller
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone

--- a/charts/node-readiness-controller/values.yaml
+++ b/charts/node-readiness-controller/values.yaml
@@ -166,6 +166,14 @@ tolerations:
 
 affinity: {}
 
+topologySpreadConstraints: []
+# - maxSkew: 1
+#   topologyKey: topology.kubernetes.io/zone
+#   whenUnsatisfiable: DoNotSchedule
+#   labelSelector:
+#     matchLabels:
+#       app.kubernetes.io/name: node-readiness-controller
+
 # NOTE: When using validating webhooks, apply NodeReadinessRule resources after the controller webhook is ready, for example in a separate helm upgrade.
 nodeReadinessRules: []
   # - name: kube-proxy-unhealthy-noschedule

--- a/charts/node-readiness-controller/values.yaml
+++ b/charts/node-readiness-controller/values.yaml
@@ -172,7 +172,7 @@ topologySpreadConstraints: []
 #   whenUnsatisfiable: DoNotSchedule
 #   labelSelector:
 #     matchLabels:
-#       app.kubernetes.io/name: node-readiness-controller
+#       app.kubernetes.io/name: node-readiness-controller # Note: Adjust this if you use nameOverride/fullnameOverride
 
 # NOTE: When using validating webhooks, apply NodeReadinessRule resources after the controller webhook is ready, for example in a separate helm upgrade.
 nodeReadinessRules: []


### PR DESCRIPTION
## Description
I had added native support for `topologySpreadConstraints` in the Helm chart to support highly available, multi zone deployments of the controller. 

While users can technically inject soft `podAntiAffinity` rules into the existing `affinity` block, `topologySpreadConstraints` is the modern standard for guaranteeing balanced zone distribution without leaving replicas stuck in `Pending`. 

**Note on isolation:** I placed this configuration alongside the existing `affinity` and `tolerations` blocks in `values.yaml` and `deployment.yaml`. This ensures it is completely structurally isolated and will not create merge conflicts with #411

## Related Issue
Fixes #413

## Type of Change
- [x] New feature (non breaking)

## Testing
- [x] Added `helm-unittest` coverage in `deployment_test.yaml` asserting correct rendering of `maxSkew` and `topologyKey` when values are provided.
- [x] `make test` passes locally.
