### PR TITLE
fix(reporter,examples): support local kubeconfig fallback and conflicting name fix

### DIFF
--- a/cmd/readiness-condition-reporter/main.go
+++ b/cmd/readiness-condition-reporter/main.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
@@ -122,12 +123,7 @@ func main() {
 	}
 
 	// Create Kubernetes client
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		klog.ErrorS(err, "Failed to create in-cluster config")
-		klog.Flush()
-		os.Exit(1)
-	}
+	config := ctrl.GetConfigOrDie()
 
 	// Set the constrained impersonation config
 	if os.Getenv(envImpersonateNode) == "true" {

--- a/examples/cni-readiness/network-readiness-dryrun-rule.yaml
+++ b/examples/cni-readiness/network-readiness-dryrun-rule.yaml
@@ -1,7 +1,7 @@
 apiVersion: readiness.node.x-k8s.io/v1alpha1
 kind: NodeReadinessRule
 metadata:
-  name: network-readiness-rule
+  name: network-readiness-dry-run-rule
 spec:
   dryRun: true
   conditions:


### PR DESCRIPTION
1. Currently the reporter uses `InClusterConfig` which does not respect `KUBECONFIG` env like node-readiness-controller
2. in cni-readiness example both `network-readiness-dry-run-rule.yaml` and `network-readiness-rule.yaml` share the same name, resulting in a conflict