### PR TITLE
fix: stamp the chart with a real version outside the release pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,6 +502,10 @@ crd-ref-docs:
 # helm
 
 HELM ?= go run helm.sh/helm/v3/cmd/helm@v3.15.1
+# Defaults to the VERSION file so build-helm produces a correctly stamped chart
+# outside the release pipeline. scripts/build-and-publish.sh overrides it from the
+# image tag being published.
+RELEASE_VERSION ?= $(shell cat $(ROOT_DIR)/VERSION)
 CHART_VERSION ?= $(shell echo "$(RELEASE_VERSION)" | sed 's/^v//')
 
 lint-chart:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@ Instead of manually creating branches and tags, the release is triggered by a pu
 - In this PR:
   - Update the `VERSION` file at the repository root to the new semantic version (e.g., `v0.2.0`).
   - Update `docs/book/src/releases.md` with the release notes.
+  - Update `version` and `appVersion` in `charts/node-readiness-controller/Chart.yaml` to match, so installing the chart from a source checkout deploys the release being cut.
   - Update any other documentation, examples, or manifests as needed for the release.
 - Ensure all tests are passing.
 - Once the PR is merged, the Release Automation GitHub Action will trigger.

--- a/charts/node-readiness-controller/Chart.yaml
+++ b/charts/node-readiness-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node-readiness-controller
 description: A Helm chart for the Node Readiness Controller
 type: application
-version: 0.1.0
-appVersion: "v0.4.1"
+version: 0.5.0
+appVersion: "v0.5.0"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/kubernetes-sigs/node-readiness-controller
 sources:

--- a/hack/verify-chart-drift.sh
+++ b/hack/verify-chart-drift.sh
@@ -28,3 +28,19 @@ make manifests
 diff -u \
   config/crd/bases/readiness.node.x-k8s.io_nodereadinessrules.yaml \
   charts/node-readiness-controller/crds/nodereadinessrules.readiness.node.x-k8s.io.yaml
+
+# Chart.yaml is stamped at package time by build-helm, but a plain
+# `helm install ./charts/...` reads it literally, so it has to match the release
+# in the VERSION file. It drifted once already and shipped the previous image.
+echo "Verifying chart version metadata matches the VERSION file..."
+release="$(tr -d '[:space:]' < VERSION)"
+chart_app="$(sed -n 's/^appVersion: *"\{0,1\}\([^"]*\)"\{0,1\}$/\1/p' charts/node-readiness-controller/Chart.yaml | tr -d '[:space:]')"
+chart_ver="$(sed -n 's/^version: *\(.*\)$/\1/p' charts/node-readiness-controller/Chart.yaml | tr -d '[:space:]')"
+if [ "${chart_app}" != "${release}" ]; then
+  echo "error: Chart.yaml appVersion (${chart_app}) does not match VERSION (${release})" >&2
+  exit 1
+fi
+if [ "${chart_ver}" != "${release#v}" ]; then
+  echo "error: Chart.yaml version (${chart_ver}) does not match VERSION (${release#v})" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Description

`Chart.yaml` has carried `version: 0.1.0` and `appVersion: "v0.4.1"` since the chart landed and is not bumped at release, so installing from a checkout deploys the previous release. This is still true at the `v0.5.0` tag:

```console
$ git checkout v0.5.0
$ helm template x ./charts/node-readiness-controller --show-only templates/deployment.yaml | grep image:
    image: "registry.k8s.io/node-readiness-controller/node-readiness-controller:v0.4.1"
```

The published chart is correct because `build-helm` stamps it at package time, but `RELEASE_VERSION` is only ever set by `scripts/build-and-publish.sh` and is undefined in the Makefile. Running the documented target outside that script expands to `--version "" --app-version ""`, which `helm package` does not reject. It falls back to `Chart.yaml` and quietly emits a `0.1.0` chart pinned to `v0.4.1`.

So this does two things. `RELEASE_VERSION` now defaults to the `VERSION` file, which already holds the release being cut, and `Chart.yaml` is synced with it.

Bumping `Chart.yaml` on its own would fix the install path but leave `make build-helm` dependent on the publish script, which is why both are here.

## Related Issue

Fixes #452

## Type of Change

/kind bug

## Testing

Source install now deploys the right image:

```console
$ helm template x ./charts/node-readiness-controller --show-only templates/deployment.yaml | grep image:
    image: "registry.k8s.io/node-readiness-controller/node-readiness-controller:v0.5.0"
```

The publish path is unaffected, since `?=` yields to the environment:

```console
$ make -n build-helm                          # --version "0.5.0"   --app-version "v0.5.0"
$ RELEASE_VERSION=v9.9.9 make -n build-helm    # --version "9.9.9"   --app-version "v9.9.9"
```

`helm unittest --strict` passes, 37 tests across 6 suites. `helm lint` clean. The bundled CRD still matches `config/crd/bases`, so `verify-chart-drift.sh` is unaffected.

The `RELEASE.md` line is the part that stops it recurring. Step 2 already lists the `VERSION` file and `releases.md` but not `Chart.yaml`, which is why it never moved. Same shape as #395.

## Checklist
- [x] `make test` passes
- [x] `make lint` passes

## Does this PR introduce a user-facing change?

```release-note
Fixed the Helm chart's version and appVersion being stale, which caused installs from a source checkout to deploy the previous controller release. `make build-helm` now stamps the chart from the VERSION file instead of silently emitting an unversioned one.
```
