### PR TITLE
test/scale: add api conflicts metric to scale test reporting

### DIFF
--- a/test/scale/promqueries.go
+++ b/test/scale/promqueries.go
@@ -131,6 +131,67 @@ var metricQueries = []MetricQuery{
 		IsCounter: true,
 	},
 	{
+		Key:       "api_conflicts_add_taint",
+		QueryTmpl: "sum(node_readiness_api_conflicts_total{rule=\"security-agent-readiness-rule\",operation=\"add_taint\"}) - (sum(node_readiness_api_conflicts_total{rule=\"security-agent-readiness-rule\",operation=\"add_taint\"} @ %.3f) or vector(0))",
+		Unit:      "conflicts",
+		IsCounter: true,
+	},
+	{
+		Key:       "api_conflicts_remove_taint",
+		QueryTmpl: "sum(node_readiness_api_conflicts_total{rule=\"security-agent-readiness-rule\",operation=\"remove_taint\"}) - (sum(node_readiness_api_conflicts_total{rule=\"security-agent-readiness-rule\",operation=\"remove_taint\"} @ %.3f) or vector(0))",
+		Unit:      "conflicts",
+		IsCounter: true,
+	},
+	{
+		Key:       "api_conflicts_rule_status_node_write",
+		QueryTmpl: "sum(node_readiness_api_conflicts_total{rule=\"security-agent-readiness-rule\",operation=\"rule_status_node_write\"}) - (sum(node_readiness_api_conflicts_total{rule=\"security-agent-readiness-rule\",operation=\"rule_status_node_write\"} @ %.3f) or vector(0))",
+		Unit:      "conflicts",
+		IsCounter: true,
+	},
+	{
+		Key:       "api_conflicts_rule_status_rule_sweep",
+		QueryTmpl: "sum(node_readiness_api_conflicts_total{rule=\"security-agent-readiness-rule\",operation=\"rule_status_rule_sweep\"}) - (sum(node_readiness_api_conflicts_total{rule=\"security-agent-readiness-rule\",operation=\"rule_status_rule_sweep\"} @ %.3f) or vector(0))",
+		Unit:      "conflicts",
+		IsCounter: true,
+	},
+	{
+		Key:       "api_conflicts_total",
+		QueryTmpl: "sum(node_readiness_api_conflicts_total{rule=\"security-agent-readiness-rule\"}) - (sum(node_readiness_api_conflicts_total{rule=\"security-agent-readiness-rule\"} @ %.3f) or vector(0))",
+		Unit:      "conflicts",
+		IsCounter: true,
+	},
+	{
+		Key:       "retry_exhaustion_add_taint",
+		QueryTmpl: "sum(node_readiness_failures_total{rule=\"security-agent-readiness-rule\",reason=\"AddTaintConflictExhausted\"}) - (sum(node_readiness_failures_total{rule=\"security-agent-readiness-rule\",reason=\"AddTaintConflictExhausted\"} @ %.3f) or vector(0))",
+		Unit:      "conflicts",
+		IsCounter: true,
+	},
+	{
+		Key:       "retry_exhaustion_remove_taint",
+		QueryTmpl: "sum(node_readiness_failures_total{rule=\"security-agent-readiness-rule\",reason=\"RemoveTaintConflictExhausted\"}) - (sum(node_readiness_failures_total{rule=\"security-agent-readiness-rule\",reason=\"RemoveTaintConflictExhausted\"} @ %.3f) or vector(0))",
+		Unit:      "conflicts",
+		IsCounter: true,
+	},
+	{
+		Key:       "retry_exhaustion_status_patch",
+		QueryTmpl: "sum(node_readiness_failures_total{rule=\"security-agent-readiness-rule\",reason=\"StatusPatchConflictExhausted\"}) - (sum(node_readiness_failures_total{rule=\"security-agent-readiness-rule\",reason=\"StatusPatchConflictExhausted\"} @ %.3f) or vector(0))",
+		Unit:      "conflicts",
+		IsCounter: true,
+	},
+	{
+		Key:       "retry_exhaustion_rule_status_sweep",
+		QueryTmpl: "sum(node_readiness_failures_total{rule=\"security-agent-readiness-rule\",reason=\"RuleStatusRuleSweepConflictExhausted\"}) - (sum(node_readiness_failures_total{rule=\"security-agent-readiness-rule\",reason=\"RuleStatusRuleSweepConflictExhausted\"} @ %.3f) or vector(0))",
+		Unit:      "conflicts",
+		IsCounter: true,
+	},
+	{
+		Key:       "rule_controller_reconcile_errors",
+		QueryTmpl: "sum(controller_runtime_reconcile_errors_total{controller=\"nodereadiness-controller\",job=\"node-readiness-controller\"}) - (sum(controller_runtime_reconcile_errors_total{controller=\"nodereadiness-controller\",job=\"node-readiness-controller\"} @ %.3f) or vector(0))",
+		Unit:      "errors",
+		IsCounter: true,
+	},
+
+	{
 		Key:       "cpu_cores_rate",
 		QueryTmpl: "sum(rate(process_cpu_seconds_total{job=\"node-readiness-controller\"}[%ds]))",
 		Unit:      "cores",

--- a/test/scale/report_types.go
+++ b/test/scale/report_types.go
@@ -66,6 +66,7 @@ type PhaseJSON struct {
 	Resources       ResourcesJSON  `json:"resources"`
 	Workqueue       WorkqueueJSON  `json:"workqueue"`
 	Operations      OperationsJSON `json:"operations"`
+	Conflicts       ConflictsJSON  `json:"conflicts"`
 	APIClient       APIClientJSON  `json:"api_client"`
 }
 
@@ -113,6 +114,23 @@ type OperationsJSON struct {
 	TaintsRemoved       int64 `json:"taints_removed"`
 	ConditionFailures   int64 `json:"condition_failures"`
 	OperationalFailures int64 `json:"operational_failures"`
+}
+
+type ConflictsJSON struct {
+	Total                         int64               `json:"total"`
+	AddTaint                      int64               `json:"add_taint"`
+	RemoveTaint                   int64               `json:"remove_taint"`
+	RuleStatusNodeWrite           int64               `json:"rule_status_node_write"`
+	RuleStatusRuleSweep           int64               `json:"rule_status_rule_sweep"`
+	RuleControllerReconcileErrors int64               `json:"rule_controller_reconcile_errors"`
+	RetryExhaustion               RetryExhaustionJSON `json:"retry_exhaustion"`
+}
+
+type RetryExhaustionJSON struct {
+	AddTaint        int64 `json:"add_taint"`
+	RemoveTaint     int64 `json:"remove_taint"`
+	StatusPatch     int64 `json:"status_patch"`
+	RuleStatusSweep int64 `json:"rule_status_sweep"`
 }
 
 type APIClientJSON struct {

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -28,10 +28,11 @@ import (
 )
 
 type phaseStats struct {
-	phase string
-	title string
-	start time.Time
-	end   time.Time
+	phase    string
+	title    string
+	start    time.Time
+	end      time.Time
+	queryEnd time.Time
 }
 
 var (
@@ -65,13 +66,6 @@ var _ = Describe("Node Readiness Controller Scalability Test", func() {
 		By("Deleting KWOK's Stage for condition false to avoid conflicting stages")
 		deleteStage(ctx, "security-agent-stage-false")
 
-		phases = append(phases, phaseStats{
-			phase: "add",
-			title: fmt.Sprintf("%d Nodes - Tainting (Add) Phase [Duration: %s]", nodeCount, taintDuration.Round(time.Millisecond)),
-			start: taintStart,
-			end:   taintEnd,
-		})
-
 		By("Sleeping 10 seconds to settle metrics before starting untainting")
 		time.Sleep(10 * time.Second)
 
@@ -81,21 +75,31 @@ var _ = Describe("Node Readiness Controller Scalability Test", func() {
 		untaintStart := time.Now()
 		applyManifest(ctx, securityAgentStageTrueManifest)
 
+		phases = append(phases, phaseStats{
+			phase:    "add",
+			title:    fmt.Sprintf("%d Nodes - Tainting (Add) Phase [Duration: %s]", nodeCount, taintDuration.Round(time.Millisecond)),
+			start:    taintStart,
+			end:      taintEnd,
+			queryEnd: untaintStart,
+		})
+
 		By("Waiting for the controller manager to reconcile and remove taints on all nodes")
 		waitForNodeTaints(ctx, 0)
 
 		untaintEnd := time.Now()
 		untaintDuration := untaintEnd.Sub(untaintStart)
 
-		phases = append(phases, phaseStats{
-			phase: "remove",
-			title: fmt.Sprintf("%d Nodes - Untainting Phase [Duration: %s]", nodeCount, untaintDuration.Round(time.Millisecond)),
-			start: untaintStart,
-			end:   untaintEnd,
-		})
-
 		By("Sleeping 10 seconds to settle metrics before gathering final report")
 		time.Sleep(10 * time.Second)
+		testEnd := time.Now()
+
+		phases = append(phases, phaseStats{
+			phase:    "remove",
+			title:    fmt.Sprintf("%d Nodes - Untainting Phase [Duration: %s]", nodeCount, untaintDuration.Round(time.Millisecond)),
+			start:    untaintStart,
+			end:      untaintEnd,
+			queryEnd: testEnd,
+		})
 
 		collectAndRecordPhaseMetrics(ctx, phases)
 	})

--- a/test/scale/spec_helpers.go
+++ b/test/scale/spec_helpers.go
@@ -114,6 +114,20 @@ func buildPhaseJSON(q queryResult) PhaseJSON {
 			ConditionFailures:   getInt("condition_failures_total"),
 			OperationalFailures: getInt("operational_failures_total"),
 		},
+		Conflicts: ConflictsJSON{
+			Total:               getInt("api_conflicts_total"),
+			AddTaint:            getInt("api_conflicts_add_taint"),
+			RemoveTaint:         getInt("api_conflicts_remove_taint"),
+			RuleStatusNodeWrite: getInt("api_conflicts_rule_status_node_write"),
+			RuleStatusRuleSweep: getInt("api_conflicts_rule_status_rule_sweep"),
+			RetryExhaustion: RetryExhaustionJSON{
+				AddTaint:        getInt("retry_exhaustion_add_taint"),
+				RemoveTaint:     getInt("retry_exhaustion_remove_taint"),
+				StatusPatch:     getInt("retry_exhaustion_status_patch"),
+				RuleStatusSweep: getInt("retry_exhaustion_rule_status_sweep"),
+			},
+			RuleControllerReconcileErrors: getInt("rule_controller_reconcile_errors"),
+		},
 		APIClient: APIClientJSON{
 			RequestsTotal: getInt("kube_api_requests_total"),
 			RequestsRate:  getRaw("kube_api_requests_rate"),
@@ -216,7 +230,7 @@ func waitForNodeTaints(ctx context.Context, targetTaintedCount int) {
 		g.Expect(err).NotTo(HaveOccurred())
 		By(fmt.Sprintf("Progress: %d/%d nodes tainted", count, cfg.NodeCount))
 		return count
-	}).WithPolling(1 * time.Second).Should(Equal(targetTaintedCount), "Tainted node count did not reach expected target")
+	}).WithPolling(1*time.Second).Should(Equal(targetTaintedCount), "Tainted node count did not reach expected target")
 }
 
 func queryPrometheusInstant(ctx context.Context, query string, ts float64) (string, error) {
@@ -264,19 +278,17 @@ func queryPrometheusInstant(ctx context.Context, query string, ts float64) (stri
 	return valStr, nil
 }
 
-func collectMetricsForPhase(ctx context.Context, phaseStart time.Time, phaseEnd time.Time) map[string]string {
-	// Add a 5-second offset to the query time. Prometheus scrapes metrics asynchronously,
-	// so querying exactly at phaseEnd might miss metrics events that occurred in the last second
-	// of the phase because they haven't been scraped and written to the database yet.
-	queryTime := phaseEnd.Add(5 * time.Second)
+func collectMetricsForPhase(ctx context.Context, phaseStart, phaseEnd, queryEnd time.Time) map[string]string {
+	// Counters use the widened end time so events during the settle period are included.
+	counterTS := float64(queryEnd.UnixNano()) / 1e9
+
+	// Keep the range tight so rates and percentiles don't include the settle period.
+	rangeEnd := phaseEnd.Add(5 * time.Second)
+	rangeTS := float64(rangeEnd.UnixNano()) / 1e9
 
 	// Calculate the range duration (in seconds) from the start of the phase up to our
 	// offset query time. This is used as the range vector window (e.g. [45s]) for gauges and rates.
-	lookbackSecs := int(queryTime.Sub(phaseStart).Seconds())
-
-	// Convert the offset query timestamp into a float64 Unix epoch (seconds with sub-second precision).
-	// The Prometheus API expects the query evaluation time parameter to be formatted as a float.
-	ts := float64(queryTime.UnixNano()) / 1e9
+	lookbackSecs := int(rangeEnd.Sub(phaseStart).Seconds())
 
 	metricsMap := make(map[string]string)
 
@@ -291,9 +303,9 @@ func collectMetricsForPhase(ctx context.Context, phaseStart time.Time, phaseEnd 
 			tsStart := float64(phaseStart.UnixNano()) / 1e9
 			queryStr := fmt.Sprintf(q.QueryTmpl, tsStart)
 
-			// Execute the instant query at the end-of-phase timestamp (ts).
+			// Execute the instant query at the widened end-of-phase timestamp.
 			// This returns: Value(end) - (Value(start) or 0).
-			val, err = queryPrometheusInstant(ctx, queryStr, ts)
+			val, err = queryPrometheusInstant(ctx, queryStr, counterTS)
 			if err != nil {
 				metricsMap[q.Key] = "0"
 				continue
@@ -303,8 +315,8 @@ func collectMetricsForPhase(ctx context.Context, phaseStart time.Time, phaseEnd 
 			// sliding range window defined by lookbackSecs (e.g., avg_over_time(metric[45s])).
 			queryStr := fmt.Sprintf(q.QueryTmpl, lookbackSecs)
 
-			// Query the statistic evaluated at the end-of-phase timestamp (ts).
-			val, err = queryPrometheusInstant(ctx, queryStr, ts)
+			// Query the statistic evaluated at the tight end-of-phase timestamp.
+			val, err = queryPrometheusInstant(ctx, queryStr, rangeTS)
 			if err != nil {
 				metricsMap[q.Key] = "N/A"
 				continue
@@ -363,7 +375,7 @@ func buildReportForPhase(phaseName string, phaseTitle string, phaseStart time.Ti
 
 func collectAndRecordPhaseMetrics(ctx context.Context, phases []phaseStats) {
 	for _, phase := range phases {
-		metricsMap := collectMetricsForPhase(ctx, phase.start, phase.end)
+		metricsMap := collectMetricsForPhase(ctx, phase.start, phase.end, phase.queryEnd)
 		reportStruct := buildReportForPhase(phase.phase, phase.title, phase.start, phase.end, metricsMap)
 		queryResults = append(queryResults, reportStruct)
 	}

--- a/test/scale/testdata/scalability_report.md.tmpl
+++ b/test/scale/testdata/scalability_report.md.tmpl
@@ -35,6 +35,26 @@
 | **Condition Check Failures** | {{index .Metrics "condition_failures_total"}} |
 | **Controller Operational Failures** | {{index .Metrics "operational_failures_total"}} |
 
+### API Conflicts
+
+| Conflict Operation | Count |
+| :--- | :--- |
+| **Total (all operations)** | {{index .Metrics "api_conflicts_total"}} |
+| **add_taint** | {{index .Metrics "api_conflicts_add_taint"}} |
+| **remove_taint** | {{index .Metrics "api_conflicts_remove_taint"}} |
+| **rule_status_node_write** | {{index .Metrics "api_conflicts_rule_status_node_write"}} |
+| **rule_status_rule_sweep** | {{index .Metrics "api_conflicts_rule_status_rule_sweep"}} |
+
+#### Retry Exhaustion
+
+| Exhausted Operation | Count |
+| :--- | :--- |
+| **add_taint** | {{index .Metrics "retry_exhaustion_add_taint"}} |
+| **remove_taint** | {{index .Metrics "retry_exhaustion_remove_taint"}} |
+| **status_patch** | {{index .Metrics "retry_exhaustion_status_patch"}} |
+| **rule_status_sweep** | {{index .Metrics "retry_exhaustion_rule_status_sweep"}} |
+| Rule Controller reconcile errors (`controller_runtime_reconcile_errors_total`) | {{index .Metrics "rule_controller_reconcile_errors"}} |
+
 ### Kubernetes API Client Metrics
 
 | Metric | Value |


### PR DESCRIPTION
## Description

Extends the scale test harness to report `node_readiness_api_conflicts_total` metric and `*ConflictExhausted` failure reasons introduced in #320.

### What's added
- Scale test report now includes conflict and retry exhaustion numbers.
- Added `controller_runtime_reconcile_errors_total` as a sanity check on retry exhaustion.
- Fixed a gap where conflicts happening between phases weren't being counted.
- Made sure that fix doesn't affect CPU, API rate, or latency numbers - those still use original measurement window.

### Depends on #320 

### Testing

- Full scale test ran successfully.
- Verified the generated report and ran the full test/vet/lint suite.

## Checklist

- [x] `make test` passes
- [x] `make lint` passes