### PR TITLE
Update node_readiness_evaluation_duration_seconds  + tests

### DIFF
--- a/docs/book/src/operations/monitoring.md
+++ b/docs/book/src/operations/monitoring.md
@@ -37,7 +37,7 @@ Total number of taint operations performed by the controller.
 
 ### `node_readiness_evaluation_duration_seconds`
 
-Duration of rule evaluations per rule.
+Duration of rule evaluations per rule, including taint operations.
 
 | Property | Value |
 | --- | --- |

--- a/docs/book/src/operations/monitoring.md
+++ b/docs/book/src/operations/monitoring.md
@@ -37,7 +37,7 @@ Total number of taint operations performed by the controller.
 
 ### `node_readiness_evaluation_duration_seconds`
 
-Duration of rule evaluations per rule, including taint operations.
+Duration of evaluating a rule against a node, including any taint add/remove operations.
 
 | Property | Value |
 | --- | --- |

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -87,7 +87,7 @@ var (
 	EvaluationDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "node_readiness_evaluation_duration_seconds",
-			Help:    "Duration of rule evaluations per rule, including taint operations",
+			Help:    "Duration of evaluating a rule against a node, including any taint add/remove operations",
 			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"rule"},

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -87,7 +87,7 @@ var (
 	EvaluationDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "node_readiness_evaluation_duration_seconds",
-			Help:    "Duration of rule evaluations per rule",
+			Help:    "Duration of rule evaluations per rule, including taint operations",
 			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"rule"},

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -52,4 +53,98 @@ node_readiness_build_info{version="unknown"} 1
 	if !found {
 		t.Fatal("expected node_readiness_build_info to be registered with the controller-runtime metrics registry")
 	}
+}
+
+func TestEvaluationDuration(t *testing.T) {
+	t.Run("registered as histogram with expected help text", func(t *testing.T) {
+		EvaluationDuration.Reset()
+		EvaluationDuration.WithLabelValues("registration-check").Observe(0)
+		defer EvaluationDuration.Reset()
+
+		gathered, err := metrics.Registry.Gather()
+		if err != nil {
+			t.Fatalf("failed to gather metrics: %v", err)
+		}
+
+		var found bool
+		for _, mf := range gathered {
+			if mf.GetName() == "node_readiness_evaluation_duration_seconds" {
+				found = true
+				if got := mf.GetType().String(); got != "HISTOGRAM" {
+					t.Fatalf("expected node_readiness_evaluation_duration_seconds to be a histogram, got %s", got)
+				}
+				const wantHelp = "Duration of rule evaluations per rule, including taint operations"
+				if got := mf.GetHelp(); got != wantHelp {
+					t.Fatalf("unexpected help text: got %q, want %q", got, wantHelp)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Fatal("expected node_readiness_evaluation_duration_seconds to be registered with the controller-runtime metrics registry")
+		}
+	})
+
+	t.Run("label set is exactly rule", func(t *testing.T) {
+		descs := make(chan *prometheus.Desc, 1)
+		EvaluationDuration.Describe(descs)
+		close(descs)
+
+		desc := <-descs
+		if desc == nil {
+			t.Fatal("expected EvaluationDuration to yield a descriptor")
+		}
+		if got, want := desc.String(), "variableLabels: {rule}"; !strings.Contains(got, want) {
+			t.Fatalf("expected descriptor to declare exactly one variable label %q, got: %s", want, got)
+		}
+	})
+
+	t.Run("observation is reflected", func(t *testing.T) {
+		EvaluationDuration.Reset()
+
+		EvaluationDuration.WithLabelValues("test-rule").Observe(0.2)
+
+		expected := `
+# HELP node_readiness_evaluation_duration_seconds Duration of rule evaluations per rule, including taint operations
+# TYPE node_readiness_evaluation_duration_seconds histogram
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="0.005"} 0
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="0.01"} 0
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="0.025"} 0
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="0.05"} 0
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="0.1"} 0
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="0.25"} 1
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="0.5"} 1
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="1"} 1
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="2.5"} 1
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="5"} 1
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="10"} 1
+node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="+Inf"} 1
+node_readiness_evaluation_duration_seconds_sum{rule="test-rule"} 0.2
+node_readiness_evaluation_duration_seconds_count{rule="test-rule"} 1
+`
+		if err := testutil.CollectAndCompare(EvaluationDuration, strings.NewReader(expected), "node_readiness_evaluation_duration_seconds"); err != nil {
+			t.Fatalf("unexpected collecting result:\n%s", err)
+		}
+
+		if got, want := testutil.CollectAndCount(EvaluationDuration, "node_readiness_evaluation_duration_seconds"), 1; got != want {
+			t.Fatalf("expected %d observed series, got %d", want, got)
+		}
+	})
+
+	t.Run("DeleteLabelValues removes the rule's series", func(t *testing.T) {
+		EvaluationDuration.Reset()
+
+		EvaluationDuration.WithLabelValues("delete-me").Observe(0.1)
+		if got, want := testutil.CollectAndCount(EvaluationDuration, "node_readiness_evaluation_duration_seconds"), 1; got != want {
+			t.Fatalf("expected %d observed series before delete, got %d", want, got)
+		}
+
+		if deleted := EvaluationDuration.DeleteLabelValues("delete-me"); !deleted {
+			t.Fatal("expected DeleteLabelValues to report that a series was deleted")
+		}
+
+		if got, want := testutil.CollectAndCount(EvaluationDuration, "node_readiness_evaluation_duration_seconds"), 0; got != want {
+			t.Fatalf("expected %d observed series after delete, got %d", want, got)
+		}
+	})
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -61,28 +61,9 @@ func TestEvaluationDuration(t *testing.T) {
 		EvaluationDuration.WithLabelValues("registration-check").Observe(0)
 		defer EvaluationDuration.Reset()
 
-		gathered, err := metrics.Registry.Gather()
-		if err != nil {
-			t.Fatalf("failed to gather metrics: %v", err)
-		}
-
-		var found bool
-		for _, mf := range gathered {
-			if mf.GetName() == "node_readiness_evaluation_duration_seconds" {
-				found = true
-				if got := mf.GetType().String(); got != "HISTOGRAM" {
-					t.Fatalf("expected node_readiness_evaluation_duration_seconds to be a histogram, got %s", got)
-				}
-				const wantHelp = "Duration of rule evaluations per rule, including taint operations"
-				if got := mf.GetHelp(); got != wantHelp {
-					t.Fatalf("unexpected help text: got %q, want %q", got, wantHelp)
-				}
-				break
-			}
-		}
-		if !found {
-			t.Fatal("expected node_readiness_evaluation_duration_seconds to be registered with the controller-runtime metrics registry")
-		}
+		assertMetricRegistered(t, metrics.Registry,
+			"node_readiness_evaluation_duration_seconds", "HISTOGRAM",
+			"Duration of evaluating a rule against a node, including any taint add/remove operations")
 	})
 
 	t.Run("label set is exactly rule", func(t *testing.T) {
@@ -105,7 +86,7 @@ func TestEvaluationDuration(t *testing.T) {
 		EvaluationDuration.WithLabelValues("test-rule").Observe(0.2)
 
 		expected := `
-# HELP node_readiness_evaluation_duration_seconds Duration of rule evaluations per rule, including taint operations
+# HELP node_readiness_evaluation_duration_seconds Duration of evaluating a rule against a node, including any taint add/remove operations
 # TYPE node_readiness_evaluation_duration_seconds histogram
 node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="0.005"} 0
 node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="0.01"} 0
@@ -122,9 +103,7 @@ node_readiness_evaluation_duration_seconds_bucket{rule="test-rule",le="+Inf"} 1
 node_readiness_evaluation_duration_seconds_sum{rule="test-rule"} 0.2
 node_readiness_evaluation_duration_seconds_count{rule="test-rule"} 1
 `
-		if err := testutil.CollectAndCompare(EvaluationDuration, strings.NewReader(expected), "node_readiness_evaluation_duration_seconds"); err != nil {
-			t.Fatalf("unexpected collecting result:\n%s", err)
-		}
+		assertObservationReflected(t, EvaluationDuration, "node_readiness_evaluation_duration_seconds", expected)
 
 		if got, want := testutil.CollectAndCount(EvaluationDuration, "node_readiness_evaluation_duration_seconds"), 1; got != want {
 			t.Fatalf("expected %d observed series, got %d", want, got)
@@ -147,4 +126,37 @@ node_readiness_evaluation_duration_seconds_count{rule="test-rule"} 1
 			t.Fatalf("expected %d observed series after delete, got %d", want, got)
 		}
 	})
+}
+
+// assertMetricRegistered checks that the metric is registered correctly.
+func assertMetricRegistered(t *testing.T, registry prometheus.Gatherer, name, wantType, wantHelp string) {
+	t.Helper()
+
+	gathered, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+
+	for _, mf := range gathered {
+		if mf.GetName() != name {
+			continue
+		}
+		if got := mf.GetType().String(); got != wantType {
+			t.Fatalf("expected %s to be a %s, got %s", name, wantType, got)
+		}
+		if got := mf.GetHelp(); got != wantHelp {
+			t.Fatalf("unexpected help text for %s: got %q, want %q", name, got, wantHelp)
+		}
+		return
+	}
+	t.Fatalf("expected %s to be registered with the controller-runtime metrics registry", name)
+}
+
+// assertObservationReflected checks the collected metric.
+func assertObservationReflected(t *testing.T, collector prometheus.Collector, name, expectedExposition string) {
+	t.Helper()
+
+	if err := testutil.CollectAndCompare(collector, strings.NewReader(expectedExposition), name); err != nil {
+		t.Fatalf("unexpected collecting result:\n%s", err)
+	}
 }


### PR DESCRIPTION
## Description
- Updates HELP string on `node_readiness_evaluation_duration_seconds` to include taint operations. No name, label, or bucket change.
- Adds related tests to `internal/metrics/metrics_test.go`, also contributes to #269.

### from the design doc:
<img width="1310" height="115" alt="image" src="https://github.com/user-attachments/assets/fa20e2b5-156f-4bb9-808b-b78974c5046b" />
<img width="1342" height="92" alt="image" src="https://github.com/user-attachments/assets/dbe49dcd-1100-48b6-a45b-cd7507179ffe" />


### Related to #446

## Type of Change
/kind documentation

## Testing
`make test`, `make lint`, `go vet`, `gofmt -l` all pass.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes